### PR TITLE
yaml entries and tests for Thai and Vietnamese

### DIFF
--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -1290,7 +1290,7 @@ vi:
     year:
         - năm
     month:
-        - tháng
+        - thang
     week:
         - tuần
         - tuần lể
@@ -1300,19 +1300,44 @@ vi:
         - ngày
     hour:
         - giờ
+        - giờ
     minute:
         - chút
         - lát
         - nguyên bản
         - phút
+        - phút
     second:
         - giây đồng hồ
         - hạng nhì
 
     ago:
         - cách đây
+        - trước đây
+        - trước
+        - trước
 
     simplifications:
-        - Hôm qua: 1 ngày
-        - Hôm nay: 0 ngày
+        - Hôm qua: 1 buổi
+        - Hôm nay: 0 buổi
         - Thg: Tháng
+        - (?:ngày|năm)\s(\d+): \1
+        - Tháng 1: january
+        - Tháng 2: february
+        - Tháng 3: march
+        - Tháng 4: april
+        - Tháng 5: may
+        - Tháng 6: june
+        - Tháng 7: july
+        - Tháng 8: august
+        - Tháng 9: september
+        - Tháng 10: october
+        - Tháng 11: november
+        - Tháng 12: december
+        - Thứ 2: monday
+        - Thứ 3: tuesday
+        - Thứ 4: wednesday
+        - Thứ 5: thursday
+        - Thứ 6: friday
+        - Thứ 7: saturday
+

--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -99,7 +99,7 @@ en:
         - day before yesterday: 2 days
         - yesterday: 1 day
         - today: 0 days
-        - last (week|month|year): 1 \1 
+        - last (week|month|year): 1 \1
         - an: 1
         - a: 1
         - one: 1
@@ -1315,5 +1315,4 @@ vi:
     simplifications:
         - Hôm qua: 1 ngày
         - Hôm nay: 0 ngày
-
-
+        - Thg: Tháng

--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -1127,3 +1127,192 @@ ar:
         - يومين: 2 يوم
         - \b(\d+)\s*أيام: \1 أيام
 
