### PR TITLE
Removed check to assert position of abbreviated timezone (e.g. EDT) at the end of the string.

### DIFF
--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -10,8 +10,9 @@ from collections import OrderedDict
 import six
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
-from dateparser.timezone_parser import pop_tz_offset_from_string, convert_to_local_tz
 
+from .timezone_parser import pop_tz_offset_from_string, convert_to_local_tz
+from .utils import strip_braces
 from .conf import settings
 
 
@@ -171,6 +172,7 @@ class DateParser(object):
         if not date_string.strip():
             raise ValueError("Empty string")
 
+        date_string = strip_braces(date_string)
         date_string, tz_offset = pop_tz_offset_from_string(date_string)
 
         date_obj, period = dateutil_parse(date_string)

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -2,10 +2,12 @@
 import re
 from datetime import datetime, timedelta
 
-from dateparser.timezones import timezone_info_list
+from .timezones import timezone_info_list
+from .utils import strip_braces
 
 
 def pop_tz_offset_from_string(date_string, as_offset=True):
+    date_string = strip_braces(date_string)
     for name, info in _tz_offsets:
         timezone_re = info['regex']
         if timezone_re.search(date_string):

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -3,11 +3,9 @@ import re
 from datetime import datetime, timedelta
 
 from .timezones import timezone_info_list
-from .utils import strip_braces
 
 
 def pop_tz_offset_from_string(date_string, as_offset=True):
-    date_string = strip_braces(date_string)
     for name, info in _tz_offsets:
         timezone_re = info['regex']
         if timezone_re.search(date_string):

--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -6,7 +6,7 @@
 timezone_info_list = [
     {
         'regex_patterns':
-            [r'(\W|\d|_)\(?%s\)?'],
+            [r'(\W|\d|_)\(?%s(\)|$|[^\w+])'],
         'timezones':
             [('ACDT', 37800),
              ('ACST', 34200),

--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -6,7 +6,7 @@
 timezone_info_list = [
     {
         'regex_patterns':
-            [r'(\W|\d|_)\(?%s(\)|$|[^\w+])'],
+            [r'(\W|\d|_)%s($|\W)'],
         'timezones':
             [('ACDT', 37800),
              ('ACST', 34200),

--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -6,7 +6,7 @@
 timezone_info_list = [
     {
         'regex_patterns':
-            [r'(\W|\d|_)\(?%s\)?$'],
+            [r'(\W|\d|_)\(?%s\)?'],
         'timezones':
             [('ACDT', 37800),
              ('ACST', 34200),

--- a/dateparser/utils.py
+++ b/dateparser/utils.py
@@ -7,6 +7,10 @@ GROUPS_REGEX = re.compile(r'(?<=\\)(\d+|g<\d+>)')
 G_REGEX = re.compile(r'g<(\d+)>')
 
 
+def strip_braces(date_string):
+    return re.sub(r'[{}()<>\[\]]+', '', date_string)
+
+
 def wrap_replacement_for_regex(replacement, regex):
     # prepend group to replacement
     replacement = r"\g<1>%s" % increase_regex_replacements_group_positions(replacement, increment=1)

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -203,6 +203,7 @@ class TestDateParser(BaseTestCase):
         param('November 19, 2014 at noon', datetime(2014, 11, 19, 12, 0)),
         param('December 13, 2014 at midnight', datetime(2014, 12, 13, 0, 0)),
         param('Nov 25 2014 10:17 pm EST', datetime(2014, 11, 26, 3, 17)),
+        param('Wed Aug 05 12:00:00 EDT 2015', datetime(2015, 8, 5, 16, 0)),
         param('April 9, 2013 at 6:11 a.m.', datetime(2013, 4, 9, 6, 11)),
         param('Aug. 9, 2012 at 2:57 p.m.', datetime(2012, 8, 9, 14, 57)),
         param('December 10, 2014, 11:02:21 pm', datetime(2014, 12, 10, 23, 2, 21)),

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -27,6 +27,8 @@ class TestTZPopping(BaseTestCase):
         param('20 Oct 2014 | 05:17 am -1200', -12),
         param('20 Oct 2014 | 05:17 am +0000', 0),
         param('15 May 2004', None),
+        param('Wed Aug 05 12:00:00 EDTERR 2015', None),
+        param('Wed Aug 05 12:00:00 EDT 2015', -4),
     ])
     def test_extracting_valid_offset(self, initial_string, expected_offset):
         self.given_string(initial_string)


### PR DESCRIPTION
I ran into this scenario while working with dates on usnews.com.

Previously,

```
In [1]: from dateparser import parse
pars
In [2]: parse('Wed Aug 05 12:00:00 EDT 2015')

In [3]: parse('Wed Aug 05 12:00:00 2015 EDT')
Out[3]: datetime.datetime(2015, 8, 5, 21, 0)
```

After the changes,

```
In [1]: from dateparser import parse

In [2]: parse('Wed Aug 05 12:00:00 2015 EDT')
Out[2]: datetime.datetime(2015, 8, 5, 21, 0)

In [3]: parse('Wed Aug 05 12:00:00 EDT 2015')
Out[3]: datetime.datetime(2015, 8, 5, 21, 0)
```