### PR TITLE
adding features for more use-cases to date_parser

### DIFF
--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -5,3 +5,5 @@ settings:
     SKIP_TOKENS: ["t"]
     TIMEZONE: 'UTC'
     RETURN_AS_TIMEZONE_AWARE: False
+    TIMEZONE_CONVERSION: True
+    NO_DEFAULT_TIMEZONE: False

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -20,6 +20,8 @@ class Settings(object):
     * `SKIP_TOKENS`: defaults to `['t']`. Can be any string.
     * `TIMEZONE`: defaults to `UTC`. Can be timezone abbreviation or any of `tz database name as given here <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
     * `RETURN_AS_TIMEZONE_AWARE`: return tz aware datetime objects in case timezone is detected in the date string.
+    * `TIMEZONE_CONVERSION`: defaults to `True`.  Converts the output to the timezone specified in `TIMEZONE`
+    * `NO_DEFAULT_TIMEZONE`: defaults to `False`. Prevents UTC timezone being used by default in case no timezone is detected and `TIMEZONE` is not specified.
     """
 
     _default = True

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from collections import OrderedDict
 
 import six
+import pytz
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 
@@ -181,8 +182,11 @@ class DateParser(object):
 
         if tz is not None:
             date_obj = tz.localize(date_obj)
+        elif not settings.NO_DEFAULT_TIMEZONE:
+            date_obj = pytz.timezone(settings.TIMEZONE).localize(date_obj)
 
-        date_obj = apply_timezone(date_obj, settings.TIMEZONE)
+        if settings.TIMEZONE_CONVERSION and not settings.NO_DEFAULT_TIMEZONE:
+            date_obj = apply_timezone(date_obj, settings.TIMEZONE)
 
         if not settings.RETURN_AS_TIMEZONE_AWARE:
             date_obj = date_obj.replace(tzinfo=None)


### PR DESCRIPTION
This PR is not ready yet but I want to get opinions first before finishing it.

### Specific issues I'm attempting to solve with this PR:
- Returning datetime with auto-detected timezone info; currently you have to manually enter the timezone as the TIMEZONE setting
- Returning datetime with no timezone info if none is detected in the string, else timezone info if it is detected; currently you either have timezone info or not depending on the code and not the date string
- Use the auto-detected timezone, or a default one if one is not detected


### Examples:

**String that I know is EST and I want a datetime with tz of EST**
Current code - possible

    DateDataParser(settings={'TIMEZONE': 'EST', 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'EST'>)

**String that I know is EST and I want a datetime converted to UTC**
Current code & PR code - only possible in hacky way

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM' + ' EST')
    datetime.datetime(2000, 3, 23, 18, 21, tzinfo=<StaticTzInfo 'UTC'>)

**String that I don't know is EST and I want a datetime converted to UTC**
Current code - possible

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM EST')
    datetime.datetime(2000, 3, 23, 18, 21, tzinfo=<StaticTzInfo 'UTC'>)

**String that I don't know is EST and I want a datetime converted to PST**
Current code - possible

    DateDataParser(settings={'TIMEZONE': 'PST', 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM EST')
    datetime.datetime(2000, 3, 23, 10, 21, tzinfo=<StaticTzInfo 'PST'>)

**String that I don't know is EST and I want a datetime with tz of EST**
Current code - not possible

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM EST')
    datetime.datetime(2000, 3, 23, 18, 21, tzinfo=<StaticTzInfo 'UTC'>)
PR code - possible

    DateDataParser(settings={'TIMEZONE_CONVERSION': False, 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM EST')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'EST'>)

**String that I think should be EST but actually I'm not sure and the string knows better than me (use a default timezone only if one is not detected)**
Current code - not possible (string is interpreted as PST and converted to EST)

    DateDataParser(settings={'TIMEZONE': 'EST', 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM PST')
    datetime.datetime(2000, 3, 23, 16, 21, tzinfo=<StaticTzInfo 'EST'>)
PR code - possible

    DateDataParser(settings={'TIMEZONE': 'EST', 'TIMEZONE_CONVERSION': False, 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM PST')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'PST'>)

**String that may have timezone info and I want a datetime with the timezone info if it has, or not if it doesn't**
Current code - not possible

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM PST')
    datetime.datetime(2000, 3, 23, 21, 21, tzinfo=<StaticTzInfo 'UTC'>)

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'UTC'>)
PR code - possible

    DateDataParser(settings={'NO_DEFAULT_TIMEZONE': True, 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM PST')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'PST'>)

    DateDataParser(settings={'NO_DEFAULT_TIMEZONE': True, 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM')
    datetime.datetime(2000, 3, 23, 13, 21)

**String that may have timezone info and I want it converted to UTC if it does, or no timezone info if it doesn't**
Current code - not possible

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM PST')
    datetime.datetime(2000, 3, 23, 21, 21, tzinfo=<StaticTzInfo 'UTC'>)

    DateDataParser(settings={'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'UTC'>)
PR code - not possible without changing `conf.py` or adding another setting

    DateDataParser(settings={'TIMEZONE': 'UTC', 'NO_DEFAULT_TIMEZONE': True, 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM PST')
    datetime.datetime(2000, 3, 23, 13, 21, tzinfo=<StaticTzInfo 'PST'>)

    DateDataParser(settings={'TIMEZONE': 'UTC', 'NO_DEFAULT_TIMEZONE': True, 'RETURN_AS_TIMEZONE_AWARE': True}).get_date_data(u'23 March 2000, 1:21 PM')
    datetime.datetime(2000, 3, 23, 13, 21)


-----------------------

The proposed solution is not really ideal and still doesn't quite cover all cases, but I'm not sure how to improve it without making it more messy or breaking existing tests.  Ideally we could:

- Separate `TIMEZONE` into two params; one for the default timezone of the string if not detected, and the second for the output timezone (the timezone the string should be converted into)
- UTC should not be assumed by default; strings with no timezone info should be possible
- Conversion to UTC can be default but should be optional