+
+th:
+    name: Thai
+    no_word_spacing: True
+
+    monday:
+        - จันทร์
+        - วันจันทร์
+    tuesday:
+        - อังคาร
+        - วันอังคาร
+    wednesday:
+        - พุธ
+        - วันพุธ
+    thursday:
+        - พฤหัสบดี
+        - พฤหัส
+        - วันพฤหัสบดี
+    friday:
+        - ศุกร์
+        - วันศุกร์
+    saturday:
+        - เสาร์
+        - วันเสาร์
+    sunday:
+        - อาทิตย์
+        - วันอาทิตย์
+
+    january:
+        - มกราคม
+        - เดือนมกราคม
+        - มกรา
+        - ม.ค.
+    february:
+        - กุมภาพันธ์
+        - ก.พ.
+        - เดือนกุมภาพันธ์
+        - กุมภา
+    march:
+        - มีนาคม
+        - เดือนมีนาคม
+        - มี.ค.
+        - มีนา
+    april:
+        - เมษายน
+        - เมษา
+        - เดือนเมษายน
+        - เม.ย.
+    may:
+        - พฤษภาคม
+        - เดือนพฤษภาคม
+        - พ.ค.
+        - พฤษภา
+    june:
+        - มิถุนายน
+        - เดือนมิถุนายน
+        - มิ.ย.
+        - มิถุนา
+    july:
+        - กรกฎาคม
+        - ก.ค.
+        - เดือนกรกฏาคม
+        - กรกฎา
+    august:
+        - สิงหาคม
+        - ส.ค.
+        - สิงหา
+        - เดือนสิงหาคม
+    september:
+        - กันยายน
+        - ก.ย.
+        - กันยา
+        - เดือนกันยายน
+    october:
+        - ตุลาคม
+        - เดือนตุลาคม
+        - ต.ค.
+        - ตุลา
+    november:
+        - พฤศจิกายน
+        - เดือนพฤศจิกายน
+        - พ.ย.
+        - พฤศจิ
+    december:
+        - ธันวาคม
+        - เดือนธันวาคม
+        - ธ.ค.
+        - ธันวา
+
+    year:
+        - ปี
+    month:
+        - เดือน
+    week:
+        - สัปดาห์
+    day:
+        - วัน
+    hour:
+        - ชั่วโมง
+        - ชม
+    minute:
+        - นาที
+    second:
+        - วินาที
+
+    ago:
+        - แต่ก่อน
+        - มาแล้ว
+
+    simplifications:
+        - วันนี้: 0 วัน
+        - เมื่อวานนี้: 1 วัน
+        - 1 วันที่แล้ว: 1 วัน
+        - เมื่อวานซืน: 2 วัน
+        - 2 วันที่แล้ว: 2 วัน
+
+vi:
+    name: Vietnamese
+    pertain: ['lúc']
+
+    monday:
+        - Thứ hai
+    tuesday:
+        - Thứ ba
+    wednesday:
+        - Thứ tư
+    thursday:
+        - Thứ năm
+    friday:
+        - Thứ sáu
+    saturday:
+        - Thứ bảy
+    sunday:
+        - Chủ nhật
+
+    january:
+        - Tháng một
+    february:
+        - Tháng hai
+    march:
+        - Tháng ba
+    april:
+        - Tháng tư
+    may:
+        - Tháng năm
+    june:
+        - Tháng sáu
+    july:
+        - Tháng bảy
+    august:
+        - Tháng tám
+    september:
+        - Tháng chín
+    october:
+        - Tháng mười
+    november:
+        - Tháng mười một
+    december:
+        - Tháng mười hai
+
+    year:
+        - năm
+    month:
+        - tháng
+    week:
+        - tuần
+        - tuần lể
+    day:
+        - ban ngày
+        - buổi
+        - ngày
+    hour:
+        - giờ
+    minute:
+        - chút
+        - lát
+        - nguyên bản
+        - phút
+    second:
+        - giây đồng hồ
+        - hạng nhì
+
+    ago:
+        - cách đây
+
+    simplifications:
+        - Hôm qua: 1 ngày
+        - Hôm nay: 0 ngày
+

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -71,7 +71,7 @@ def get_intersecting_periods(low, high, period='day'):
 
 def sanitize_date(date_string):
     date_string = re.sub(
-        u'\t|\n|\r|\u00bb|\xe0|,\s\u0432|\u0433\.|\u200e|\xb7', ' ', date_string, flags=re.M
+        u'\t|\n|\r|\u00bb|,\s\u0432|\u0433\.|\u200e|\xb7', ' ', date_string, flags=re.M
     )
     date_string = sanitize_spaces(date_string)
     date_string = re.sub('([AP]M).*', r'\1', date_string, flags=re.DOTALL)

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -154,12 +154,9 @@ class TestDateParser(BaseTestCase):
         param('1 เดือนตุลาคม 2005, 1:00 AM', datetime(2005, 10, 1, 1, 0)),
         param('11 ก.พ. 2020, 13:13 AM', datetime(2020, 2, 11, 13, 13)),
         # Vietnamese dates
-        # bpsosrcs.wordpress.com:
-        param('Tháng Mười Hai 29, 2013, 14:14', datetime(2013, 12, 29, 14, 14)),
-        # http://clbthietbiyte.com/Blogs:
-        param('Thg 11 25', datetime(2014, 11, 25)),
-        # http://www.dutoang8.com/forum:
-        param('19 Jan 2010 lúc 2:19pm', datetime(2010, 1, 19, 14, 19)),
+        param('Thứ năm', datetime(2012, 11, 8)),  # Thursday
+        param('Thứ sáu', datetime(2012, 11, 9)),  # Friday
+        param('Tháng Mười Hai 29, 2013, 14:14', datetime(2013, 12, 29, 14, 14)),  # bpsosrcs.wordpress.com
         param('05 Tháng một 2015 - 03:54 AM', datetime(2015, 1, 5, 3, 54)),
         # Numeric dates
         param('06-17-2014', datetime(2014, 6, 17)),

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -147,6 +147,10 @@ class TestDateParser(BaseTestCase):
         param('18.10.14 um 22:56 Uhr', datetime(2014, 10, 18, 22, 56)),
         # Czech dates
         param('pon 16. čer 2014 10:07:43', datetime(2014, 6, 16, 10, 7, 43)),
