### PR TITLE
[Portuguese] Fix for translation of "second".

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,7 @@ Committers
 
 * Artur Sadurski
 * Claudio Salazar
+* Cesar Flores
 * Elias Dorneles
 * Eugene Amirov
 * Faisal Anees

--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -566,7 +566,7 @@ pt:
         - minutos
         - min
     second:
-        - segunda
+        - segundo
         - segundos
 
     ago:

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -107,6 +107,7 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('anteontem', ago={'days': 2}, period='day'),
         param('hoje', ago={'days': 0}, period='day'),
         param('uma hora atrás', ago={'hours': 1}, period='day'),
+        param('1 segundo atrás', ago={'seconds': 1}, period='day'),
         param('um dia atrás', ago={'days': 1}, period='day'),
         param('uma semana atrás', ago={'weeks': 1}, period='week'),
         param('2 horas atrás', ago={'hours': 2}, period='day'),

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -118,6 +118,7 @@ class TestBundledLanguages(BaseTestCase):
         param('pt', "56 minutos", "56 minute"),
         param('pt', "12 dias", "12 day"),
         param('pt', "há 14 min.", "ago 14 minute."),
+        param('pt', "1 segundo atrás", "1 second ago"),
         # Russian
         param('ru', "9 месяцев", "9 month"),
         param('ru', "8 недели", "8 week"),


### PR DESCRIPTION
Quick fix for issue https://github.com/scrapinghub/dateparser/issues/113.