### PR TITLE
Add 'Fev' month name in FR lang

### DIFF
--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -230,6 +230,7 @@ fr:
         - Février
         - Févr
         - Fév
+        - Fev
     march:
         - Mars
         - Mar


### PR DESCRIPTION
This forum: http://ile-maurice.com/ uses "Fev" instead of "Fév".