+        # Thai dates
+        param('ธันวาคม 11, 2014, 08:55:08 PM', datetime(2014, 12, 11, 20, 55, 8)),
+        param('22 พฤษภาคม 2012, 22:12', datetime(2012, 5, 22, 22, 12)),
+        param('11 กุมภา 2020, 8:13 AM', datetime(2020, 2, 11, 8, 13)),
         # Numeric dates
         param('06-17-2014', datetime(2014, 6, 17))
     ])

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -154,9 +154,12 @@ class TestDateParser(BaseTestCase):
         param('1 เดือนตุลาคม 2005, 1:00 AM', datetime(2005, 10, 1, 1, 0)),
         param('11 ก.พ. 2020, 13:13 AM', datetime(2020, 2, 11, 13, 13)),
         # Vietnamese dates
-        param('Tháng Mười Hai 29, 2013, 14:14', datetime(2013, 12, 29, 14, 14)),  # bpsosrcs.wordpress.com
-        param('Thg 11 25', datetime(2014, 11, 25)),  # http://clbthietbiyte.com/Blogs
-        param('19 Jan 2010 lúc 2:19pm', datetime(2010, 1, 19, 14, 19)),  # http://www.dutoang8.com/forum
+        # bpsosrcs.wordpress.com:
+        param('Tháng Mười Hai 29, 2013, 14:14', datetime(2013, 12, 29, 14, 14)),
+        # http://clbthietbiyte.com/Blogs:
+        param('Thg 11 25', datetime(2014, 11, 25)),
+        # http://www.dutoang8.com/forum:
+        param('19 Jan 2010 lúc 2:19pm', datetime(2010, 1, 19, 14, 19)),
         param('05 Tháng một 2015 - 03:54 AM', datetime(2015, 1, 5, 3, 54)),
         # Numeric dates
         param('06-17-2014', datetime(2014, 6, 17)),

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -213,10 +213,6 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('1 năm 1 tháng 1 tuần 1 ngày 1 giờ 1 chút',
               ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
               period='day'),
-        # weekday (last Thursday):
-        param('Thứ năm', ago={'days': 3}, period='day'),
-        # weekday (last Friday):
-        param('Thứ sáu', ago={'days': 2}, period='day'),
     ])
     def test_relative_dates(self, date_string, ago, period):
         self.given_parser()

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -191,6 +191,23 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('1 عام, 1 شهر, 1 أسبوع, 1 يوم, 1 ساعة, 1 دقيقة',
               ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
               period='day'),
+
+        # Thai dates
+        param('วันนี้', ago={'days': 0}, period='day'),
+        param('เมื่อวานนี้', ago={'days': 1}, period='day'),
+        param('2 วัน', ago={'days': 2}, period='day'),
+        param('2 ชั่วโมง', ago={'hours': 2}, period='day'),
+        param('23 ชม.', ago={'hours': 23}, period='day'),
+        param('2 สัปดาห์ 3 วัน', ago={'weeks': 2, 'days': 3}, period='day'),
+        param('1 ปี 9 เดือน 1 สัปดาห์', ago={'years': 1, 'months': 9, 'weeks': 1},
+              period='week'),
+        param('1 ปี 1 เดือน 1 สัปดาห์ 1 วัน 1 ชั่วโมง 1 นาที',
+              ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
+              period='day'),
+
+        # Vietnamese dates
+        param('Hôm nay', ago={'days': 0}, period='day'),
+        param('Hôm qua', ago={'days': 1}, period='day'),
     ])
     def test_relative_dates(self, date_string, ago, period):
         self.given_parser()

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -213,6 +213,10 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('1 năm 1 tháng 1 tuần 1 ngày 1 giờ 1 chút',
               ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
               period='day'),
