### PR TITLE
Fix a bug with parsing of string "now" and date strings in the "YYYY-mm-dd" format

### DIFF
--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -35,6 +35,9 @@ class new_parser(parser.parser):
 
         if res is None:
             raise ValueError("unknown string format")
+        if isinstance(res, tuple):
+            # First item is a result object
+            res = res[0]
 
         # Fill in missing date
         new_date = self._populate(res, default, settings=settings)

--- a/dateparser/utils.py
+++ b/dateparser/utils.py
@@ -21,6 +21,9 @@ def is_dateutil_result_obj_parsed(date_string):
     res = parser()._parse(date_string)
     if not res:
         return False
+    if isinstance(res, tuple):
+        # First item is a result object
+        res = res[0]
 
     def get_value(obj, key):
         value = getattr(obj, key)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -334,6 +334,7 @@ class TestDateDataParser(BaseTestCase):
     def test_should_not_assume_language_too_early(self):
         dates_to_parse = OrderedDict([(u'07/07/2014', datetime(2014, 7, 7).date()),  # any language
                                       (u'2013-10-24', datetime(2013, 10, 24).date()),  # any language
+                                      (u'2013-05-24', datetime(2013, 5, 24).date()),  # any language
                                       (u'07.jul.2014 | 12:52', datetime(2014, 7, 7).date()),  # en, es, pt, nl
                                       (u'07.ago.2014 | 12:52', datetime(2014, 8, 7).date()),  # es, it, pt
                                       (u'07.feb.2014 | 12:52', datetime(2014, 2, 7).date()),  # en, de, es, it, nl, ro

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -333,6 +333,7 @@ class TestDateDataParser(BaseTestCase):
 
     def test_should_not_assume_language_too_early(self):
         dates_to_parse = OrderedDict([(u'07/07/2014', datetime(2014, 7, 7).date()),  # any language
+                                      (u'2013-10-24', datetime(2013, 10, 24).date()),  # any language
                                       (u'07.jul.2014 | 12:52', datetime(2014, 7, 7).date()),  # en, es, pt, nl
                                       (u'07.ago.2014 | 12:52', datetime(2014, 8, 7).date()),  # es, it, pt
                                       (u'07.feb.2014 | 12:52', datetime(2014, 2, 7).date()),  # en, de, es, it, nl, ro

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -312,6 +312,8 @@ class TestDateDataParser(BaseTestCase):
         param('Сегодня', days_ago=0),
         param('Hoje', days_ago=0),
         param('Oggi', days_ago=0),
+        # Now
+        param('now', days_ago=0),
         # Yesterday
         param('yesterday', days_ago=1),
         param(' Yesterday \n', days_ago=1),


### PR DESCRIPTION
This pull request fixes a bug with parsing of string `now` which was introduced by #115.

Before this change if you wanted to parse this string, the following exception was thrown:

```python
>>> import dateparser
>>> dateparser.parse('now')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/conf.py", line 80, in wrapper
    return f(*args, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/__init__.py", line 40, in parse
    data = parser.get_date_data(date_string, date_formats)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/date.py", line 343, in get_date_data
    language, date_string, date_formats, settings=self._settings)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/date.py", line 161, in parse
    return instance._parse()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/date.py", line 171, in _parse
    date_obj = parser()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/date.py", line 184, in _try_freshness_parser
    return freshness_date_parser.get_date_data(self._get_translated_date(), self._settings)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/freshness_date_parser.py", line 95, in get_date_data
    date, period = self.parse(date_string, settings)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/freshness_date_parser.py", line 50, in parse
    _time = self._parse_time(date_string)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/freshness_date_parser.py", line 40, in _parse_time
    if is_dateutil_result_obj_parsed(date_string):
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/dateparser/utils.py", line 33, in is_dateutil_result_obj_parsed
    return any([get_value(res, k) for k in res.__slots__])
AttributeError: 'tuple' object has no attribute '__slots__
```

The issue appears to be that the `res` object is a tuple (`(_result(), None)`) and `is_dateutil_result_obj_parsed` function doesn't take that into account.