### PR TITLE
Handle change in return type of private method in dateutil 2.5.0

### DIFF
--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -33,6 +33,10 @@ class new_parser(parser.parser):
         # Parse timestr
         res = self._parse(timestr, **kwargs)
 
+        # python-dateutil >= 2.50 changed return type of parser._parse()
+        if isinstance(res, tuple):
+            res = res[0]
+
         if res is None:
             raise ValueError("unknown string format")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-dateutil<=2.4.2
+python-dateutil
 PyYAML
 regex
 jdatetime

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=('tests', 'tests.*')),
     include_package_data=True,
     install_requires=[
-        'python-dateutil <= 2.4.2',
+        'python-dateutil',
         'PyYAML',
         'jdatetime',
         'umalqurra',


### PR DESCRIPTION
Fixes #154.

The "fix" in #154 was really just a workaround and didn't address the cause of the problem: `dateparser` uses the private `_parse()` method of `dateutil.parser.parser`. This method changed its return type in `python-dateuti` 2.5.0 to a tuple. This PR handles this in a backwards-compatible way and removes the version restriction for python-dateutil in `setup.py` and `requirements.txt` again.