### PR TITLE
Fix sanitize Russian year

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -88,9 +88,11 @@ def get_intersecting_periods(low, high, period='day'):
 
 def sanitize_date(date_string):
     date_string = re.sub(
-        r'\t|\n|\r|\u00bb|,\s\u0432|\u0433\.|\u200e|\xb7|\u200f|\u064e|\u064f',
+        r'\t|\n|\r|\u00bb|,\s\u0432|\u200e|\xb7|\u200f|\u064e|\u064f',
         ' ', date_string, flags=re.M
     )
+    date_string = re.sub(r'([\W\d])\u0433\.', r'\1 ', date_string,
+                         flags=re.I | re.U)  # remove u'г.' (Russian for year) but not in words
     date_string = sanitize_spaces(date_string)
     date_string = re.sub(r'\b([ap])(\.)?m(\.)?\b', r'\1m', date_string, flags=re.DOTALL | re.I)
     date_string = re.sub(r'^.*?on:\s+(.*)', r'\1', date_string)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -508,5 +508,12 @@ class TestParserInitialization(BaseTestCase):
         six.assertCountEqual(self, languages, [repr(l) for l in unknown_languages])
 
 
+class TestSanitizeDate(BaseTestCase):
+    def test_remove_year_in_russian(self):
+        self.assertEqual(date.sanitize_date(u'2005г.'), u'2005 ')
+        self.assertEqual(date.sanitize_date(u'2005 г.'), u'2005 ')
+        self.assertEqual(date.sanitize_date(u'Авг.'), u'Авг.')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -253,6 +253,10 @@ class TestDateParser(BaseTestCase):
         param('09 августа 2012', datetime(2012, 8, 9, 0, 0)),
         param('Авг 26, 2015 15:12', datetime(2015, 8, 26, 15, 12)),
         param('2 Декабрь 95 11:15', datetime(1995, 12, 2, 11, 15)),
+        param('13 янв. 2005 19:13', datetime(2005, 1, 13, 19, 13)),
+        param('13 авг. 2005 19:13', datetime(2005, 8, 13, 19, 13)),
+        param('13 авг. 2005г. 19:13', datetime(2005, 8, 13, 19, 13)),
+        param('13 авг. 2005 г. 19:13', datetime(2005, 8, 13, 19, 13)),
         # Turkish dates
         param('11 Ağustos, 2014', datetime(2014, 8, 11)),
         param('08.Haziran.2014, 11:07', datetime(2014, 6, 8, 11, 7)),  # forum.andronova.net


### PR DESCRIPTION
Hi,
I've fixed issue: https://github.com/scrapinghub/dateparser/issues/147
Problem was that sanitize_date remove 'г.' even if it's part of word like 'Авг.'