### PR TITLE
Fix: add settings.yaml in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 include data/languages.yaml
+include data/settings.yaml
 include requirements.txt
 include requirements-build.txt
 


### PR DESCRIPTION
Fixing problem with build:
- newly introduced settings.yaml was missing from MANIFEST.in file list.