### PR TITLE
Add "Monaten" as "Months" in Deustch

### DIFF
--- a/data/languages.yaml
+++ b/data/languages.yaml
@@ -190,6 +190,7 @@ de:
     month:
         - Monat
         - Monate
+        - Monaten
     week:
         - Woche
         - Wochen

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -98,6 +98,8 @@ class TestBundledLanguages(BaseTestCase):
         param('de', "vorgestern", "2 day"),
         param('de', "heute", "0 day"),
         param('de', "vor 3 Stunden", "ago 3 hour"),
+        param('de', "vor 2 Monaten", "ago 2 month"),
+        param('de', "vor 2 Monaten, 2 Wochen", "ago 2 month 2 week"),
         # French
         param('fr', "avant-hier", "2 day"),
         param('fr', "hier", "1 day"),


### PR DESCRIPTION
I got the following error:
"ERROR	[root] Unknown date format u'vor 2 Monaten, 2 Wochen' in http://www.headbook.me/foren/page/6/"

I added a translation for "Monaten" -> "month(s)" in DE language.

Please review @waqasshabbir 