### PR TITLE
Take into account parsing ambiguous years using 'PREFER_DATES_FROM'

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -381,6 +381,14 @@ class _parser(object):
                 if 'future' in self.settings.PREFER_DATES_FROM:
                     dateobj = dateobj.replace(year=dateobj.year + 1)
 
+        if self._token_year and len(self._token_year[0]) == 2:
+            if self.now < dateobj:
+                if 'past' in self.settings.PREFER_DATES_FROM:
+                    dateobj = dateobj.replace(year=dateobj.year - 100)
+            else:
+                if 'future' in self.settings.PREFER_DATES_FROM:
+                    dateobj = dateobj.replace(year=dateobj.year + 100)
+
         if self._token_time and not any([self._token_year,
                                          self._token_month,
                                          self._token_day,

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -544,8 +544,8 @@ class TestDateParser(BaseTestCase):
         param('16:10', datetime(2015, 2, 14, 16, 10)),
         param('14:05', datetime(2015, 2, 15, 14, 5)),
         param('15 february 15:00', datetime(2015, 2, 15, 15, 0)),
-        param('3/7/50', datetime(1950, 3, 7)),
-        param('3/7/94', datetime(1994, 3, 7)),
+        param('3/3/50', datetime(1950, 3, 3)),
+        param('3/3/94', datetime(1994, 3, 3)),
     ])
     def test_preferably_past_dates(self, date_string, expected):
         self.given_parser(settings={'PREFER_DATES_FROM': 'past', 'RELATIVE_BASE': datetime(2015, 2, 15, 15, 30)})
@@ -561,8 +561,8 @@ class TestDateParser(BaseTestCase):
         param('10:00PM', datetime(2015, 2, 15, 22, 0)),
         param('16:10', datetime(2015, 2, 15, 16, 10)),
         param('14:05', datetime(2015, 2, 16, 14, 5)),
-        param('3/7/50', datetime(2050, 3, 7)),
-        param('3/7/94', datetime(2094, 3, 7)),
+        param('3/3/50', datetime(2050, 3, 3)),
+        param('3/3/94', datetime(2094, 3, 3)),
     ])
     def test_preferably_future_dates(self, date_string, expected):
         self.given_local_tz_offset(0)

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -544,6 +544,8 @@ class TestDateParser(BaseTestCase):
         param('16:10', datetime(2015, 2, 14, 16, 10)),
         param('14:05', datetime(2015, 2, 15, 14, 5)),
         param('15 february 15:00', datetime(2015, 2, 15, 15, 0)),
+        param('3/7/50', datetime(1950, 3, 7)),
+        param('3/7/94', datetime(1994, 3, 7)),
     ])
     def test_preferably_past_dates(self, date_string, expected):
         self.given_parser(settings={'PREFER_DATES_FROM': 'past', 'RELATIVE_BASE': datetime(2015, 2, 15, 15, 30)})
@@ -559,6 +561,8 @@ class TestDateParser(BaseTestCase):
         param('10:00PM', datetime(2015, 2, 15, 22, 0)),
         param('16:10', datetime(2015, 2, 15, 16, 10)),
         param('14:05', datetime(2015, 2, 16, 14, 5)),
+        param('3/7/50', datetime(2050, 3, 7)),
+        param('3/7/94', datetime(2094, 3, 7)),
     ])
     def test_preferably_future_dates(self, date_string, expected):
         self.given_local_tz_offset(0)


### PR DESCRIPTION
Addresses #218

This accounts for situations where the year token in form `YY` is ambiguous and uses the `PREFER_DATES_FROM` setting to select the correct century.

Ex., `3/7/50` should parse as `datetime(1950, 3, 7)` and not `datetime(2050, 3, 7)` when `past` is chosen, and `datetime(2050, 3, 7)` when `future` is chosen.

We ran into this issue when parsing birthdays - older folks would have birthdays from the future!