### PR TITLE
Introducing regex module

### DIFF
--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -1,7 +1,7 @@
-import re
 from datetime import datetime
 
 from umalqurra.hijri_date import HijriDate
+import regex as re
 
 from dateparser.calendars import CalendarBase
 from dateparser.date import DateDataParser

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
-import re
+
+import regex as re
 from collections import OrderedDict
 from datetime import datetime, time
 from functools import reduce

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import calendar
 import collections
-import re
+import regex as re
 import six
 from datetime import datetime, timedelta
 from warnings import warn

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import calendar
-import re
+import regex as re
 import sys
 from datetime import datetime
 from collections import OrderedDict

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
+import regex as re
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import re
+import regex as re
 from six.moves import zip_longest
 from operator import methodcaller
 

--- a/dateparser/languages/language.py
+++ b/dateparser/languages/language.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import re
+import regex as re
 from itertools import chain
 
 from dateutil import parser

--- a/dateparser/languages/validation.py
+++ b/dateparser/languages/validation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import re
+import regex as re
 import six
 from dateparser.utils import get_logger
 

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import re
+import regex as re
 from datetime import datetime, timedelta
 
 from dateparser.timezones import timezone_info_list

--- a/dateparser/utils.py
+++ b/dateparser/utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-import re
+import regex as re
 import logging
-import logging.config
 
 GROUPS_REGEX = re.compile(r'(?<=\\)(\d+|g<\d+>)')
 G_REGEX = re.compile(r'g<(\d+)>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dateutil>=2.3
 PyYAML
+regex

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'jdatetime',
         'umalqurra',
         'pytz',
+        'regex',
     ],
     license="BSD",
     zip_safe=False,

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import re
+import regex as re
 import unittest
 from collections import OrderedDict
 from datetime import datetime, timedelta


### PR DESCRIPTION
Introduction of `regex` module (used instead of standard `re`) will allow for more flexible approach to regular expressions.