### PR TITLE
Feature tz aware return type

### DIFF
--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -4,3 +4,4 @@ settings:
     PREFER_DAY_OF_MONTH: 'current'
     SKIP_TOKENS: ["t"]
     TIMEZONE: 'UTC'
+    RETURN_AS_TIMEZONE_AWARE: False

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -19,6 +19,7 @@ class Settings(object):
     * `PREFER_DAY_OF_MONTH`: defaults to `current`. Could be `first` and `last` day of month.
     * `SKIP_TOKENS`: defaults to `['t']`. Can be any string.
     * `TIMEZONE`: defaults to `UTC`. Can be timezone abbreviation or any of `tz database name as given here <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
+    * `RETURN_AS_TIMEZONE_AWARE`: return tz aware datetime objects in case timezone is detected in the date string.
     """
 
     _default = True

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -327,7 +327,8 @@ class DateDataParser(object):
             >>> DateDataParser().get_date_data(u'2014')
             {'date_obj': datetime.datetime(2014, 6, 16, 0, 0), 'period': u'year'}
 
-        Dates with time zone indications or UTC offsets are returned in UTC time.
+        Dates with time zone indications or UTC offsets are returned in UTC time unless
+        specified using `Settings`_.
 
             >>> DateDataParser().get_date_data(u'23 March 2000, 1:21 PM CET')
             {'date_obj': datetime.datetime(2000, 3, 23, 14, 21), 'period': 'day'}

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -175,14 +175,17 @@ class DateParser(object):
             raise ValueError("Empty string")
 
         date_string = strip_braces(date_string)
-        date_string, tz_offset = pop_tz_offset_from_string(date_string)
+        date_string, tz = pop_tz_offset_from_string(date_string)
 
         date_obj, period = dateutil_parse(date_string, settings=settings)
 
-        if tz_offset is not None:
-            date_obj -= tz_offset  # convert date to UTC if timezone detected
+        if tz is not None:
+            date_obj = tz.localize(date_obj)
 
         date_obj = apply_timezone(date_obj, settings.TIMEZONE)
+
+        if not settings.RETURN_AS_TIMEZONE_AWARE:
+            date_obj = date_obj.replace(tzinfo=None)
 
         return date_obj, period
 

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -56,6 +56,9 @@ class FreshnessDateDataParser(object):
                 # e.g. `2 days ago at 1 PM`
                 date = apply_timezone(date, settings.TIMEZONE)
 
+            if not settings.RETURN_AS_TIMEZONE_AWARE:
+                date = date.replace(tzinfo=None)
+
         return date, period
 
     def _parse(self, date_string):

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -25,7 +25,7 @@ class StaticTzInfo(tzinfo):
 
     def localize(self, dt, is_dst=False):
         if dt.tzinfo is not None:
-            raise ValueError, 'Not naive datetime (tzinfo is already set)'
+            raise ValueError('Not naive datetime (tzinfo is already set)')
         return dt.replace(tzinfo=self)
 
 

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -1,8 +1,32 @@
 # -*- coding: utf-8 -*-
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
 
 from .timezones import timezone_info_list
+
+
+class StaticTzInfo(tzinfo):
+
+    def __init__(self, name, offset):
+        self.__offset = offset
+        self.__name = name
+
+    def tzname(self, dt):
+        return self.__name
+
+    def utcoffset(self, dt):
+        return self.__offset
+
+    def dst(self, dt):
+        return timedelta(0)
+
+    def __repr__(self):
+        return "<%s '%s'>" % (self.__class__.__name__, self.__name)
+
+    def localize(self, dt, is_dst=False):
+        if dt.tzinfo is not None:
+            raise ValueError, 'Not naive datetime (tzinfo is already set)'
+        return dt.replace(tzinfo=self)
 
 
 def pop_tz_offset_from_string(date_string, as_offset=True):
@@ -10,7 +34,7 @@ def pop_tz_offset_from_string(date_string, as_offset=True):
         timezone_re = info['regex']
         if timezone_re.search(date_string):
             date_string = timezone_re.sub(r'\1', date_string)
-            return date_string, info['offset'] if as_offset else name
+            return date_string, StaticTzInfo(name, info['offset']) if as_offset else name
     else:
         return date_string, None
 

--- a/dateparser/utils.py
+++ b/dateparser/utils.py
@@ -93,9 +93,6 @@ def find_date_separator(format):
 
 
 def apply_tzdatabase_timezone(date_time, pytz_string):
-    if not date_time.tzinfo:
-        date_time = UTC.localize(date_time)
-
     usr_timezone = timezone(pytz_string)
 
     if date_time.tzinfo != usr_timezone:
@@ -111,11 +108,14 @@ def apply_dateparser_timezone(utc_datetime, offset_or_timezone_abb):
             return utc_datetime.astimezone(tz)
 
 
-def apply_timezone(datetime, tz_string):
-    new_datetime = apply_dateparser_timezone(datetime, tz_string)
+def apply_timezone(date_time, tz_string):
+    if not date_time.tzinfo:
+        date_time = UTC.localize(date_time)
+
+    new_datetime = apply_dateparser_timezone(date_time, tz_string)
 
     if not new_datetime:
-        new_datetime = apply_tzdatabase_timezone(datetime, tz_string)
+        new_datetime = apply_tzdatabase_timezone(date_time, tz_string)
 
     return new_datetime
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,3 +71,12 @@ Assuming current date is June 16, 2015:
     >>> from dateparser.date import DateDataParser
     >>> DateDataParser(settings={'SKIP_TOKENS': ['de']}).get_date_data(u'27 Haziran 1981 de')  # Turkish (at 27 June 1981)
     {'date_obj': datetime.datetime(1981, 6, 27, 0, 0), 'period': 'day'}
+
+``RETURN_AS_TIMEZONE_AWARE`` is a flag to turn on timezone aware dates if timezone is detected or specified.:
+
+    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True})
+    datetime.datetime(2015, 2, 13, 3, 56, tzinfo=<StaticTzInfo 'UTC'>)
+
+    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': 'EST'})
+    datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)
+

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,10 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from nose_parameterized import parameterized, param
+from datetime import datetime, tzinfo
+
 from tests import BaseTestCase
 
 from dateparser.conf import settings
 from dateparser.conf import apply_settings
 
+from dateparser import parse
+
 def test_function(settings=None):
     return settings
+
+
+class TimeZoneSettingsTest(BaseTestCase):
+    def setUp(self):
+        super(TimeZoneSettingsTest, self).setUp()
+        self.given_ds = NotImplemented
+        self.result = NotImplemented
+        self.timezone = NotImplemented
+        self.confs = NotImplemented
+
+    @parameterized.expand([
+        param('12 Feb 2015 10:30 PM +0100', datetime(2015, 2, 12, 21, 30)),
+        param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 21, 30)),
+        param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 15, 30)),
+        param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 13, 1, 30)),
+        ])
+    def test_should_return_tz_aware_dates(self, ds, dt):
+        self.given(ds)
+        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': True})
+        self.when_date_is_parsed()
+        self.then_date_is_tz_aware()
+        self.then_date_is(dt)
+
+    @parameterized.expand([
+        param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 16, 30), 'EST'),
+        param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 20, 30), 'PKT'),
+        param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 12, 20, 30), 'ACT'),
+        ])
+    def test_should_return_and_assert_tz(self, ds, dt, tz):
+        self.given(ds)
+        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': tz})
+        self.when_date_is_parsed()
+        self.then_date_is_tz_aware()
+        self.then_date_is(dt)
+        self.then_timezone_is(tz)
+
+    def then_timezone_is(self, tzname):
+        self.assertEqual(self.result.tzinfo.tzname(''), tzname)
+
+    def given(self, ds):
+        self.given_ds = ds
+
+    def given_configurations(self, confs):
+        self.confs = confs
+
+    def when_date_is_parsed(self):
+        self.result = parse(self.given_ds, settings=(self.confs or {}))
+
+    def then_date_is_tz_aware(self):
+        self.assertIsInstance(self.result.tzinfo, tzinfo)
+
+    def then_date_is(self, date):
+        dtc = self.result.replace(tzinfo=None)
+        self.assertEqual(dtc, date)
 
 
 class SettingsTest(BaseTestCase):

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -59,7 +59,11 @@ class TestTZPopping(BaseTestCase):
         self.initial_string = string_
 
     def when_offset_popped_from_string(self):
-        self.datetime_string, self.timezone_offset = pop_tz_offset_from_string(self.initial_string)
+        self.datetime_string, timezone_offset = pop_tz_offset_from_string(self.initial_string)
+        if timezone_offset:
+            self.timezone_offset = timezone_offset.utcoffset('')
+        else:
+            self.timezone_offset = timezone_offset
 
     def then_string_modified_to(self, expected_string):
         self.assertEqual(expected_string, self.datetime_string)


### PR DESCRIPTION
Fixes #143.

Example:

```
In [2]: parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': 'EST'})
Out[2]: datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)

# if no `TIMEZONE` isn't specified.
In [3]: parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True})
Out[3]: datetime.datetime(2015, 2, 13, 3, 56, tzinfo=<StaticTzInfo 'UTC'>)
```