### PR TITLE
fixes to work under Python3 and PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: python
 
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "pypy"
 env:
 - TOXENV=py27
 install:

--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __version__ = '0.2.1'
 
-from date import DateDataParser
+from .date import DateDataParser
 
 _default_parser = DateDataParser(allow_redetect_language=True)
 

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -2,8 +2,8 @@
 import calendar
 import collections
 import re
+import six
 from datetime import datetime, timedelta
-from types import NoneType
 from warnings import warn
 
 from dateutil.relativedelta import relativedelta
@@ -99,10 +99,6 @@ def parse_with_formats(date_string, date_formats):
     :returns: :class:`datetime.datetime`, dict or None
 
     """
-    # Encode to support locale setting in spiders
-    if isinstance(date_string, unicode):
-        date_string = date_string.encode('utf-8')
-
     period = 'day'
     for date_format in date_formats:
         try:
@@ -130,10 +126,10 @@ class _DateLanguageParser(object):
     DATE_FORMATS_ERROR_MESSAGE = "Date formats should be list, tuple or set of strings"
 
     def __init__(self, language, date_string, date_formats):
-        if isinstance(date_formats, basestring):
+        if isinstance(date_formats, six.string_types):
             warn(self.DATE_FORMATS_ERROR_MESSAGE, FutureWarning)
             date_formats = [date_formats]
-        elif not isinstance(date_formats, (list, tuple, collections.Set, NoneType)):
+        elif not (date_formats is None or isinstance(date_formats, (list, tuple, collections.Set))):
             raise TypeError(self.DATE_FORMATS_ERROR_MESSAGE)
 
         self.language = language
@@ -261,13 +257,13 @@ class DateDataParser(object):
 
         if allow_redetect_language:
             self.language_detector = AutoDetectLanguage(
-                    languages if languages else available_language_map.values(),
+                    languages if languages else list(available_language_map.values()),
                     allow_redetection=True)
         elif languages:
             self.language_detector = ExactLanguages(languages=languages)
         else:
             self.language_detector = AutoDetectLanguage(
-                available_language_map.values(), allow_redetection=False)
+                list(available_language_map.values()), allow_redetection=False)
 
     def get_date_data(self, date_string, date_formats=None):
         """

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -26,7 +26,7 @@ class FreshnessDateDataParser(object):
 
         words = filter(lambda x: x if x else False, re.split('\W', date_string))
         words = filter(lambda x: not re.match(r'%s' % '|'.join(skip), x), words)
-        return not bool(words)
+        return not list(words)
 
     def _parse_time(self, date_string):
         """Attemps to parse time part of date strings like '1 day ago, 2 PM' """

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import re
-from itertools import izip_longest
+from six.moves import zip_longest
 from operator import methodcaller
 
 DATEUTIL_PARSER_HARDCODED_TOKENS = [":", ".", " ", "-", "/"]  # Consts used in dateutil.parser._parse
@@ -21,19 +22,19 @@ class Dictionary(object):
 
         if 'skip' in language_info:
             skip = map(methodcaller('lower'), language_info['skip'])
-            dictionary.update(izip_longest(skip, [], fillvalue=None))
+            dictionary.update(zip_longest(skip, [], fillvalue=None))
         if 'pertain' in language_info:
             pertain = map(methodcaller('lower'), language_info['pertain'])
-            dictionary.update(izip_longest(pertain, [], fillvalue=None))
+            dictionary.update(zip_longest(pertain, [], fillvalue=None))
         for word in ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
                      'january', 'february', 'march', 'april', 'may', 'june', 'july',
                      'august', 'september', 'october', 'november', 'december',
                      'year', 'month', 'week', 'day', 'hour', 'minute', 'second',
                      'ago']:
             translations = map(methodcaller('lower'), language_info[word])
