### PR TITLE
french: skip "er" and "min" for minutes

### DIFF
--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -205,7 +205,7 @@ de:
 fr:
     name: French
 
-    skip: ["le", "environ", "et", "\xe0"]
+    skip: ["le", "environ", "et", "\xe0", "er"]
 
     monday:
         - Lundi
@@ -276,6 +276,7 @@ fr:
         - heure
         - heures
     minute:
+        - min
         - minute
         - minutes
     second:

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -115,6 +115,7 @@ class TestDateParser(BaseTestCase):
         param('11 Mai 2014', datetime(2014, 5, 11)),
         param('dimanche, 11 Mai 2014', datetime(2014, 5, 11)),
         param('22 janvier 2015 \xe0 14h40', datetime(2015, 1, 22, 14, 40)),
+        param('Dimanche 1er F\xe9vrier \xe0 21:24', datetime(2012, 2, 1, 21, 24)),
         # Spanish dates
         param('Martes 21 de Octubre de 2014', datetime(2014, 10, 21)),
         param('Miércoles 20 de Noviembre de 2013', datetime(2013, 11, 20)),

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -70,6 +70,7 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('Il ya 1 an, 1 mois, 1 semaine, 1 jour, 1 heure et 1 minute',
               ago={'years': 1, 'months': 1, 'weeks': 1, 'days': 1, 'hours': 1, 'minutes': 1},
               period='day'),
+        param('Il y a 40 min', ago={'minutes': 40}, period='day'),
 
         # German dates
         param('Heute', ago={'days': 0}, period='day'),


### PR DESCRIPTION
 - Skipping `er` is necessary for `1er` (like `1st` for english)
 - `min` is also an abbreviation for minutes.

needed for http://doc.eklablog.com/forums