### PR TITLE
quick-fix for missing jdatetime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'python-dateutil >= 2.3',
-        'PyYAML'
+        'PyYAML',
+        'jdatetime'
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
Added `jdatetime` dependency in `setup.py`.