+        # weekday (last Thursday):
+        param('Thứ năm', ago={'days': 3}, period='day'),
+        # weekday (last Friday):
+        param('Thứ sáu', ago={'days': 2}, period='day'),
     ])
     def test_relative_dates(self, date_string, ago, period):
         self.given_parser()

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -210,9 +210,11 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('Hôm qua', ago={'days': 1}, period='day'),
         param('2 giờ', ago={'hours': 2}, period='day'),
         param('2 tuần 3 ngày', ago={'weeks': 2, 'days': 3}, period='day'),
-        param('1 năm 1 tháng 1 tuần 1 ngày 1 giờ 1 chút',
-              ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
-              period='day'),
+        # following test unsupported, refer to discussion at:
+        # http://github.com/scrapinghub/dateparser/issues/33
+        #param('1 năm 1 tháng 1 tuần 1 ngày 1 giờ 1 chút',
+        #      ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
+        #      period='day'),
     ])
     def test_relative_dates(self, date_string, ago, period):
         self.given_parser()

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -98,6 +98,8 @@ class TestBundledLanguages(BaseTestCase):
         param('ar', "يوم أمس", "1 day"),
         param('ar', "4 عام", "4 year"),
         param('ar', "منذ 2 ساعات", "ago 2 hour"),
+        # Vietnamese
+        param('vi', "2 tuần 3 ngày", "2 week 3 day")
     ])
     def test_freshness_translation(self, shortname, datetime_string, expected_translation):
         self.given_bundled_language(shortname)
@@ -122,6 +124,7 @@ class TestBundledLanguages(BaseTestCase):
     @parameterized.expand([
         param('en', "17th October, 2034 @ 01:08 am PDT", strip_timezone=True),
         param('en', "#@Sept#04#2014", strip_timezone=False),
+        param('vi', "2 tuần 3 ngày", strip_timezone=False),
     ])
     def test_applicable_languages(self, shortname, datetime_string, strip_timezone):
         self.given_bundled_language(shortname)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -23,6 +23,10 @@ class TestBundledLanguages(BaseTestCase):
         # French
         param('fr', "20 Février 2012", "20 february 2012"),
         param('fr', "Mercredi 19 Novembre 2013", "wednesday 19 november 2013"),
+        # Vietnamese
+        param('vi', "Thứ Năm, ngày 8 tháng 1 năm 2015", "thursday 8  january  2015"),
+        param('vi', "Thứ Tư, 07/01/2015 | 22:34", "wednesday 07/01/2015  22:34"),
+        param('vi', "9 Tháng 1 2015 lúc 15:08", "9  january  2015  15:08"),
     ])
     def test_translation(self, shortname, datetime_string, expected_translation):
         self.given_bundled_language(shortname)
@@ -99,7 +103,10 @@ class TestBundledLanguages(BaseTestCase):
         param('ar', "4 عام", "4 year"),
         param('ar', "منذ 2 ساعات", "ago 2 hour"),
         # Vietnamese
-        param('vi', "2 tuần 3 ngày", "2 week 3 day")
+        param('vi', "2 tuần 3 ngày", "2 week 3 day"),
+        param('vi', "21 giờ trước", "21 hour ago"),
+        param('vi', "Hôm qua 08:16", "1 day 08:16"),
+        param('vi', "Hôm nay 15:39", "0 day 15:39"),
     ])
     def test_freshness_translation(self, shortname, datetime_string, expected_translation):
         self.given_bundled_language(shortname)
@@ -114,6 +121,7 @@ class TestBundledLanguages(BaseTestCase):
         param('cn', "1年11个月", ["1", "年", "11", "个月"]),
         param('tr', "2 saat önce", ["2", " ", "saat", " ", "önce"]),
         param('fr', "il ya environ 23 heures'", ["il ya", " ", "environ", " ", "23", " ", "heures"]),
+        param('vi', "Thứ Năm, ngày 8 tháng 1 năm 2015", ["Thứ Năm", " ", "ngày", " ", "8", " tháng ", "1", " ", "năm", " ", "2015"]),
     ])
     def test_split(self, shortname, datetime_string, expected_tokens):
         self.given_bundled_language(shortname)


### PR DESCRIPTION
Moved Thai and Vietnamese entries to yaml.
Moved tests.
To-do: more tests, support for Vietnamese weekdays is partial.