-            dictionary.update(izip_longest(translations, [], fillvalue=word))
-        dictionary.update(izip_longest(ALWAYS_KEEP_TOKENS, ALWAYS_KEEP_TOKENS))
-        dictionary.update(izip_longest(map(methodcaller('lower'),
+            dictionary.update(zip_longest(translations, [], fillvalue=word))
+        dictionary.update(zip_longest(ALWAYS_KEEP_TOKENS, ALWAYS_KEEP_TOKENS))
+        dictionary.update(zip_longest(map(methodcaller('lower'),
                                            DATEUTIL_PARSERINFO_KNOWN_TOKENS),
                                        DATEUTIL_PARSERINFO_KNOWN_TOKENS))
 
@@ -84,7 +85,7 @@ class Dictionary(object):
     def _construct_split_regex(self):
         known_words_group = u"|".join(map(re.escape, self._get_sorted_words()))
         if self._no_word_spacing:
-            regex = ur"^(.*?)({})(.*)$".format(known_words_group)
+            regex = r"^(.*?)({})(.*)$".format(known_words_group)
         else:
-            regex = ur"^(.*?(?:\A|\d|_|\W))({})((?:\d|_|\W|\Z).*)$".format(known_words_group)
+            regex = r"^(.*?(?:\A|\d|_|\W))({})((?:\d|_|\W|\Z).*)$".format(known_words_group)
         self._split_regex = re.compile(regex, re.UNICODE | re.IGNORECASE)

--- a/dateparser/languages/language.py
+++ b/dateparser/languages/language.py
@@ -20,7 +20,7 @@ class Language(object):
         self.shortname = shortname
         self.info = language_info.copy()
         for simplification in self.info.get('simplifications', []):
-            key, value = simplification.items()[0]
+            key, value = list(simplification.items())[0]
             if isinstance(value, int):
                 simplification[key] = str(value)
 
@@ -51,15 +51,15 @@ class Language(object):
             if word in dictionary:
                 words[i] = dictionary[word] or ''
 
-        return self._join(filter(bool, words), separator="" if keep_formatting else " ")
+        return self._join(list(filter(bool, words)), separator="" if keep_formatting else " ")
 
     def _simplify(self, date_string):
         date_string = date_string.lower()
         for simplification in self.info.get('simplifications', []):
-            pattern, replacement = simplification.items()[0]
+            pattern, replacement = list(simplification.items())[0]
             if not self.info.get('no_word_spacing', False):
                 replacement = wrap_replacement_for_regex(replacement, pattern)
-                pattern = ur'(\A|\d|_|\W)%s(\d|_|\W|\Z)' % pattern
+                pattern = r'(\A|\d|_|\W)%s(\d|_|\W|\Z)' % pattern
             date_string = re.sub(pattern, replacement, date_string, flags=re.IGNORECASE | re.UNICODE).lower()
         return date_string
 
@@ -83,8 +83,8 @@ class Language(object):
 
     def _split(self, date_string, keep_formatting):
         tokens = [date_string]
-        tokens = self._split_tokens_with_regex(tokens, "(\d+)")
-        tokens = self._split_tokens_by_known_words(tokens, keep_formatting)
+        tokens = list(self._split_tokens_with_regex(tokens, "(\d+)"))
+        tokens = list(self._split_tokens_by_known_words(tokens, keep_formatting))
         return tokens
 
     def _split_tokens_with_regex(self, tokens, regex):

--- a/dateparser/languages/loader.py
+++ b/dateparser/languages/loader.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from pkgutil import get_data
 
+import six
 from yaml import load as load_yaml
 
 from .language import Language
@@ -11,7 +12,7 @@ class LanguageDataLoader(object):
     _data = None
 
     def __init__(self, file=None):
-        if isinstance(file, basestring):
+        if isinstance(file, six.string_types):
             file = open(file)
         self.file = file
 
@@ -39,7 +40,7 @@ class LanguageDataLoader(object):
         base_data = data.pop('base', {'skip': []})
         base_data['skip'] += settings.SKIP_TOKENS
         known_languages = {}
-        for shortname, language_info in data.iteritems():
+        for shortname, language_info in six.iteritems(data):
             self._update_language_info_with_base_info(language_info, base_data)
             language = Language(shortname, language_info)
             if language.validate_info():
@@ -47,7 +48,7 @@ class LanguageDataLoader(object):
         self._data = known_languages
 
     def _update_language_info_with_base_info(self, language_info, base_info):
-        for key, values in base_info.iteritems():
+        for key, values in six.iteritems(base_info):
             if isinstance(values, list):
                 extended_values = (values + language_info[key]) if key in language_info else values
                 language_info[key] = extended_values

--- a/dateparser/languages/validation.py
+++ b/dateparser/languages/validation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+import six
 from dateparser.utils import get_logger
 
 
@@ -54,7 +55,7 @@ class LanguageValidator(object):
     def _validate_name(cls, language_id, info):
         result = True
 
-        if 'name' not in info or not isinstance(info['name'], basestring) or not info['name']:
+        if 'name' not in info or not isinstance(info['name'], six.string_types) or not info['name']:
             cls.get_logger().error("Language '%(id)s' does not have a name", {'id': language_id})
             result = False
 
@@ -86,7 +87,7 @@ class LanguageValidator(object):
         skip_tokens_list = info['skip']
         if isinstance(skip_tokens_list, list):
             for token in skip_tokens_list:
-                if not isinstance(token, basestring) or not token:
+                if not isinstance(token, six.string_types) or not token:
                     cls.get_logger().error(
                         "Invalid 'skip' token %(token)r for '%(id)s' language: "
                         "expected not empty string",
@@ -111,7 +112,7 @@ class LanguageValidator(object):
         pertain_tokens_list = info['skip']
         if isinstance(pertain_tokens_list, list):
             for token in pertain_tokens_list:
-                if not isinstance(token, basestring) or not token:
+                if not isinstance(token, six.string_types) or not token:
                     cls.get_logger().error(
                         "Invalid 'pertain' token %(token)r for '%(id)s' language: "
                         "expected not empty string",
@@ -141,7 +142,7 @@ class LanguageValidator(object):
             translations_list = info[weekday]
             if isinstance(translations_list, list):
                 for token in translations_list:
-                    if not isinstance(token, basestring) or not token:
+                    if not isinstance(token, six.string_types) or not token:
                         cls.get_logger().error(
                             "Invalid '%(weekday)s' translation %(token)r for '%(id)s' language: "
                             "expected not empty string",
@@ -174,7 +175,7 @@ class LanguageValidator(object):
             translations_list = info[month]
             if isinstance(translations_list, list):
                 for token in translations_list:
-                    if not isinstance(token, basestring) or not token:
+                    if not isinstance(token, six.string_types) or not token:
                         cls.get_logger().error(
                             "Invalid '%(month)s' translation %(token)r for '%(id)s' language: "
                             "expected not empty string",
@@ -204,7 +205,7 @@ class LanguageValidator(object):
             translations_list = info[unit]
             if isinstance(translations_list, list):
                 for token in translations_list:
-                    if not isinstance(token, basestring) or not token:
+                    if not isinstance(token, six.string_types) or not token:
                         cls.get_logger().error(
                             "Invalid '%(unit)s' translation %(token)r for '%(id)s' language: "
                             "expected not empty string",
@@ -234,7 +235,7 @@ class LanguageValidator(object):
             translations_list = info[word]
             if isinstance(translations_list, list):
                 for token in translations_list:
-                    if not isinstance(token, basestring) or not token:
+                    if not isinstance(token, six.string_types) or not token:
                         cls.get_logger().error(
                             "Invalid '%(word)s' translation %(token)r for '%(id)s' language: "
                             "expected not empty string",
@@ -267,8 +268,8 @@ class LanguageValidator(object):
                     result = False
                     continue
 
-                key, value = simplification.items()[0]
-                if not isinstance(key, basestring) or not isinstance(value, (basestring, int)):
+                key, value = list(simplification.items())[0]
+                if not isinstance(key, six.string_types) or not isinstance(value, (six.string_types, int)):
                     cls.get_logger().error(
                         "Invalid simplification %(simplification)r for '%(id)s' language: "
                         "each simplification suppose to be string-to-string-or-int mapping",
@@ -277,7 +278,7 @@ class LanguageValidator(object):
                     continue
 
                 compiled_key = re.compile(key)
-                value = unicode(value)
+                value = six.text_type(value)
                 replacements = re.findall(r'\\(\d+)', value)
                 replacements.extend(re.findall(r'\\g<(.+?)>', value))
 
@@ -308,7 +309,7 @@ class LanguageValidator(object):
                         "unknown groups %(groups)s",
                         {'simplification': simplification,
                          'id': language_id,
-                         'groups': ", ".join(map(unicode, sorted(extra_groups)))})
+                         'groups': ", ".join(map(six.text_type, sorted(extra_groups)))})
                     result = False
 
                 if not_used_groups:
@@ -317,7 +318,7 @@ class LanguageValidator(object):
                         "groups %(groups)s were not used",
                         {'simplification': simplification,
                          'id': language_id,
-                         'groups': ", ".join(map(unicode, sorted(not_used_groups)))})
+                         'groups': ", ".join(map(six.text_type, sorted(not_used_groups)))})
                     result = False
         else:
             cls.get_logger().error(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,6 +18,8 @@ class BaseTestCase(TestCase):
         for patch in reversed(self.__patches):
             patch.stop()
 
-    def then_error_was_raised(self, error_cls, error_message):
+    def then_error_was_raised(self, error_cls, allowed_substrings=()):
         self.assertIsInstance(self.error, error_cls)
-        self.assertEqual(error_message, str(self.error))
+        self.assertTrue(any(mesg in str(self.error) for mesg in allowed_substrings),
+                        "Didn't found any of the expected messages (%r) -- message was: %r" % (
+                            allowed_substrings, self.error))

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -11,11 +11,11 @@ from mock import Mock, patch
 from nose_parameterized import parameterized, param
 
 import dateparser
+import six
 from dateparser import date
 from dateparser.date import get_last_day_of_month
 from dateparser.languages.loader import LanguageDataLoader
 from dateparser.languages.loader import default_language_loader
-from dateparser.conf import settings
 
 from tests import BaseTestCase
 
@@ -87,11 +87,11 @@ class TestDateRangeFunction(BaseTestCase):
             date_under_test += timedelta(days=1)
 
     def then_range_is_in_ascending_order(self):
-        for i in xrange(len(self.result) - 1):
+        for i in six.moves.range(len(self.result) - 1):
             self.assertLess(self.result[i], self.result[i + 1])
 
     def then_period_was_rejected(self, period):
-        self.then_error_was_raised(ValueError, 'Invalid argument: {}'.format(period))
+        self.then_error_was_raised(ValueError, ['Invalid argument: {}'.format(period)])
 
 
 class TestGetIntersectingPeriodsFunction(BaseTestCase):
@@ -181,7 +181,7 @@ class TestGetIntersectingPeriodsFunction(BaseTestCase):
         self.when_intersecting_period_calculated(low=datetime(2014, 6, 15),
                                                  high=datetime(2014, 6, 25),
                                                  period_size=period_size)
-        self.then_error_was_raised(ValueError, 'Invalid period: ' + str(period_size))
+        self.then_error_was_raised(ValueError, ['Invalid period: ' + str(period_size)])
 
     @parameterized.expand([
         param(low=datetime(2014, 4, 15), high=datetime(2014, 4, 14), period_size='month'),
@@ -338,7 +338,7 @@ class TestDateDataParser(BaseTestCase):
                           allow_redetect_language=False)
         self.when_multiple_dates_are_parsed(dates_to_parse.keys())
         self.then_all_results_were_parsed()
-        self.then_parsed_dates_are(dates_to_parse.values())
+        self.then_parsed_dates_are(list(dates_to_parse.values()))
 
     def test_should_enable_redetection_for_multiple_languages(self):
         dates_to_parse = OrderedDict([(u'13 Ago, 2014', datetime(2014, 8, 13).date()),  # es, it, pt
@@ -350,7 +350,7 @@ class TestDateDataParser(BaseTestCase):
         self.given_parser(restrict_to_languages=['es', 'it', 'pt'], allow_redetect_language=True)
         self.when_multiple_dates_are_parsed(dates_to_parse.keys())
         self.then_all_results_were_parsed()
-        self.then_parsed_dates_are(dates_to_parse.values())
+        self.then_parsed_dates_are(list(dates_to_parse.values()))
 
     @parameterized.expand([
         param("2014-10-09T17:57:39+00:00"),
@@ -502,8 +502,8 @@ class TestParserInitialization(BaseTestCase):
         self.assertIsInstance(self.error, ValueError)
         match = self.UNKNOWN_LANGUAGES_EXCEPTION_RE.match(str(self.error))
         self.assertTrue(match)
-        languages = [shortname[2:-1] for shortname in match.group(1).split(", ")]
-        self.assertItemsEqual(languages, unknown_languages)
+        languages = match.group(1).split(", ")
+        six.assertCountEqual(self, languages, [repr(l) for l in unknown_languages])
 
 
 if __name__ == '__main__':

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -10,6 +10,7 @@ from mock import patch, Mock
 from nose_parameterized import parameterized, param
 
 import dateparser.timezone_parser
+import six
 from dateparser.date import DateDataParser, date_parser
 from dateparser.date_parser import DateParser
 from dateparser.languages import default_language_loader
@@ -114,23 +115,23 @@ class AutoDetectLanguageTest(BaseTestCase):
                                  for language in languages]
 
     def when_all_languages_are_detected(self, date_strings, modify=False):
-        assert not isinstance(date_strings, basestring)
+        assert not isinstance(date_strings, six.string_types)
         for date_string in date_strings:
             detected_languages = list(self.parser.iterate_applicable_languages(date_string, modify=modify))
         self.detected_languages = detected_languages
 
     def when_one_language_is_detected(self, date_strings, modify=False):
         for date_string in date_strings:
-            detected_language = self.parser.iterate_applicable_languages(date_string, modify=modify).next()
+            detected_language = next(self.parser.iterate_applicable_languages(date_string, modify=modify))
         self.detected_languages = [detected_language]
 
     def then_detected_languages_are(self, expected_languages):
         shortnames = map(attrgetter('shortname'), self.detected_languages)
-        self.assertItemsEqual(expected_languages, shortnames)
+        six.assertCountEqual(self, expected_languages, shortnames)
 
     def then_parser_languages_are(self, expected_languages):
         shortnames = map(attrgetter('shortname'), self.parser.languages)
-        self.assertItemsEqual(expected_languages, shortnames)
+        six.assertCountEqual(self, expected_languages, shortnames)
 
 
 class ExactLanguagesTest(BaseTestCase):
@@ -141,7 +142,7 @@ class ExactLanguagesTest(BaseTestCase):
 
     def test_languages_passed_in_constructor_should_not_be_none(self):
         self.when_parser_is_constructed(languages=None)
-        self.then_error_was_raised(ValueError, 'language cannot be None for ExactLanguages')
+        self.then_error_was_raised(ValueError, ['language cannot be None for ExactLanguages'])
 
     @parameterized.expand([
         param(languages=['es'], date_strings=["13 Ago, 2014"]),
@@ -169,7 +170,7 @@ class ExactLanguagesTest(BaseTestCase):
         self.parser = ExactLanguages(languages)
 
     def when_languages_are_detected(self, date_strings, modify=False):
-        assert not isinstance(date_strings, basestring)
+        assert not isinstance(date_strings, six.string_types)
         for date_string in date_strings:
             detected_languages = list(self.parser.iterate_applicable_languages(date_string, modify=modify))
         self.detected_languages = detected_languages
@@ -182,7 +183,7 @@ class ExactLanguagesTest(BaseTestCase):
 
     def then_detected_languages_are(self, expected_languages):
         shortnames = map(attrgetter('shortname'), self.detected_languages)
-        self.assertItemsEqual(expected_languages, shortnames)
+        six.assertCountEqual(self, expected_languages, shortnames)
 
 
 class TestDateParser(BaseTestCase):
@@ -320,7 +321,7 @@ class TestDateParser(BaseTestCase):
 
     def test_empty_dates_string_is_not_parsed(self):
         self.when_date_is_parsed_by_date_parser('')
-        self.then_error_was_raised(ValueError, "Empty string")
+        self.then_error_was_raised(ValueError, ["Empty string"])
 
     @parameterized.expand([
         param('invalid date string'),
@@ -329,7 +330,7 @@ class TestDateParser(BaseTestCase):
     ])
     def test_dates_not_parsed(self, date_string):
         self.when_date_is_parsed_by_date_parser(date_string)
-        self.then_error_was_raised(ValueError, "unknown string format")
+        self.then_error_was_raised(ValueError, ["unknown string format"])
 
     @parameterized.expand([
         param('10 December', datetime(2014, 12, 10)),
@@ -455,7 +456,7 @@ class TestDateParser(BaseTestCase):
     ])
     def test_error_should_be_raised_for_invalid_dates_with_too_large_day_number(self, date_string):
         self.when_date_is_parsed_by_date_parser(date_string)
-        self.then_error_was_raised(ValueError, 'Day not in range for month')
+        self.then_error_was_raised(ValueError, ['Day not in range for month'])
 
     @parameterized.expand([
         param('2015-05-02T10:20:19+0000', languages=['fr'], expected=datetime(2015, 5, 2, 10, 20, 19)),
@@ -537,6 +538,7 @@ class TestDateParser(BaseTestCase):
         self.assertEqual(expected, self.result['date_obj'])
 
     def then_date_was_parsed_by_date_parser(self):
+        self.assertNotEqual(NotImplemented, self.date_result, "Date was not parsed")
         self.assertEqual(self.result['date_obj'], self.date_result[0])
 
 

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
+import six
 import unittest
 from datetime import datetime, timedelta, date, time
 from functools import wraps
@@ -251,7 +251,8 @@ class TestFreshnessDateDataParser(BaseTestCase):
         self.given_parser()
         self.given_date_string(date_string)
         self.when_date_is_parsed()
-        self.then_error_was_raised(ValueError, 'year is out of range')
+        self.then_error_was_raised(ValueError, ['year is out of range',
+                                                "('year must be in 1..9999'"])
 
     @parameterized.expand([
         param('несколько секунд назад', boundary={'seconds': 45}, period='day'),

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -29,7 +29,6 @@ class TestTZPopping(BaseTestCase):
         param('15 May 2004', None),
     ])
     def test_extracting_valid_offset(self, initial_string, expected_offset):
-        print self.datetime_string, self.timezone_offset
         self.given_string(initial_string)
         self.when_offset_popped_from_string()
         self.then_offset_is(expected_offset)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27, py33, py34, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Hey, folks,

@Allactaga, @csalazar, @kmike and I teamed up to port dateparser to Python 3 -- we got excited and also made sure the tests are running in PyPy as well. :)

Some interesting changes:

* We got rid of the new_relativedelta class because after realizing we don't need it anymore
* We also got rid of the decoding to bytes that was being done in parse_with_formats, as discussed in previous PR: https://github.com/scrapinghub/dateparser/pull/15/files#r21062682

That's it, folks -- thanks everyone for the help! =)