### PR TITLE
using strict markup in README.rst to avoid breaking description in PyPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ History
 * Added a number of new simplifications for more comprehensive generic parsing.
 * Improved validation for dates.
 * Support for Polish, Thai and Arabic dates.
-* Support for pytz timezones.
+* Support for :mod:`pytz` timezones.
 * Fixed building and packaging issues.
 
 

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,12 @@ dateparser -- python parser for human readable dates
 any string formats commonly found on web pages.
 
 
+Documentation
+=============
+
+Documentation can be found `here <https://dateparser.readthedocs.org/en/latest/>`_.
+
+
 Features
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,8 @@ any string formats commonly found on web pages.
 
 
 Features
---------
+========
+
 * Generic parsing of dates in English, Spanish, Dutch, Russian and several other langauges and formats.
 * Generic parsing of relative dates like: ``'1 min ago'``, ``'2 weeks ago'``, ``'3 months, 1 week and 1 day ago'``.
 * Generic parsing of dates with time zones abbreviations like: ``'August 14, 2015 EST'``, ``'July 4, 2013 PST'``.
@@ -28,16 +29,14 @@ Features
 
 
 Usage
------
-The most straightforward way is to use the :func:`dateparser.parse` function,
-that wraps around most of the functionality in the module.
+=====
 
-.. automodule:: dateparser
-   :members: parse
+The most straightforward way is to use the `dateparser.parse` function,
+that wraps around most of the functionality in the module.
 
 
 Popular Formats
-+++++++++++++++
+---------------
 
     >>> import dateparser
     >>> dateparser.parse('12/12/12')
@@ -69,7 +68,7 @@ use the ``date_formats`` argument::
 
 
 Relative Dates
-++++++++++++++
+--------------
 
     >>> parse('1 hour ago')
     datetime.datetime(2015, 5, 31, 23, 0)
@@ -88,7 +87,8 @@ Relative Dates
 
 
 Dependencies
-------------
+============
+
 `dateparser` translates non-english dates to English and uses dateutil_ module ``'parser'`` to parse the translated date.
 
 Also, it requires PyYAML_ for its language detection module to work.
@@ -98,7 +98,8 @@ Also, it requires PyYAML_ for its language detection module to work.
 
 
 Limitations
------------
+===========
+
 `dateparser` at this point does not support generic parsing of dates with fixed UTC offsets. This restricts its ability to reliably parse time zone aware dates since the use of abbreviated time zones as a sole designator of time zones is not recommended.
 
 Read `Wikipedia Time Zone article`_ for more information.

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,11 @@ Features
 Usage
 =====
 
-The most straightforward way is to use the `dateparser.parse` function,
+The most straightforward way is to use the `dateparser.parse <#dateparser.parse>`_ function,
 that wraps around most of the functionality in the module.
+
+.. automodule:: dateparser
+   :members: parse
 
 
 Popular Formats

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import setup, find_packages
 (__version__, ) = re.findall("__version__.*\s*=\s*[']([^']+)[']",
                              open('dateparser/__init__.py').read())
 
-readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+readme = re.sub(r':members:.+|..\sautomodule::.+', '', open('README.rst').read())
+history = re.sub(r':mod:', '', open('HISTORY.rst').read())
 
 
 test_requirements = open('tests/requirements.txt').read().splitlines()


### PR DESCRIPTION
Hey fellows!

So, the [description page in pypi](https://pypi.python.org/pypi/dateparser) is basically the concatenation of `README.rst` and `HISTORY.rst`.
The ReST markup supported in PyPI is more strict (e.g.: you can't use autodocs, it also does some more strict validation), you can check if it will work in PyPI using `restview --strict README.rst`.

This PR removes the unsupported markup from `README.rst` and adjust the titles hierarchy to match `HISTORY.rst`.

Looks good?