### PR TITLE
Allow client code to determine whether a timezone was explicitly specified

### DIFF
--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -182,7 +182,8 @@ class DateParser(object):
         if tz is not None:
             date_obj = tz.localize(date_obj)
 
-        date_obj = apply_timezone(date_obj, settings.TIMEZONE)
+        if settings.TIMEZONE:
+            date_obj = apply_timezone(date_obj, settings.TIMEZONE)
 
         if not settings.RETURN_AS_TIMEZONE_AWARE:
             date_obj = date_obj.replace(tzinfo=None)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -80,3 +80,10 @@ Assuming current date is June 16, 2015:
     >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': 'EST'})
     datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)
 
+If ``RETURN_AS_TIMEZONE_AWARE`` is set to ``True``, and ``TIMEZONE`` is ``None``, a timezone aware date is only returned if the input string explicitly specifies the time zone, otherwise an unaware date is returned:
+
+    >>> parse('12 Feb 2015 10:56 PM', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': None})
+    datetime.datetime(2015, 2, 12, 22, 56)
+
+    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': None})
+    datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -49,6 +49,23 @@ class TimeZoneSettingsTest(BaseTestCase):
         self.then_date_is(dt)
         self.then_timezone_is(tz)
 
+    @parameterized.expand([
+        param('12 Feb 2015 4:30 PM', datetime(2015, 2, 12, 16, 30), None),
+        param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 16, 30), 'EST'),
+        param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 20, 30), 'PKT'),
+        param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 12, 20, 30), 'ACT'),
+        ])
+    def test_only_return_explicit_timezone(self, ds, dt, tz):
+        self.given(ds)
+        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': None})
+        self.when_date_is_parsed()
+        self.then_date_is(dt)
+        if tz:
+            self.then_date_is_tz_aware()
+            self.then_timezone_is(tz)
+        else:
+            self.then_date_is_not_tz_aware()
+
     def then_timezone_is(self, tzname):
         self.assertEqual(self.result.tzinfo.tzname(''), tzname)
 
@@ -63,6 +80,9 @@ class TimeZoneSettingsTest(BaseTestCase):
 
     def then_date_is_tz_aware(self):
         self.assertIsInstance(self.result.tzinfo, tzinfo)
+
+    def then_date_is_not_tz_aware(self):
+        self.assertIsNone(self.result.tzinfo)
 
     def then_date_is(self, date):
         dtc = self.result.replace(tzinfo=None)


### PR DESCRIPTION
If ``RETURN_AS_TIMEZONE_AWARE`` is set to ``True``, and ``TIMEZONE`` is ``None``, a timezone aware date is only returned if the input string explicitly specifies the time zone, otherwise an unaware date is returned.

This change allows client code to determine whether or not a timezone was explicitly specified in the date string.