### PR TITLE
Added get_date_tuple method to DateDataParser

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -351,6 +351,11 @@ class DateDataParser(object):
         else:
             return {'date_obj': None, 'period': 'day'}
 
+    def get_date_tuple(self, *args, **kwargs):
+        date_tuple = collections.namedtuple('DateData', 'date_obj period')
+        date_data = self.get_date_data(*args, **kwargs)
+        return date_tuple(**date_data)
+
     @classmethod
     def _get_language_loader(cls):
         if not cls.language_loader:


### PR DESCRIPTION
Added method `get_date_tuple` to `DateDataParser` that returns the same data as `get_date_data` but as a `namedtuple` since in most cases the dictionary returned by `get_date_data` won't be modified and it's more readable to use.