### PR TITLE
Add missing install requirement (PyYAML)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'python-dateutil >= 2.2',
+        'PyYAML'
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
Installing it with pip does not install all requirements. This fixes it.