### PR TITLE
tweak for timezone

### DIFF
--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -106,7 +106,8 @@ def apply_dateparser_timezone(utc_datetime, offset_or_timezone_abb):
 
 def apply_timezone(date_time, tz_string):
     if not date_time.tzinfo:
-        date_time = UTC.localize(date_time)
+        thetz = timezone(tz_string)
+        date_time = thetz.localize(date_time)
 
     new_datetime = apply_dateparser_timezone(date_time, tz_string)
 


### PR DESCRIPTION
The default was to assume the input date_time was UTC but the `tz_string` appears to hold the information.  So I created a timezone object based on the `tz_string`.  

One thing I did not check for was an empty `tz_string` as I did not follow it back through. So a little more work might have to be done.