### PR TITLE
Feature improve french language

### DIFF
--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -206,7 +206,7 @@ de:
 fr:
     name: French
 
-    skip: ["le", "environ", "et", "\xe0", "er"]
+    skip: ["le", "environ", "et", "\xe0", "er", "moins de", "moins d'"]
 
     monday:
         - Lundi
@@ -296,6 +296,9 @@ fr:
         - une: 1
         - (\d+)\sh\s(\d+)\smin: \1h\2m
         - (\d+)h(\d+)m?: \1:\2
+        - (\d+)s: \1 secondes
+        - (\d+)m: \1 minutes
+        - (\d+)h: \1 heures
 
 
 es:

--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -207,7 +207,7 @@ de:
 fr:
     name: French
 
-    skip: ["le", "environ", "et", "\xe0", "er", "moins de", "moins d'"]
+    skip: ["le", "environ", "et", "\xe0", "er"]
 
     monday:
         - Lundi
@@ -293,13 +293,13 @@ fr:
         - avant-hier: 2 jour
         - hier: 1 jour
         - aujourd'hui: 0 jours
+        - d'une: 1
         - un: 1
         - une: 1
         - (\d+)\sh\s(\d+)\smin: \1h\2m
         - (\d+)h(\d+)m?: \1:\2
-        - (\d+)s: \1 secondes
-        - (\d+)m: \1 minutes
-        - (\d+)h: \1 heures
+        - moins\sde\s(\d+)([smh]|minute|seconde|heure): \1\2 
+        - moins\s(\d+)\s([smh]|minute|seconde|heure): \1\2
 
 
 es:

--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -109,7 +109,7 @@ en:
         - noon: '12:00'
         - midnight: '00:00'
         - (\d+)h(\d+)m?: \1:\2
-        - less then 1 minute ago: 45 seconds
+        - less than 1 minute ago: 45 seconds
         - now: 0 second
 
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -161,7 +161,7 @@ class TestBundledLanguages(BaseTestCase):
         param('vi', "Hôm nay 15:39", "0 day 15:39"),
         #French
         param('fr', u"Il y a moins d'une minute", "ago 1 minute"),
-        param('fr', u"Il y a moins de 30s", "ago  30 second"),
+        param('fr', u"Il y a moins de 30s", "ago 30 s"),
         #Filipino
         param('ph', "kahapon", "1 day"),
         param('ph', "ngayon", "0 second"),

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -159,6 +159,10 @@ class TestBundledLanguages(BaseTestCase):
         param('vi', "21 giờ trước", "21 hour ago"),
         param('vi', "Hôm qua 08:16", "1 day 08:16"),
         param('vi', "Hôm nay 15:39", "0 day 15:39"),
+        #French
+        param('fr', u"Il y a moins d'une minute", "ago 1 minute"),
+        param('fr', u"Il y a moins de 30s", "ago  30 second")
+
     ])
     def test_freshness_translation(self, shortname, datetime_string, expected_translation):
         self.given_bundled_language(shortname)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -84,7 +84,7 @@ class TestBundledLanguages(BaseTestCase):
         param('en', "today", "0 day"),
         param('en', "day before yesterday", "2 day"),
         param('en', "last month", "1 month"),
-        param('en', "less then a minute ago", "45 second"),
+        param('en', "less than a minute ago", "45 second"),
         # German
         param('de', "vorgestern", "2 day"),
         param('de', "heute", "0 day"),


### PR DESCRIPTION
I've added new words and tests for French cases. Maybe can we add regexp support for ``skip`` attribute?