### PR TITLE
Enhancement calendar interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,9 +223,9 @@ Supported Calendars
 
 * Hijri/Islamic Calendar. For more information, refer to `Hijri Calendar <https://en.wikipedia.org/wiki/Islamic_calendar>`_.
 
-	>>> from dateparser.calendars.jalali import JalaliParser
-	>>> JalaliParser(u'جمعه سی ام اسفند ۱۳۸۷').get_date()
-	datetime.datetime(2009, 3, 20, 0, 0)
+	>>> from dateparser.calendars.jalali import JalaliCalendar
+	>>> JalaliCalendar(u'جمعه سی ام اسفند ۱۳۸۷').get_date()
+	{'date_obj': datetime.datetime(2009, 3, 20, 0, 0), 'period': 'day'}
 
         >>> from dateparser.calendars.hijri import HijriCalendar
         >>> HijriCalendar(u'17-01-1437 هـ 08:30 مساءً').get_date()

--- a/dateparser/calendars/__init__.py
+++ b/dateparser/calendars/__init__.py
@@ -5,6 +5,7 @@ from dateparser.parser import _parser
 from dateparser.conf import settings
 from datetime import datetime
 
+
 class CalendarBase(object):
     """Base setup class for non-Gregorian calendar system.
 
@@ -27,21 +28,6 @@ class CalendarBase(object):
             return {'date_obj': date_obj, 'period': period}
         except ValueError:
             pass
-
-class CalendarConverter(object):
-
-    @classmethod
-    def to_gregorian(cls, year=None, month=None, day=None):
-        raise NotImplemented
-
-
-    @classmethod
-    def from_gregorian(cls, year=None, month=None, day=None):
-        raise NotImplemented
-
-    @classmethod
-    def month_length(cls, year, month):
-        raise NotImplemented
 
 
 class non_gregorian_parser(_parser):

--- a/dateparser/calendars/__init__.py
+++ b/dateparser/calendars/__init__.py
@@ -85,7 +85,7 @@ class non_gregorian_parser(_parser):
     def _get_datetime_obj(self, **params):
         day = params['day']
         if not(0 < day <= self.calendar_converter.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
-            day = persian.month_length(params['year'], params['month'])
+            day = self.calendar_converter.month_length(params['year'], params['month'])
         year, month, day = self.calendar_converter.to_gregorian(year=params['year'], month=params['month'], day=day)
         c_params = params.copy()
         c_params.update(dict(year=year,month=month, day=day))

--- a/dateparser/calendars/__init__.py
+++ b/dateparser/calendars/__init__.py
@@ -1,3 +1,10 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+from dateparser.parser import _parser
+from dateparser.conf import settings
+from datetime import datetime
+
 class CalendarBase(object):
     """Base setup class for non-Gregorian calendar system.
 
@@ -6,8 +13,127 @@ class CalendarBase(object):
     :type source: str|unicode
     """
 
+    parser = NotImplemented
+
     def __init__(self, source):
         self.source = source
 
     def get_date(self):
         raise NotImplemented
+
+    def get_date(self):
+        try:
+            date_obj, period = self.parser.parse(self.source, settings)
+            return {'date_obj': date_obj, 'period': period}
+        except ValueError:
+            pass
+
+class CalendarConverter(object):
+
+    @classmethod
+    def to_gregorian(cls, year=None, month=None, day=None):
+        raise NotImplemented
+
+
+    @classmethod
+    def from_gregorian(cls, year=None, month=None, day=None):
+        raise NotImplemented
+
+    @classmethod
+    def month_length(cls, year, month):
+        raise NotImplemented
+
+
+class non_gregorian_parser(_parser):
+
+    calendar_converter = NotImplemented
+    default_year = NotImplemented
+    default_month = NotImplemented
+    default_day = NotImplemented
+    non_gregorian_date_cls = NotImplemented
+
+    _digits = None
+    _months = None
+    _weekdays = None
+    _number_letters = None
+
+
+    @classmethod
+    def replace_time_conventions(cls, source):
+        return source
+
+    @classmethod
+    def replace_digits(cls, source):
+        return source
+
+    @classmethod
+    def replace_months(cls, source):
+        return source
+
+    @classmethod
+    def replace_weekdays(cls, source):
+        return source
+
+    @classmethod
+    def replace_time(cls, source):
+        return source
+
+    @classmethod
+    def replace_days(cls, source):
+        return source
+
+    @classmethod
+    def to_latin(cls, source):
+        result = source
+        result = cls.replace_months(result)
+        result = cls.replace_weekdays(result)
+        result = cls.replace_digits(result)
+        result = cls.replace_days(result)
+        result = cls.replace_time(result)
+        result = cls.replace_time_conventions(result)
+
+        result = result.strip()
+
+        return result
+
+    def _get_datetime_obj(self, **params):
+        day = params['day']
+        if not(0 < day <= self.calendar_converter.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
+            day = persian.month_length(params['year'], params['month'])
+        year, month, day = self.calendar_converter.to_gregorian(year=params['year'], month=params['month'], day=day)
+        c_params = params.copy()
+        c_params.update(dict(year=year,month=month, day=day))
+        return datetime(**c_params)
+
+    def _get_datetime_obj_params(self):
+        if not self.now:
+            self._set_relative_base()
+        now_year, now_month, now_day = self.calendar_converter.from_gregorian(self.now.year, self.now.month, self.now.day)
+        params = {
+            'day': self.day or now_day,
+            'month': self.month or now_month,
+            'year': self.year or now_year,
+            'hour': 0, 'minute': 0, 'second': 0, 'microsecond': 0,
+        }
+        return params
+
+    def _get_date_obj(self, token, directive):
+        year, month, day = self.default_year, self.default_month, self.default_day
+        if directive == '%A' and self._weekdays and token.title() in self._weekdays:
+            pass
+        elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+            month = int(token)
+        elif directive == '%B' and self._months and token in self._months:
+            month = list(self._months.keys()).index(token) + 1
+        elif directive == '%d' and len(token) <= 2 and token.isdigit() and 0 < int(token) <= self.calendar_converter.month_length(year, month):
+            day = int(token)
+        elif directive == '%Y' and len(token) == 4 and token.isdigit():
+            year = int(token)
+        else:
+            raise ValueError
+        return self.non_gregorian_date_cls(year, month, day)
+
+    @classmethod
+    def parse(cls, datestring, settings):
+        datestring = cls.to_latin(datestring)
+        return super(non_gregorian_parser, cls).parse(datestring, settings)

--- a/dateparser/calendars/__init__.py
+++ b/dateparser/calendars/__init__.py
@@ -20,9 +20,6 @@ class CalendarBase(object):
         self.source = source
 
     def get_date(self):
-        raise NotImplemented
-
-    def get_date(self):
         try:
             date_obj, period = self.parser.parse(self.source, settings)
             return {'date_obj': date_obj, 'period': period}
@@ -42,7 +39,6 @@ class non_gregorian_parser(_parser):
     _months = None
     _weekdays = None
     _number_letters = None
-
 
     @classmethod
     def replace_time_conventions(cls, source):
@@ -84,17 +80,23 @@ class non_gregorian_parser(_parser):
 
     def _get_datetime_obj(self, **params):
         day = params['day']
-        if not(0 < day <= self.calendar_converter.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
-            day = self.calendar_converter.month_length(params['year'], params['month'])
-        year, month, day = self.calendar_converter.to_gregorian(year=params['year'], month=params['month'], day=day)
+        year = params['year']
+        month = params['month']
+        if (
+            not(0 < day <= self.calendar_converter.month_length(year, month)) and
+            not(self._token_day or hasattr(self, '_token_weekday'))
+        ):
+            day = self.calendar_converter.month_length(year, month)
+        year, month, day = self.calendar_converter.to_gregorian(year=year, month=month, day=day)
         c_params = params.copy()
-        c_params.update(dict(year=year,month=month, day=day))
+        c_params.update(dict(year=year, month=month, day=day))
         return datetime(**c_params)
 
     def _get_datetime_obj_params(self):
         if not self.now:
             self._set_relative_base()
-        now_year, now_month, now_day = self.calendar_converter.from_gregorian(self.now.year, self.now.month, self.now.day)
+        now_year, now_month, now_day = self.calendar_converter.from_gregorian(
+                self.now.year, self.now.month, self.now.day)
         params = {
             'day': self.day or now_day,
             'month': self.month or now_month,
@@ -105,15 +107,27 @@ class non_gregorian_parser(_parser):
 
     def _get_date_obj(self, token, directive):
         year, month, day = self.default_year, self.default_month, self.default_day
+        token_len = len(token)
+        is_digit = token.isdigit()
         if directive == '%A' and self._weekdays and token.title() in self._weekdays:
             pass
-        elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+        elif (
+            directive == '%m' and
+            token_len <= 2 and
+            is_digit and
+            int(token) >= 1 and int(token) <= 12
+        ):
             month = int(token)
         elif directive == '%B' and self._months and token in self._months:
             month = list(self._months.keys()).index(token) + 1
-        elif directive == '%d' and len(token) <= 2 and token.isdigit() and 0 < int(token) <= self.calendar_converter.month_length(year, month):
+        elif (
+            directive == '%d' and
+            token_len <= 2 and
+            is_digit and
+            0 < int(token) <= self.calendar_converter.month_length(year, month)
+        ):
             day = int(token)
-        elif directive == '%Y' and len(token) == 4 and token.isdigit():
+        elif directive == '%Y' and token_len == 4 and is_digit:
             year = int(token)
         else:
             raise ValueError

--- a/dateparser/calendars/__init__.py
+++ b/dateparser/calendars/__init__.py
@@ -41,38 +41,38 @@ class non_gregorian_parser(_parser):
     _number_letters = None
 
     @classmethod
-    def replace_time_conventions(cls, source):
+    def _replace_time_conventions(cls, source):
         return source
 
     @classmethod
-    def replace_digits(cls, source):
+    def _replace_digits(cls, source):
         return source
 
     @classmethod
-    def replace_months(cls, source):
+    def _replace_months(cls, source):
         return source
 
     @classmethod
-    def replace_weekdays(cls, source):
+    def _replace_weekdays(cls, source):
         return source
 
     @classmethod
-    def replace_time(cls, source):
+    def _replace_time(cls, source):
         return source
 
     @classmethod
-    def replace_days(cls, source):
+    def _replace_days(cls, source):
         return source
 
     @classmethod
     def to_latin(cls, source):
         result = source
-        result = cls.replace_months(result)
-        result = cls.replace_weekdays(result)
-        result = cls.replace_digits(result)
-        result = cls.replace_days(result)
-        result = cls.replace_time(result)
-        result = cls.replace_time_conventions(result)
+        result = cls._replace_months(result)
+        result = cls._replace_weekdays(result)
+        result = cls._replace_digits(result)
+        result = cls._replace_days(result)
+        result = cls._replace_time(result)
+        result = cls._replace_time_conventions(result)
 
         result = result.strip()
 

--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -27,5 +27,5 @@ class HijriCalendar(CalendarBase):
         try:
             date_obj, period =  hijri_parser.parse(translated, settings)
             return {'date_obj': date_obj, 'period': period}
-        except ValueError, ex:
+        except ValueError:
             pass

--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -25,7 +25,7 @@ class HijriCalendar(CalendarBase):
         from dateparser.calendars.hijri_parser import hijri_parser
         translated = self.replace_time_conventions(self.source)
         try:
-            return hijri_parser.parse(translated, settings)
+            date_obj, period =  hijri_parser.parse(translated, settings)
+            return {'date_obj': date_obj, 'period': period}
         except ValueError, ex:
-            raise ex
             pass

--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -1,31 +1,21 @@
 # coding: utf-8
+
+import regex as re
+
 from datetime import datetime
 
 from umalqurra.hijri_date import HijriDate
-import regex as re
 
 from dateparser.calendars import CalendarBase
 from dateparser.conf import settings
+from dateparser.calendars.hijri_parser import hijri_parser
 
 
 class HijriCalendar(CalendarBase):
-    _time_conventions = {
-        'am': [u"صباحاً"],
-        'pm': [u"مساءً"],
-    }
-
-    def replace_time_conventions(self, source):
-        result = source
-        for latin, arabics in self._time_conventions.items():
-            for arabic in arabics:
-                result = result.replace(arabic, latin)
-        return result
 
     def get_date(self):
-        from dateparser.calendars.hijri_parser import hijri_parser
-        translated = self.replace_time_conventions(self.source)
         try:
-            date_obj, period =  hijri_parser.parse(translated, settings)
+            date_obj, period =  hijri_parser.parse(self.source, settings)
             return {'date_obj': date_obj, 'period': period}
         except ValueError:
             pass

--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -1,21 +1,8 @@
 # coding: utf-8
 
-import regex as re
-
-from datetime import datetime
-
-from umalqurra.hijri_date import HijriDate
-
 from dateparser.calendars import CalendarBase
-from dateparser.conf import settings
 from dateparser.calendars.hijri_parser import hijri_parser
 
 
 class HijriCalendar(CalendarBase):
-
-    def get_date(self):
-        try:
-            date_obj, period =  hijri_parser.parse(self.source, settings)
-            return {'date_obj': date_obj, 'period': period}
-        except ValueError:
-            pass
+    parser = hijri_parser

--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -4,93 +4,15 @@ from umalqurra.hijri_date import HijriDate
 import regex as re
 
 from dateparser.calendars import CalendarBase
-from dateparser.date import DateDataParser
-from dateparser.languages.loader import default_language_loader
-from dateparser.utils import find_date_separator
 from dateparser.conf import settings
-
-
-class HijriGregorianFebruaryMismatch(Exception):
-    pass
 
 
 class HijriCalendar(CalendarBase):
 
-    def get_date(self, date_formats=None, languages=None):
-        date_formats = date_formats or ['%d-%m-%Y %I:%M %p', '%d-%m-%Y %I:%M',
-                                        '%d-%m-%Y']
-        languages = languages or ['ar']
-        date_data = self._parser_get_date(self.source, date_formats, languages)
-        date_obj = date_data.get('date_obj')
-        if date_obj:
-            # Convert Hijri to Gregorian
-            date_data['date_obj'] = self._hijri_to_gregorian(
-                date_obj.year, date_obj.month, date_obj.day, date_obj)
-        else:
-            try:
-                self._detect_parse_error(date_formats, languages)
-            except HijriGregorianFebruaryMismatch:
-                date_data = self._fix_hijri_gregorian_feb_mismatch(
-                    date_formats, languages)
-        return date_data
-
-    def _parser_get_date(self, date_string, date_formats, languages):
-        parser = DateDataParser(languages)
-        return parser.get_date_data(date_string, date_formats)
-
-    def _detect_parse_error(self, date_formats, languages):
-        """
-        Check following cases:
-
-        * 2nd month in Hijri calendar can be 29 or 30 days whilst this is
-        not possible for Gregorian calendar.
-        """
-        for lang_shortname in languages:
-            language = default_language_loader.get_language(lang_shortname)
-            translated = language.translate(self.source, settings=settings)
-            for date_format in date_formats:
-                try:
-                    datetime.strptime(date_format, translated)
-                except ValueError:
-                    sep = find_date_separator(date_format)
-                    m = re.search(
-                        r'(?<!\d)(?:(?:(0?2){sep}(29|30))|(?:(29|30){sep}(0?2)))'.format(sep=sep),
-                        translated)
-                    if m:
-                        raise HijriGregorianFebruaryMismatch()
-
-    def _fix_hijri_gregorian_feb_mismatch(self, date_formats, languages):
-        # Now, search for 29th or 30th day of 2nd month.
-        # If found, reduce it by 10 days and use regular parse
-        # function again, if succeeds this time, then add 10
-        # days to parsed Hijri form.
-        for lang_shortname in languages:
-            language = default_language_loader.get_language(lang_shortname)
-            translated = language.translate(self.source, settings=settings)
-
-            def _sub_fn(m):
-                digit = int(m.group(0))
-                return '{:02d}'.format(digit - 10)
-            fixed_date_string, nreplaced = re.subn(
-                r'(?<!\d)(29|30)', _sub_fn, translated, 1)
-            if not nreplaced:
-                continue
-
-            date_data = self._parser_get_date(fixed_date_string, date_formats, languages)
-            date_obj = date_data.get('date_obj')
-            if date_obj:
-                # Remember that, we have subtracted 10 days.
-                date_data['date_obj'] = self._hijri_to_gregorian(
-                    date_obj.year, date_obj.month, date_obj.day + 10, date_obj)
-                return date_data
-
-    @staticmethod
-    def _hijri_to_gregorian(year, month, day, date_obj=None):
-        hd = HijriDate(year=year, month=month, day=day)
-        year_gr = int(hd.year_gr)
-        month_gr = int(hd.month_gr)
-        day_gr = int(hd.day_gr)
-        if date_obj:
-            return date_obj.replace(year=year_gr, month=month_gr, day=day_gr)
-        else:
-            return datetime(year=year_gr, month=month_gr, day=day_gr)
+    def get_date(self):
+        from dateparser.calendars.hijri_parser import hijri_parser
+        try:
+            return hijri_parser.parse(self.source, settings)
+        except ValueError, ex:
+            raise ex
+            pass

--- a/dateparser/calendars/hijri.py
+++ b/dateparser/calendars/hijri.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from datetime import datetime
 
 from umalqurra.hijri_date import HijriDate
@@ -8,11 +9,23 @@ from dateparser.conf import settings
 
 
 class HijriCalendar(CalendarBase):
+    _time_conventions = {
+        'am': [u"صباحاً"],
+        'pm': [u"مساءً"],
+    }
+
+    def replace_time_conventions(self, source):
+        result = source
+        for latin, arabics in self._time_conventions.items():
+            for arabic in arabics:
+                result = result.replace(arabic, latin)
+        return result
 
     def get_date(self):
         from dateparser.calendars.hijri_parser import hijri_parser
+        translated = self.replace_time_conventions(self.source)
         try:
-            return hijri_parser.parse(self.source, settings)
+            return hijri_parser.parse(translated, settings)
         except ValueError, ex:
             raise ex
             pass

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -1,22 +1,21 @@
 # coding: utf-8
-from dateparser.parser import _parser
-from convertdate import islamic
-from datetime import datetime
-from umalqurra.hijri_date import HijriDate
+
+from umalqurra.hijri_date import HijriDate as hj
 from umalqurra.ummalqura_arrray import UmalqurraArray
+from dateparser.calendars import non_gregorian_parser
 
 
 class hijri(object):
 
     @classmethod
     def to_gregorian(cls, year=None, month=None, day=None):
-        h = HijriDate(year=year, month=month, day=day)
+        h = hj(year=year, month=month, day=day)
         return int(h.year_gr), int(h.month_gr), int(h.day_gr)
 
 
     @classmethod
     def from_gregorian(cls, year=None, month=None, day=None):
-        h = HijriDate(year=year, month=month, day=day, gr=True)
+        h = hj(year=year, month=month, day=day, gr=True)
         return int(h.year), int(h.month), int(h.day)
 
     @classmethod
@@ -33,7 +32,7 @@ class hijri(object):
         return ml
 
 
-class hijri_date(object):
+class HijriDate(object):
     def __init__(self, year, month, day):
         self.year=year
         self.month=month
@@ -46,12 +45,20 @@ class hijri_date(object):
                     return idx
 
 
-class hijri_parser(_parser): 
+class hijri_parser(non_gregorian_parser): 
+
+    calendar_converter = hijri
+    default_year = 1389
+    default_month = 1
+    default_day = 1
+    non_gregorian_date_cls = HijriDate
 
     _time_conventions = {
         'am': [u"صباحاً"],
         'pm': [u"مساءً"],
     }
+
+    # TODO: Implement arabic to latin translation replace_ methods according to the way native speakers write
 
     @classmethod
     def replace_time_conventions(cls, source):
@@ -60,84 +67,3 @@ class hijri_parser(_parser):
             for arabic in arabics:
                 result = result.replace(arabic, latin)
         return result
-
-    @classmethod
-    def replace_digits(cls, source):
-        # TODO
-        return source
-
-    @classmethod
-    def replace_months(cls, source):
-        # TODO
-        return source
-
-    @classmethod
-    def replace_weekdays(cls, source):
-        # TODO
-        return source
-
-    @classmethod
-    def replace_time(cls, source):
-        # TODO
-        return source
-
-    @classmethod
-    def replace_days(cls, source):
-        # TODO
-        return source
-
-    @classmethod
-    def to_latin(cls, source):
-        result = source
-        result = cls.replace_months(result)
-        result = cls.replace_weekdays(result)
-        result = cls.replace_digits(result)
-        result = cls.replace_days(result)
-        result = cls.replace_time(result)
-        result = cls.replace_time_conventions(result)
-
-        result = result.strip()
-
-        return result
-
-    def _get_datetime_obj(self, **params):
-        day = params['day']
-        if not(0 < day <= hijri.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
-            day = hijri.month_length(params['year'], params['month'])
-        year, month, day = hijri.to_gregorian(year=params['year'], month=params['month'], day=day)
-        c_params = params.copy()
-        c_params.update(dict(year=year,month=month, day=day))
-        return datetime(**c_params)
-
-    def _get_datetime_obj_params(self):
-        if not self.now:
-            self._set_relative_base()
-        hijri_now_year, hijri_now_month, hijri_now_day = hijri.from_gregorian(self.now.year, self.now.month, self.now.day)
-        params = {
-            'day': self.day or hijri_now_day,
-            'month': self.month or hijri_now_month,
-            'year': self.year or hijri_now_year,
-            'hour': 0, 'minute': 0, 'second': 0, 'microsecond': 0,
-        }
-        return params
-
-    def _get_date_obj(self, token, directive):
-        year, month, day = 1389, 1, 1
-        if directive == '%A' and token.title() in self._weekdays:
-            pass
-        elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
-            month = int(token)
-        #elif directive == '%B' and token in self._months:
-        #    month = self._months.index(token) + 1
-        elif directive == '%d' and len(token) <= 2 and token.isdigit() and 0 < int(token) <= hijri.month_length(year, month):
-            day = int(token)
-        elif directive == '%Y' and len(token) == 4 and token.isdigit():
-            year = int(token)
-        else:
-            raise ValueError
-        return hijri_date(year,month,day)
-
-    @classmethod
-    def parse(cls, datestring, settings):
-        datestring = cls.to_latin(datestring)
-        return super(hijri_parser, cls).parse(datestring, settings)

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -8,8 +8,6 @@ from umalqurra.ummalqura_arrray import UmalqurraArray
 
 class hijri(object):
 
-    WEEKDAYS = islamic.WEEKDAYS
-
     @classmethod
     def to_gregorian(cls, year=None, month=None, day=None):
         h = HijriDate(year=year, month=month, day=day)
@@ -50,6 +48,58 @@ class hijri_date(object):
 
 class hijri_parser(_parser): 
 
+    _time_conventions = {
+        'am': [u"صباحاً"],
+        'pm': [u"مساءً"],
+    }
+
+    @classmethod
+    def replace_time_conventions(cls, source):
+        result = source
+        for latin, arabics in cls._time_conventions.items():
+            for arabic in arabics:
+                result = result.replace(arabic, latin)
+        return result
+
+    @classmethod
+    def replace_digits(cls, source):
+        # TODO
+        return source
+
+    @classmethod
+    def replace_months(cls, source):
+        # TODO
+        return source
+
+    @classmethod
+    def replace_weekdays(cls, source):
+        # TODO
+        return source
+
+    @classmethod
+    def replace_time(cls, source):
+        # TODO
+        return source
+
+    @classmethod
+    def replace_days(cls, source):
+        # TODO
+        return source
+
+    @classmethod
+    def to_latin(cls, source):
+        result = source
+        result = cls.replace_months(result)
+        result = cls.replace_weekdays(result)
+        result = cls.replace_digits(result)
+        result = cls.replace_days(result)
+        result = cls.replace_time(result)
+        result = cls.replace_time_conventions(result)
+
+        result = result.strip()
+
+        return result
+
     def _get_datetime_obj(self, **params):
         day = params['day']
         if not(0 < day <= hijri.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
@@ -72,9 +122,8 @@ class hijri_parser(_parser):
         return params
 
     def _get_date_obj(self, token, directive):
-        days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
         year, month, day = 1389, 1, 1
-        if directive == '%A' and (token.title() in hijri.WEEKDAYS or token.title() in days):
+        if directive == '%A' and token.title() in self._weekdays:
             pass
         elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
             month = int(token)
@@ -87,3 +136,8 @@ class hijri_parser(_parser):
         else:
             raise ValueError
         return hijri_date(year,month,day)
+
+    @classmethod
+    def parse(cls, datestring, settings):
+        datestring = cls.to_latin(datestring)
+        return super(hijri_parser, cls).parse(datestring, settings)

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -61,7 +61,7 @@ class hijri_parser(non_gregorian_parser):
     # replace_ methods according to the way native speakers write
 
     @classmethod
-    def replace_time_conventions(cls, source):
+    def _replace_time_conventions(cls, source):
         result = source
         for latin, arabics in cls._time_conventions.items():
             for arabic in arabics:

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -4,6 +4,7 @@ from convertdate import islamic
 from datetime import datetime, timedelta
 from umalqurra.hijri_date import HijriDate
 from umalqurra.hijri import Umalqurra
+from umalqurra.ummalqura_arrray import UmalqurraArray
 
 
 class hijri(object):
@@ -23,9 +24,16 @@ class hijri(object):
 
     @classmethod
     def month_length(cls, year, month):
-        year, month , day = Umalqurra().hijri_to_gregorian(year, month, 1)
-        _, _, _, ml = Umalqurra().gegorean_to_hijri(year, month, day)
-        return int(ml)
+        iy = year
+        im = month
+        id = 1
+        ii = iy - 1
+        iln = (ii * 12) + 1 + (im - 1)
+        i = iln - 16260
+        mcjdn = id + UmalqurraArray.ummalqura_dat[i - 1] - 1
+        index = UmalqurraArray.get_index(mcjdn)
+        ml = UmalqurraArray.ummalqura_dat[index] - UmalqurraArray.ummalqura_dat[index - 1]
+        return ml
 
 
 class hijri_date(object):

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -1,9 +1,8 @@
 # coding: utf-8
 from dateparser.parser import _parser
 from convertdate import islamic
-from datetime import datetime, timedelta
+from datetime import datetime
 from umalqurra.hijri_date import HijriDate
-from umalqurra.hijri import Umalqurra
 from umalqurra.ummalqura_arrray import UmalqurraArray
 
 

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+from dateparser.parser import _parser
+from convertdate import islamic
+from datetime import datetime, timedelta
+from umalqurra.hijri_date import HijriDate
+from umalqurra.hijri import Umalqurra
+
+
+class hijri(object):
+
+    WEEKDAYS = islamic.WEEKDAYS
+
+    @classmethod
+    def to_gregorian(cls, year=None, month=None, day=None):
+        h = HijriDate(year=year, month=month, day=day)
+        return int(h.year_gr), int(h.month_gr), int(h.day_gr)
+
+
+    @classmethod
+    def from_gregorian(cls, year=None, month=None, day=None):
+        h = HijriDate(year=year, month=month, day=day, gr=True)
+        return int(h.year), int(h.month), int(h.day)
+
+    @classmethod
+    def month_length(cls, year, month):
+        year, month , day = Umalqurra().hijri_to_gregorian(year, month, 1)
+        _, _, _, ml = Umalqurra().gegorean_to_hijri(year, month, day)
+        return int(ml)
+
+
+class hijri_date(object):
+    def __init__(self, year, month, day):
+        self.year=year
+        self.month=month
+        self.day=day
+
+    def weekday(self):
+        for week in hijri.monthcalendar(self.year, self.month):
+            for idx, day in enumerate(week):
+                if day==self.day:
+                    return idx
+
+
+class hijri_parser(_parser): 
+
+    def _get_datetime_obj(self, **params):
+        day = params['day']
+        if not(0 < day <= hijri.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
+            day = hijri.month_length(params['year'], params['month'])
+        year, month, day = hijri.to_gregorian(year=params['year'], month=params['month'], day=day)
+        c_params = params.copy()
+        c_params.update(dict(year=year,month=month, day=day))
+        return datetime(**c_params)
+
+    def _get_datetime_obj_params(self):
+        if not self.now:
+            self._set_relative_base()
+        hijri_now_year, hijri_now_month, hijri_now_day = hijri.from_gregorian(self.now.year, self.now.month, self.now.day)
+        params = {
+            'day': self.day or hijri_now_day,
+            'month': self.month or hijri_now_month,
+            'year': self.year or hijri_now_year,
+            'hour': 0, 'minute': 0, 'second': 0, 'microsecond': 0,
+        }
+        return params
+
+    def _get_date_obj(self, token, directive):
+        days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+        year, month, day = 1389, 1, 1
+        if directive == '%A' and (token.title() in hijri.WEEKDAYS or token.title() in days):
+            pass
+        elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+            month = int(token)
+        #elif directive == '%B' and token in self._months:
+        #    month = self._months.index(token) + 1
+        elif directive == '%d' and len(token) <= 2 and token.isdigit() and 0 < int(token) <= hijri.month_length(year, month):
+            day = int(token)
+        elif directive == '%Y' and len(token) == 4 and token.isdigit():
+            year = int(token)
+        else:
+            raise ValueError
+        return hijri_date(year,month,day)
+
+    @classmethod
+    def parse(cls, datestring, settings):
+        dateobj, period = super(hijri_parser, cls).parse(datestring, settings)
+        o = super(hijri_parser, cls).parse(datestring, settings)
+
+        return dateobj, period 

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -92,6 +92,5 @@ class hijri_parser(_parser):
     @classmethod
     def parse(cls, datestring, settings):
         dateobj, period = super(hijri_parser, cls).parse(datestring, settings)
-        o = super(hijri_parser, cls).parse(datestring, settings)
 
         return dateobj, period 

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -88,9 +88,3 @@ class hijri_parser(_parser):
         else:
             raise ValueError
         return hijri_date(year,month,day)
-
-    @classmethod
-    def parse(cls, datestring, settings):
-        dateobj, period = super(hijri_parser, cls).parse(datestring, settings)
-
-        return dateobj, period 

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -12,7 +12,6 @@ class hijri(object):
         h = hj(year=year, month=month, day=day)
         return int(h.year_gr), int(h.month_gr), int(h.day_gr)
 
-
     @classmethod
     def from_gregorian(cls, year=None, month=None, day=None):
         h = hj(year=year, month=month, day=day, gr=True)
@@ -34,18 +33,18 @@ class hijri(object):
 
 class HijriDate(object):
     def __init__(self, year, month, day):
-        self.year=year
-        self.month=month
-        self.day=day
+        self.year = year
+        self.month = month
+        self.day = day
 
     def weekday(self):
         for week in hijri.monthcalendar(self.year, self.month):
             for idx, day in enumerate(week):
-                if day==self.day:
+                if day == self.day:
                     return idx
 
 
-class hijri_parser(non_gregorian_parser): 
+class hijri_parser(non_gregorian_parser):
 
     calendar_converter = hijri
     default_year = 1389
@@ -58,7 +57,8 @@ class hijri_parser(non_gregorian_parser):
         'pm': [u"مساءً"],
     }
 
-    # TODO: Implement arabic to latin translation replace_ methods according to the way native speakers write
+    # TODO: Implement arabic to latin translation
+    # replace_ methods according to the way native speakers write
 
     @classmethod
     def replace_time_conventions(cls, source):

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -2,11 +2,10 @@
 from __future__ import unicode_literals
 
 import regex as re
-from collections import OrderedDict
-from functools import reduce
 
 from . import CalendarBase
 from dateparser.conf import settings
+from dateparser.calendars.jalali_parser import jalali_parser
 
 
 def validate_time(string):
@@ -42,145 +41,14 @@ def validate_time(string):
     return template % result_dict
 
 
-class JalaliParser(CalendarBase):
-    """Calendar parser class for Jalali calendar."""
+class JalaliCalendar(CalendarBase):
+    """Calendar class for Jalali calendar."""
 
-    _digits = {"۰": 0, "۱": 1, "۲": 2, "۳": 3, "۴": 4,
-               "۵": 5, "۶": 6, "۷": 7, "۸": 8, "۹": 9}
-
-    _months = OrderedDict([
-        # pinglish : (persian literals, month index, number of days)
-        ("Farvardin", (1, 31, ["فروردین"])),
-        ("Ordibehesht", (2, 31, ["اردیبهشت"])),
-        ("Khordad", (3, 31, ["خرداد"])),
-        ("Tir", (4, 31, ["تیر"])),
-        ("Mordad", (5, 31, ["امرداد", "مرداد"])),
-        ("Shahrivar", (6, 31, ["شهریور", "شهريور"])),
-        ("Mehr", (7, 30, ["مهر"])),
-        ("Aban", (8, 30, ["آبان"])),
-        ("Azar", (9, 30, ["آذر"])),
-        ("Dey", (10, 30, ["دی"])),
-        ("Bahman", (11, 30, ["بهمن", "بهن"])),
-        ("Esfand", (12, 29, ["اسفند"])),
-    ])
-
-    _weekdays = [
-        ("Sunday", ["یکشنبه"]),
-        ("Monday", ["دوشنبه"]),
-        ("Tuesday", ["سهشنبه", "سه شنبه"]),
-        ("Wednesday", ["چهارشنبه", "چهار شنبه"]),
-        ("Thursday", ["پنجشنبه", "پنج شنبه"]),
-        ("Friday", ["جمعه"]),
-        ("Saturday", ["روز شنبه", "شنبه"]),
-    ]
-
-    _number_letters = {
-        0: ["صفر"],
-        1: ["یک", "اول"],
-        2: ["دو"],
-        3: ["سه", "سو"],
-        4: ["چهار"],
-        5: ["پنج"],
-        6: ["شش"],
-        7: ["هفت"],
-        8: ["هشت"],
-        9: ["نه"],
-        10: ["ده"],
-        11: ["یازده"],
-        12: ["دوازده"],
-        13: ["سیزده"],
-        14: ["چهارده"],
-        15: ["پانزده"],
-        16: ["شانزده"],
-        17: ["هفده"],
-        18: ["هجده"],
-        19: ["نوزده"],
-        20: ["بیست"],
-        21: ["بیست و یک"],
-        22: ["بیست و دو", "بیست ثانیه"],
-        23: ["بیست و سه", "بیست و سو"],
-        24: ["بیست و چهار"],
-        25: ["بیست و پنج"],
-        26: ["بیست و شش"],
-        27: ["بیست و هفت"],
-        28: ["بیست و هشت"],
-        29: ["بیست و نه"],
-        30: ["سی"],
-        31: ["سی و یک"],
-    }
-
-    def replace_digits(self, source):
-        result = source
-        for pers_digit, number in self._digits.items():
-            result = result.replace(pers_digit, str(number))
-        return result
-
-    def replace_months(self, source):
-        result = source
-        for persian, latin in reduce(
-                lambda a, b: a + b,
-                [[(value, month) for value in repl[-1]] for month, repl in self._months.items()]):
-            result = result.replace(persian, latin)
-        return result
-
-    def replace_weekdays(self, source):
-        result = source
-        for persian, latin in reduce(
-                lambda a, b: a + b,
-                [[(value, weekday) for value in repl] for weekday, repl in self._weekdays]):
-            result = result.replace(persian, latin)
-        return result
-
-    def replace_time(self, source):
-        def only_numbers(match_obj):
-            matched_string = match_obj.group()
-            return re.sub(r'\D', ' ', matched_string)
-        hour_pattern = r'ساعت\s+\d{2}'
-        minute_pattern = r'\d{2}\s+دقیقه'
-        second_pattern = r'\d{2}\s+ثانیه'
-        result = re.sub(hour_pattern, only_numbers, source)
-        result = re.sub(minute_pattern, only_numbers, result)
-        result = re.sub(second_pattern, only_numbers, result)
-        result = re.sub(r'\s+و\s+', ':', result)
-        result = result.replace('ساعت', '')
-        return result
-
-    def replace_days(self, source):
-        result = re.sub(r'ام|م|ین', '', source)  # removes persian variant of th/first/second/third
-        day_pairs = list(self._number_letters.items())
-
-        def comp_key(tup):
-            return tup[0]
-
-        day_pairs.sort(key=comp_key, reverse=True)
-
-        thirteen, thirty = day_pairs[-14], day_pairs[1]
-        day_pairs[-14] = thirty
-        day_pairs[1] = thirteen
-
-        for persian, number in reduce(
-                lambda a, b: a + b,
-                [[(val, repl) for val in persian] for repl, persian in day_pairs]):
-            result = result.replace(persian, str(number))
-        return result
-
-    def persian_to_latin(self, source):
-        result = source
-        result = self.replace_months(result)
-        result = self.replace_weekdays(result)
-        result = self.replace_digits(result)
-        result = self.replace_days(result)
-        result = self.replace_time(result)
-
-        result = result.strip()
-
-        return result
-
+    
     def get_date(self):
-        translated = self.persian_to_latin(self.source)
-        from dateparser.calendars.jalali_parser import jalali_parser
         try:
-            date_obj, period = jalali_parser.parse(translated, settings)
+            date_obj, period = jalali_parser.parse(self.source, settings)
             return {'date_obj': date_obj, 'period': period}
-        except ValueError:
+        except ValueError as ex:
+            raise ex
             pass

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -179,6 +179,7 @@ class JalaliParser(CalendarBase):
         translated = self.persian_to_latin(self.source)
         from dateparser.calendars.jalali_parser import jalali_parser
         try:
-            return jalali_parser.parse(translated, settings)
+            date_obj, period = jalali_parser.parse(translated, settings)
+            return {'date_obj': date_obj, 'period': period}
         except ValueError, ex:
             pass

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -10,6 +10,7 @@ from jdatetime import JalaliToGregorian
 from dateutil.parser import parse
 
 from . import CalendarBase
+from dateparser.conf import settings
 
 
 def validate_time(string):
@@ -204,16 +205,13 @@ class JalaliParser(CalendarBase):
         return time(0, 0)
 
     def get_date(self):
-        """Output method for Jalali calendar parser."""
-        jdate = self.search_persian_date(self.source)
-        gtime = self.search_time()
+        self.persian_to_latin(self.source)
+        self.search_time()
+        from dateparser.calendars.jalali_parser import jalali_parser
+        #print self.translated
+        settings.FUZZY = True
         try:
-            gdate = JalaliToGregorian(
-                int(jdate['year']),
-                self._months[jdate['month']][0],
-                int(jdate['day'])
-            ).getGregorianList()
-            return datetime(gdate[0], gdate[1], gdate[2],
-                            gtime.hour, gtime.minute, gtime.second)
-        except TypeError:
+            return jalali_parser.parse(self.translated, settings)
+        except ValueError, ex:
             pass
+

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import regex as re
 
 from . import CalendarBase
-from dateparser.conf import settings
 from dateparser.calendars.jalali_parser import jalali_parser
 
 
@@ -44,11 +43,4 @@ def validate_time(string):
 class JalaliCalendar(CalendarBase):
     """Calendar class for Jalali calendar."""
 
-    
-    def get_date(self):
-        try:
-            date_obj, period = jalali_parser.parse(self.source, settings)
-            return {'date_obj': date_obj, 'period': period}
-        except ValueError as ex:
-            raise ex
-            pass
+    parser = jalali_parser

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -3,11 +3,7 @@ from __future__ import unicode_literals
 
 import regex as re
 from collections import OrderedDict
-from datetime import datetime, time
 from functools import reduce
-
-from jdatetime import JalaliToGregorian
-from dateutil.parser import parse
 
 from . import CalendarBase
 from dateparser.conf import settings

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -135,13 +135,13 @@ class JalaliParser(CalendarBase):
         def only_numbers(match_obj):
             matched_string = match_obj.group()
             return re.sub(r'\D', ' ', matched_string)
-        hour_pattern = ur'ساعت\s+\d{2}'
-        minute_pattern = ur'\d{2}\s+دقیقه'
-        second_pattern = ur'\d{2}\s+ثانیه'
+        hour_pattern = r'ساعت\s+\d{2}'
+        minute_pattern = r'\d{2}\s+دقیقه'
+        second_pattern = r'\d{2}\s+ثانیه'
         result = re.sub(hour_pattern, only_numbers, source)
         result = re.sub(minute_pattern, only_numbers, result)
         result = re.sub(second_pattern, only_numbers, result)
-        result = re.sub(ur'\s+و\s+', ':', result)
+        result = re.sub(r'\s+و\s+', ':', result)
         return result
 
     def replace_days(self, source):
@@ -181,5 +181,5 @@ class JalaliParser(CalendarBase):
         try:
             date_obj, period = jalali_parser.parse(translated, settings)
             return {'date_obj': date_obj, 'period': period}
-        except ValueError, ex:
+        except ValueError:
             pass

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -142,6 +142,7 @@ class JalaliParser(CalendarBase):
         result = re.sub(minute_pattern, only_numbers, result)
         result = re.sub(second_pattern, only_numbers, result)
         result = re.sub(r'\s+و\s+', ':', result)
+        result = result.replace('ساعت', '')
         return result
 
     def replace_days(self, source):

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -45,10 +45,6 @@ def validate_time(string):
 class JalaliParser(CalendarBase):
     """Calendar parser class for Jalali calendar."""
 
-    def __init__(self, source):
-        super(JalaliParser, self).__init__(source)
-        self.translated = None
-
     _digits = {"۰": 0, "۱": 1, "۲": 2, "۳": 3, "۴": 4,
                "۵": 5, "۶": 6, "۷": 7, "۸": 8, "۹": 9}
 
@@ -173,17 +169,16 @@ class JalaliParser(CalendarBase):
         result = self.replace_weekdays(result)
         result = self.replace_digits(result)
         result = self.replace_days(result)
+        result = self.replace_time(result)
 
         result = result.strip()
 
-        self.translated = result
         return result
 
     def get_date(self):
-        self.persian_to_latin(self.source)
-        self.translated = self.replace_time(self.translated)
+        translated = self.persian_to_latin(self.source)
         from dateparser.calendars.jalali_parser import jalali_parser
         try:
-            return jalali_parser.parse(self.translated, settings)
+            return jalali_parser.parse(translated, settings)
         except ValueError, ex:
             pass

--- a/dateparser/calendars/jalali.py
+++ b/dateparser/calendars/jalali.py
@@ -1,43 +1,9 @@
 # coding: utf-8
-from __future__ import unicode_literals
 
-import regex as re
+from __future__ import unicode_literals
 
 from . import CalendarBase
 from dateparser.calendars.jalali_parser import jalali_parser
-
-
-def validate_time(string):
-    if string.find(':') != -1:
-        return string
-
-    persian_time_map = [
-        (u'\u0633\u0627\u0639\u062a', 'hour'),
-        (u'\u062f\u0642\u06cc\u0642\u0647', 'minute'),
-        (u'\u062b\u0627\u0646\u06cc\u0647', 'second')
-    ]
-
-    result_dict = {}
-    template = '%(hour)s:%(minute)s:%(second)s'
-    string = string.replace(u'و', '').strip()
-
-    for persian, latin in persian_time_map:
-        cursor = string.find(persian)
-        if cursor == -1:
-            result_dict[latin] = '00'
-            continue
-        elif cursor > 0:
-            cursor_back = cursor - 3
-            if cursor_back == -1:
-                cursor_back = 0
-            result = string[cursor_back: cursor]
-        else:
-            cursor += len(persian)
-            result = string[cursor: cursor+3]
-
-        result_dict[latin] = result.strip()
-
-    return template % result_dict
 
 
 class JalaliCalendar(CalendarBase):

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -50,10 +50,11 @@ class jalali_parser(_parser):
         return params
 
     def _get_date_obj(self, token, directive):
-        persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']))
+        days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+        persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  days))
         year, month, day = 1348, 1, 1
-        if directive in ('%A', '%a') and token.title() in persian.WEEKDAYS:
-            pass
+        if directive in ('%A', '%a') and (token.title() in persian.WEEKDAYS or token.title() in days):
+            print 'WHOOP ', token
         elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
             month = int(token)
         elif directive == '%B' and token in self._months:

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -6,22 +6,22 @@ import re
 
 from dateparser.calendars import non_gregorian_parser
 from convertdate import persian
-from datetime import datetime
 from collections import OrderedDict
 from functools import reduce
 
 
 class PersianDate(object):
     def __init__(self, year, month, day):
-        self.year=year
-        self.month=month
-        self.day=day
+        self.year = year
+        self.month = month
+        self.day = day
 
     def weekday(self):
         for week in persian.monthcalendar(self.year, self.month):
             for idx, day in enumerate(week):
-                if day==self.day:
+                if day == self.day:
                     return idx
+
 
 class jalali_parser(non_gregorian_parser):
 
@@ -105,19 +105,21 @@ class jalali_parser(non_gregorian_parser):
     @classmethod
     def replace_months(cls, source):
         result = source
-        for persian, latin in reduce(
-                lambda a, b: a + b,
-                [[(value, month) for value in repl[-1]] for month, repl in cls._months.items()]):
-            result = result.replace(persian, latin)
+        for pers, latin in reduce(
+            lambda a, b: a + b,
+            [[(value, month) for value in repl[-1]] for month, repl in cls._months.items()]
+        ):
+            result = result.replace(pers, latin)
         return result
 
     @classmethod
     def replace_weekdays(cls, source):
         result = source
-        for persian, latin in reduce(
-                lambda a, b: a + b,
-                [[(value, weekday) for value in repl] for weekday, repl in cls._weekdays.items()]):
-            result = result.replace(persian, latin)
+        for pers, latin in reduce(
+            lambda a, b: a + b,
+            [[(value, weekday) for value in repl] for weekday, repl in cls._weekdays.items()]
+        ):
+            result = result.replace(pers, latin)
         return result
 
     @classmethod

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -96,14 +96,14 @@ class jalali_parser(non_gregorian_parser):
     }
 
     @classmethod
-    def replace_digits(cls, source):
+    def _replace_digits(cls, source):
         result = source
         for pers_digit, number in cls._digits.items():
             result = result.replace(pers_digit, str(number))
         return result
 
     @classmethod
-    def replace_months(cls, source):
+    def _replace_months(cls, source):
         result = source
         for pers, latin in reduce(
             lambda a, b: a + b,
@@ -113,7 +113,7 @@ class jalali_parser(non_gregorian_parser):
         return result
 
     @classmethod
-    def replace_weekdays(cls, source):
+    def _replace_weekdays(cls, source):
         result = source
         for pers, latin in reduce(
             lambda a, b: a + b,
@@ -123,7 +123,7 @@ class jalali_parser(non_gregorian_parser):
         return result
 
     @classmethod
-    def replace_time(cls, source):
+    def _replace_time(cls, source):
         def only_numbers(match_obj):
             matched_string = match_obj.group()
             return re.sub(r'\D', ' ', matched_string)
@@ -138,7 +138,7 @@ class jalali_parser(non_gregorian_parser):
         return result
 
     @classmethod
-    def replace_days(cls, source):
+    def _replace_days(cls, source):
         result = re.sub(r'ام|م|ین', '', source)  # removes persian variant of th/first/second/third
         day_pairs = list(cls._number_letters.items())
 

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -2,47 +2,47 @@
 from dateparser.parser import _parser
 from convertdate import persian
 from datetime import datetime
-from datetime import date
-from dateutil.relativedelta import relativedelta
 
-def add_years(d, years):
-    """Return a date that's `years` years after the date (or datetime)
-    object `d`. Return the same calendar date (month and day) in the
-    destination year, if it exists, otherwise use the following day
-    (thus changing February 29 to March 1).
-
-    """
-    try:
-        return d.replace(year = d.year + years)
-    except ValueError:
-        return d + (date(d.year + years, 1, 1) - date(d.year, 1, 1))
-
-class jalali_parser(_parser):
-
-    def _parse_date_component(self, token, directive):
-        print token, directive, len(token)
-        day_pairs = dict(zip(persian.WEEKDAYS,  ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']))
-        persian_dummy_year, persian_dummy_month, persian_dummy_day = persian.from_gregorian(1999, 3, 17)
-        #dummy_jd_year, dummy_jd_month, dummy_jd_day = persian.gregorian.to_jd(1900, 1, 1)
-        if directive in ('%A', '%a') and token.title() in persian.WEEKDAYS:
-            return datetime.strptime(day_pairs[token.title()], '%A')
-        elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
-            return datetime(*persian.to_gregorian(persian_dummy_year, int(token), persian_dummy_day))
-        elif directive == '%d' and len(token) == 2 and token.isdigit():
-            if  0 < int(token) <= persian.month_length(persian_dummy_year, persian_dummy_month):
-                return datetime(*persian.to_gregorian(persian_dummy_year, persian_dummy_month, int(token)))
-            else:
-                raise ValueError
-        elif directive == '%Y' and len(token) == 4 and token.isdigit():
-            return datetime(*persian.to_gregorian(int(token), persian_dummy_month, persian_dummy_day))
-        elif directive == '%y' and len(token) == 2 and token.isdigit():
-            return datetime(*persian.to_gregorian(int(token), persian_dummy_month, persian_dummy_day))
-        else:
-            raise ValueError
-
+class persian_datetime(object):
+    def __init__(self, year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=0):
+        self.year=year
+        self.month=month
+        self.day=day
+        self.hour=hour
+        self.minute=minute
+        self.microsecond=microsecond
+        self.tzinfo=tzinfo
 
     @classmethod
-    def parse(cls, datestring, settings):
-        dateobj, period = super(jalali_parser, cls).parse(datestring ,settings)
+    def utcnow(cls):
+        g_dt = datetime.utcnow()
+        p_year, p_month, p_day = persian.from_gregorian(g_dt.year, g_dt.month, g_dt.day)
+        return cls(p_year, p_month, p_day, g_dt.hour, g_dt.minute, g_dt.second, g_dt.microsecond, g_dt.tzinfo)
 
-        return dateobj - relativedelta(years=1) - relativedelta(days=1), period
+    @classmethod
+    def strptime(cls, token, directive):
+        persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']))
+        year, month, day = 1348, 1, 1
+        if directive in ('%A', '%a') and token.title() in persian.WEEKDAYS:
+            pass
+        elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+            month = int(token)
+        elif directive == '%d' and len(token) == 2 and token.isdigit() and 0 < int(token) <= persian.month_length(year, month):
+            day = int(token)
+        elif directive == '%Y' and len(token) == 4 and token.isdigit():
+            year = int(token)
+        else:
+            raise ValueError
+        return cls(year,month,day)
+
+class jalali_parser(_parser):
+    datetime_cls = persian_datetime
+    def _get_datetime_obj(self, **params):
+        from convertdate import persian 
+        day = params['day']
+        if not(0 < day <= persian.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
+            day = persian.month_length(params['year'], params['month'])
+        year, month, day = persian.to_gregorian(year=params['year'], month=params['month'], day=day)
+        c_params = params.copy()
+        c_params.update(dict(year=year,month=month, day=day))
+        return datetime(**c_params)

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -1,7 +1,15 @@
 # coding: utf-8
+
+from __future__ import unicode_literals
+
+import re
+
 from dateparser.parser import _parser
 from convertdate import persian
 from datetime import datetime
+from collections import OrderedDict
+from functools import reduce
+
 
 class persian_date(object):
     def __init__(self, year, month, day):
@@ -17,21 +25,143 @@ class persian_date(object):
 
 class jalali_parser(_parser):
 
-    _months = [
+    _digits = {"۰": 0, "۱": 1, "۲": 2, "۳": 3, "۴": 4,
+               "۵": 5, "۶": 6, "۷": 7, "۸": 8, "۹": 9}
+
+    _months = OrderedDict([
         # pinglish : (persian literals, month index, number of days)
-        "Farvardin",
-        "Ordibehesht",
-        "Khordad",
-        "Tir",
-        "Mordad",
-        "Shahrivar",
-        "Mehr",
-        "Aban",
-        "Azar",
-        "Dey",
-        "Bahman",
-        "Esfand",
-    ]
+        ("Farvardin", (1, 31, ["فروردین"])),
+        ("Ordibehesht", (2, 31, ["اردیبهشت"])),
+        ("Khordad", (3, 31, ["خرداد"])),
+        ("Tir", (4, 31, ["تیر"])),
+        ("Mordad", (5, 31, ["امرداد", "مرداد"])),
+        ("Shahrivar", (6, 31, ["شهریور", "شهريور"])),
+        ("Mehr", (7, 30, ["مهر"])),
+        ("Aban", (8, 30, ["آبان"])),
+        ("Azar", (9, 30, ["آذر"])),
+        ("Dey", (10, 30, ["دی"])),
+        ("Bahman", (11, 30, ["بهمن", "بهن"])),
+        ("Esfand", (12, 29, ["اسفند"])),
+    ])
+
+    _weekdays = OrderedDict([
+        ("Sunday", ["یکشنبه"]),
+        ("Monday", ["دوشنبه"]),
+        ("Tuesday", ["سهشنبه", "سه شنبه"]),
+        ("Wednesday", ["چهارشنبه", "چهار شنبه"]),
+        ("Thursday", ["پنجشنبه", "پنج شنبه"]),
+        ("Friday", ["جمعه"]),
+        ("Saturday", ["روز شنبه", "شنبه"]),
+    ])
+
+    _number_letters = {
+        0: ["صفر"],
+        1: ["یک", "اول"],
+        2: ["دو"],
+        3: ["سه", "سو"],
+        4: ["چهار"],
+        5: ["پنج"],
+        6: ["شش"],
+        7: ["هفت"],
+        8: ["هشت"],
+        9: ["نه"],
+        10: ["ده"],
+        11: ["یازده"],
+        12: ["دوازده"],
+        13: ["سیزده"],
+        14: ["چهارده"],
+        15: ["پانزده"],
+        16: ["شانزده"],
+        17: ["هفده"],
+        18: ["هجده"],
+        19: ["نوزده"],
+        20: ["بیست"],
+        21: ["بیست و یک"],
+        22: ["بیست و دو", "بیست ثانیه"],
+        23: ["بیست و سه", "بیست و سو"],
+        24: ["بیست و چهار"],
+        25: ["بیست و پنج"],
+        26: ["بیست و شش"],
+        27: ["بیست و هفت"],
+        28: ["بیست و هشت"],
+        29: ["بیست و نه"],
+        30: ["سی"],
+        31: ["سی و یک"],
+    }
+
+    @classmethod
+    def replace_digits(cls, source):
+        result = source
+        for pers_digit, number in cls._digits.items():
+            result = result.replace(pers_digit, str(number))
+        return result
+
+    @classmethod
+    def replace_months(cls, source):
+        result = source
+        for persian, latin in reduce(
+                lambda a, b: a + b,
+                [[(value, month) for value in repl[-1]] for month, repl in cls._months.items()]):
+            result = result.replace(persian, latin)
+        return result
+
+    @classmethod
+    def replace_weekdays(cls, source):
+        result = source
+        for persian, latin in reduce(
+                lambda a, b: a + b,
+                [[(value, weekday) for value in repl] for weekday, repl in cls._weekdays.items()]):
+            result = result.replace(persian, latin)
+        return result
+
+    @classmethod
+    def replace_time(cls, source):
+        def only_numbers(match_obj):
+            matched_string = match_obj.group()
+            return re.sub(r'\D', ' ', matched_string)
+        hour_pattern = r'ساعت\s+\d{2}'
+        minute_pattern = r'\d{2}\s+دقیقه'
+        second_pattern = r'\d{2}\s+ثانیه'
+        result = re.sub(hour_pattern, only_numbers, source)
+        result = re.sub(minute_pattern, only_numbers, result)
+        result = re.sub(second_pattern, only_numbers, result)
+        result = re.sub(r'\s+و\s+', ':', result)
+        result = result.replace('ساعت', '')
+        return result
+
+    @classmethod
+    def replace_days(cls, source):
+        result = re.sub(r'ام|م|ین', '', source)  # removes persian variant of th/first/second/third
+        day_pairs = list(cls._number_letters.items())
+
+        def comp_key(tup):
+            return tup[0]
+
+        day_pairs.sort(key=comp_key, reverse=True)
+
+        thirteen, thirty = day_pairs[-14], day_pairs[1]
+        day_pairs[-14] = thirty
+        day_pairs[1] = thirteen
+
+        for persian, number in reduce(
+                lambda a, b: a + b,
+                [[(val, repl) for val in persian] for repl, persian in day_pairs]):
+            result = result.replace(persian, str(number))
+        return result
+
+    @classmethod
+    def to_latin(cls, source):
+        result = source
+        result = cls.replace_months(result)
+        result = cls.replace_weekdays(result)
+        result = cls.replace_digits(result)
+        result = cls.replace_days(result)
+        result = cls.replace_time(result)
+
+        result = result.strip()
+
+        return result
+
 
     def _get_datetime_obj(self, **params):
         day = params['day']
@@ -55,15 +185,13 @@ class jalali_parser(_parser):
         return params
 
     def _get_date_obj(self, token, directive):
-        days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
-        persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  days))
         year, month, day = 1348, 1, 1
-        if directive == '%A' and (token.title() in persian.WEEKDAYS or token.title() in days):
+        if directive == '%A' and token.title() in self._weekdays:
             pass
         elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
             month = int(token)
         elif directive == '%B' and token in self._months:
-            month = self._months.index(token) + 1
+            month = list(self._months.keys()).index(token) + 1
         elif directive == '%d' and len(token) <= 2 and token.isdigit() and 0 < int(token) <= persian.month_length(year, month):
             day = int(token)
         elif directive == '%Y' and len(token) == 4 and token.isdigit():
@@ -71,3 +199,9 @@ class jalali_parser(_parser):
         else:
             raise ValueError
         return persian_date(year,month,day)
+
+    @classmethod
+    def parse(cls, datestring, settings):
+        datestring = cls.to_latin(datestring)
+        return super(jalali_parser, cls).parse(datestring, settings)
+

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -54,12 +54,12 @@ class jalali_parser(_parser):
         persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  days))
         year, month, day = 1348, 1, 1
         if directive in ('%A', '%a') and (token.title() in persian.WEEKDAYS or token.title() in days):
-            print 'WHOOP ', token
-        elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+            pass
+        elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
             month = int(token)
         elif directive == '%B' and token in self._months:
             month = self._months.index(token) + 1
-        elif directive == '%d' and len(token) == 2 and token.isdigit() and 0 < int(token) <= persian.month_length(year, month):
+        elif directive == '%d' and len(token) <= 2 and token.isdigit() and 0 < int(token) <= persian.month_length(year, month):
             day = int(token)
         elif directive == '%Y' and len(token) == 4 and token.isdigit():
             year = int(token)

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+from dateparser.parser import _parser
+from convertdate import persian
+from datetime import datetime
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+def add_years(d, years):
+    """Return a date that's `years` years after the date (or datetime)
+    object `d`. Return the same calendar date (month and day) in the
+    destination year, if it exists, otherwise use the following day
+    (thus changing February 29 to March 1).
+
+    """
+    try:
+        return d.replace(year = d.year + years)
+    except ValueError:
+        return d + (date(d.year + years, 1, 1) - date(d.year, 1, 1))
+
+class jalali_parser(_parser):
+
+    def _parse_date_component(self, token, directive):
+        print token, directive, len(token)
+        day_pairs = dict(zip(persian.WEEKDAYS,  ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']))
+        persian_dummy_year, persian_dummy_month, persian_dummy_day = persian.from_gregorian(1999, 3, 17)
+        #dummy_jd_year, dummy_jd_month, dummy_jd_day = persian.gregorian.to_jd(1900, 1, 1)
+        if directive in ('%A', '%a') and token.title() in persian.WEEKDAYS:
+            return datetime.strptime(day_pairs[token.title()], '%A')
+        elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+            return datetime(*persian.to_gregorian(persian_dummy_year, int(token), persian_dummy_day))
+        elif directive == '%d' and len(token) == 2 and token.isdigit():
+            if  0 < int(token) <= persian.month_length(persian_dummy_year, persian_dummy_month):
+                return datetime(*persian.to_gregorian(persian_dummy_year, persian_dummy_month, int(token)))
+            else:
+                raise ValueError
+        elif directive == '%Y' and len(token) == 4 and token.isdigit():
+            return datetime(*persian.to_gregorian(int(token), persian_dummy_month, persian_dummy_day))
+        elif directive == '%y' and len(token) == 2 and token.isdigit():
+            return datetime(*persian.to_gregorian(int(token), persian_dummy_month, persian_dummy_day))
+        else:
+            raise ValueError
+
+
+    @classmethod
+    def parse(cls, datestring, settings):
+        dateobj, period = super(jalali_parser, cls).parse(datestring ,settings)
+
+        return dateobj - relativedelta(years=1) - relativedelta(days=1), period

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -34,7 +34,6 @@ class jalali_parser(_parser):
     ]
 
     def _get_datetime_obj(self, **params):
-        from convertdate import persian 
         day = params['day']
         if not(0 < day <= persian.month_length(params['year'], params['month'])) and not(self._token_day or hasattr(self, '_token_weekday')):
             day = persian.month_length(params['year'], params['month'])

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -9,6 +9,12 @@ class persian_date(object):
         self.month=month
         self.day=day
 
+    def weekday(self):
+        for week in persian.monthcalendar(self.year, self.month):
+            for idx, day in enumerate(week):
+                if day==self.day:
+                    return idx
+
 class jalali_parser(_parser):
 
     _months = [
@@ -53,7 +59,7 @@ class jalali_parser(_parser):
         days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
         persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  days))
         year, month, day = 1348, 1, 1
-        if directive in ('%A', '%a') and (token.title() in persian.WEEKDAYS or token.title() in days):
+        if directive == '%A' and (token.title() in persian.WEEKDAYS or token.title() in days):
             pass
         elif directive == '%m' and len(token) <= 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
             month = int(token)

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -3,40 +3,30 @@ from dateparser.parser import _parser
 from convertdate import persian
 from datetime import datetime
 
-class persian_datetime(object):
-    def __init__(self, year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=0):
+class persian_date(object):
+    def __init__(self, year, month, day):
         self.year=year
         self.month=month
         self.day=day
-        self.hour=hour
-        self.minute=minute
-        self.microsecond=microsecond
-        self.tzinfo=tzinfo
-
-    @classmethod
-    def utcnow(cls):
-        g_dt = datetime.utcnow()
-        p_year, p_month, p_day = persian.from_gregorian(g_dt.year, g_dt.month, g_dt.day)
-        return cls(p_year, p_month, p_day, g_dt.hour, g_dt.minute, g_dt.second, g_dt.microsecond, g_dt.tzinfo)
-
-    @classmethod
-    def strptime(cls, token, directive):
-        persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']))
-        year, month, day = 1348, 1, 1
-        if directive in ('%A', '%a') and token.title() in persian.WEEKDAYS:
-            pass
-        elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
-            month = int(token)
-        elif directive == '%d' and len(token) == 2 and token.isdigit() and 0 < int(token) <= persian.month_length(year, month):
-            day = int(token)
-        elif directive == '%Y' and len(token) == 4 and token.isdigit():
-            year = int(token)
-        else:
-            raise ValueError
-        return cls(year,month,day)
 
 class jalali_parser(_parser):
-    datetime_cls = persian_datetime
+
+    _months = [
+        # pinglish : (persian literals, month index, number of days)
+        "Farvardin",
+        "Ordibehesht",
+        "Khordad",
+        "Tir",
+        "Mordad",
+        "Shahrivar",
+        "Mehr",
+        "Aban",
+        "Azar",
+        "Dey",
+        "Bahman",
+        "Esfand",
+    ]
+
     def _get_datetime_obj(self, **params):
         from convertdate import persian 
         day = params['day']
@@ -46,3 +36,32 @@ class jalali_parser(_parser):
         c_params = params.copy()
         c_params.update(dict(year=year,month=month, day=day))
         return datetime(**c_params)
+
+    def _get_datetime_obj_params(self):
+        if not self.now:
+            self._set_relative_base()
+        persian_now_year, persian_now_month, persian_now_day = persian.from_gregorian(self.now.year, self.now.month, self.now.day)
+        params = {
+            'day': self.day or persian_now_day,
+            'month': self.month or persian_now_month,
+            'year': self.year or persian_now_year,
+            'hour': 0, 'minute': 0, 'second': 0, 'microsecond': 0,
+        }
+        return params
+
+    def _get_date_obj(self, token, directive):
+        persian_gregorian_day_map = dict(zip(persian.WEEKDAYS,  ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']))
+        year, month, day = 1348, 1, 1
+        if directive in ('%A', '%a') and token.title() in persian.WEEKDAYS:
+            pass
+        elif directive == '%m' and len(token) == 2 and token.isdigit() and int(token) >= 1 and int(token) <= 12:
+            month = int(token)
+        elif directive == '%B' and token in self._months:
+            month = self._months.index(token) + 1
+        elif directive == '%d' and len(token) == 2 and token.isdigit() and 0 < int(token) <= persian.month_length(year, month):
+            day = int(token)
+        elif directive == '%Y' and len(token) == 4 and token.isdigit():
+            year = int(token)
+        else:
+            raise ValueError
+        return persian_date(year,month,day)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -73,6 +73,7 @@ def parse(datestring, settings):
     exceptions = []
     for parser in [_parser.parse, _no_spaces_parser.parse]:
         try:
+            print datestring
             res = parser(datestring, settings)
             if res:
                 return res
@@ -185,6 +186,9 @@ class _parser(object):
 
     def _get_component_token(self, key):
         return getattr(self, '_token_%s' % key, None)
+
+    def _parse_date_component(self, token, directive):
+        return datetime.strptime(token, directive)
 
     def __init__(self, tokens, settings):
         self.settings = settings
@@ -431,7 +435,7 @@ class _parser(object):
                     continue
                 for directive in directives:
                     try:
-                        do = datetime.strptime(token, directive)
+                        do = self._parse_date_component(token, directive)
                         prev_value = getattr(self, component, None)
                         if not prev_value:
                             return set_and_return(token, type, component, do)
@@ -439,7 +443,7 @@ class _parser(object):
                             try:
                                 prev_token, prev_type = getattr(self, '_token_%s' % component)
                                 if prev_type == type:
-                                    do = datetime.strptime(prev_token, directive)
+                                    do = self._parse_date_component(prev_token, directive)
                             except ValueError:
                                 self.unset_tokens.append((prev_token, prev_type, component))
                                 return set_and_return(token, type, component, do)
@@ -459,7 +463,7 @@ class _parser(object):
                     continue
                 for directive in directives:
                     try:
-                        do = datetime.strptime(token, directive)
+                        do = self._parse_date_component(token, directive)
                         prev_value = getattr(self, component, None)
                         if not prev_value:
                             return set_and_return(token, type, component, do, skip_date_order=True)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -132,8 +132,9 @@ class _no_spaces_parser(object):
                      self._timeformats)
 
         self.date_formats = {
-            '%m%d%y': (self._preferred_formats +
-                       sorted(self._all, key=lambda x: x.lower().startswith('%m%d%y'), reverse=True)
+            '%m%d%y': (
+                self._preferred_formats +
+                sorted(self._all, key=lambda x: x.lower().startswith('%m%d%y'), reverse=True)
             ),
             '%m%y%d': sorted(self._all, key=lambda x: x.lower().startswith('%m%y%d'), reverse=True),
             '%y%m%d': sorted(self._all, key=lambda x: x.lower().startswith('%y%m%d'), reverse=True),
@@ -158,7 +159,10 @@ class _no_spaces_parser(object):
 
         datestring = datestring.replace(':', '')
         tokens = tokenizer(datestring)
-        order = resolve_date_order(settings.DATE_ORDER) if settings.DATE_ORDER else cls._default_order
+        if settings.DATE_ORDER:
+            order = resolve_date_order(settings.DATE_ORDER)
+        else:
+            order = cls._default_order
         nsp = cls()
         ambiguous_date = None
         for token, _ in tokens.tokenize():
@@ -298,9 +302,10 @@ class _parser(object):
         except ValueError as e:
             error_text = getattr(e, 'message', None) or e.__str__()
             error_msgs = ['day is out of range', 'day must be in']
-            if ((error_msgs[0] in error_text or error_msgs[1] in error_text) and
+            if (
+                (error_msgs[0] in error_text or error_msgs[1] in error_text) and
                 not(self._token_day or hasattr(self, '_token_weekday'))
-                ):
+            ):
                 _, tail = calendar.monthrange(params['year'], params['month'])
                 params['day'] = tail
                 return datetime(**params)
@@ -341,10 +346,10 @@ class _parser(object):
 
         self._set_relative_base()
 
-        time = self.time() if not self.time is None else None
+        time = self.time() if self.time is not None else None
 
         if self.settings.FUZZY:
-            attr_truth_values = [] 
+            attr_truth_values = []
             for attr in ['day', 'month', 'year', 'time']:
                 attr_truth_values.append(getattr(self, attr, False))
 
@@ -411,9 +416,11 @@ class _parser(object):
         return dateobj
 
     def _correct_for_day(self, dateobj):
-        if (getattr(self, '_token_day', None) or
+        if (
+            getattr(self, '_token_day', None) or
             getattr(self, '_token_weekday', None) or
-            getattr(self, '_token_time', None)):
+            getattr(self, '_token_time', None)
+        ):
             return dateobj
 
         _, tail = calendar.monthrange(dateobj.year, dateobj.month)
@@ -514,7 +521,9 @@ class tokenizer(object):
     nonwords = u"./\()\"',.;<>~!@#$%^&*|+=[]{}`~?-     "
 
     def _isletter(self, tkn): return tkn in self.letters
+
     def _isdigit(self, tkn): return tkn in self.digits
+
     def _isnonword(self, tkn): return tkn in self.nonwords
 
     def __init__(self, ds):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ ruamel.yaml
 regex
 jdatetime
 umalqurra
+convertdate
 pytz

--- a/tests/test_hijri.py
+++ b/tests/test_hijri.py
@@ -33,7 +33,7 @@ class TestHijriParser(BaseTestCase):
     def when_date_is_given(self, dt_string, date_formats, languages):
         self.date_string = dt_string
         self.parser = HijriCalendar(dt_string)
-        self.result = self.parser.get_date(date_formats, languages)
+        self.result = self.parser.get_date()
 
     def then_parsed_datetime_is(self, dt):
         self.assertEqual(dt, self.result['date_obj'])
@@ -49,5 +49,7 @@ class TestHijriParser(BaseTestCase):
     ])
     def test_datetime_parsing(self, dt_string, dt_obj,
                               date_formats=None, languages=None):
+        from dateparser.conf import settings
+        settings.DATE_ORDER = 'DMY'
         self.when_date_is_given(dt_string, date_formats, languages)
         self.then_parsed_datetime_is(dt_obj)

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -5,7 +5,8 @@ from nose_parameterized import parameterized, param
 from unittest import TestCase
 from datetime import datetime
 
-from dateparser.calendars.jalali import JalaliParser
+from dateparser.calendars.jalali import JalaliCalendar
+from dateparser.calendars.jalali_parser import jalali_parser
 from dateparser.calendars.jalali import validate_time
 from tests import BaseTestCase
 
@@ -35,19 +36,14 @@ class TestValidateTime(BaseTestCase):
         self.when_date_is_given(time_string)
         self.then_time_is_parsed_as(time)
 
+
 class TestJalaliParser(BaseTestCase):
     def setUp(self):
         super(TestJalaliParser, self).setUp()
-        self.result = NotImplemented
-        self.date_string = NotImplemented
-        self.parser = NotImplemented
         self.translated = NotImplemented
 
     def when_date_is_given(self, date_string):
-        self.date_string = date_string
-        self.parser = JalaliParser(date_string)
-        self.result = self.parser.get_date()
-        self.translated = self.parser.persian_to_latin(date_string)
+        self.translated = jalali_parser.to_latin(date_string)
 
     def then_month_is_parsed_as(self, month_name):
         self.assertEqual(month_name, self.translated)
@@ -57,9 +53,6 @@ class TestJalaliParser(BaseTestCase):
 
     def then_digit_is_parsed_as(self, digit):
         self.assertEqual(digit, self.translated)
-
-    def then_date_parsed_is(self, datetime):
-        self.assertEqual(datetime, self.result['date_obj'])
 
     def then_numeral_parsed_is(self, datetime):
         self.assertEqual(datetime, self.translated)
@@ -167,6 +160,23 @@ class TestJalaliParser(BaseTestCase):
     def test_replace_day_literal_with_numerals(self, persian, numeral):
         self.when_date_is_given(persian)
         self.then_numeral_parsed_is(numeral)
+
+
+class TestJalaliCalendar(BaseTestCase):
+
+    def setUp(self):
+        super(TestJalaliCalendar, self).setUp()
+        self.result = NotImplemented
+        self.date_string = NotImplemented
+        self.calendar = NotImplemented
+
+    def when_date_is_given(self, date_string):
+        self.date_string = date_string
+        self.calendar = JalaliCalendar(date_string)
+        self.result = self.calendar.get_date()
+
+    def then_date_parsed_is(self, datetime):
+        self.assertEqual(datetime, self.result['date_obj'])
 
     @parameterized.expand([
         param(date_string=u'سه شنبه سوم شهریور ۱۳۹۴', dt=datetime(2015, 8, 25, 0, 0)),

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from nose_parameterized import parameterized, param
-from unittest import TestCase
 from datetime import datetime
 
 from dateparser.calendars.jalali import JalaliCalendar
@@ -171,11 +170,23 @@ class TestJalaliCalendar(BaseTestCase):
         param(date_string=u'دوشنبه ۲۳ شهريور ۱۳۹۴ ساعت ۱۹:۱۱', dt=datetime(2015, 9, 14, 19, 11)),
         param(date_string=u'جمعه سی ام اسفند ۱۳۸۷ساعت 19:47', dt=datetime(2009, 3, 20, 19, 47)),
         param(date_string=u'شنبه چهاردهم دی ۱۳۹۲ساعت 12:1', dt=datetime(2014, 1, 4, 12, 1)),
-        param(date_string=u'پنجشنبه 26 شهریور 1394 ساعت ساعت 11 و 01 دقیقه و 47 ثانیه', dt=datetime(2015, 9, 17, 11, 1, 47)),
-        param(date_string=u'پنجشنبه 26 شهریور 1394 ساعت ساعت 10 و 58 دقیقه و 04 ثانیه', dt=datetime(2015, 9, 17, 10, 58, 4)),
-        param(date_string=u'سه شنبه 17 شهریور 1394 ساعت ساعت 18 و 21 دقیقه و 44 ثانیه', dt=datetime(2015, 9, 8, 18, 21, 44)),
+        param(
+            date_string=u'پنجشنبه 26 شهریور 1394 ساعت ساعت 11 و 01 دقیقه و 47 ثانیه',
+            dt=datetime(2015, 9, 17, 11, 1, 47)
+        ),
+        param(
+            date_string=u'پنجشنبه 26 شهریور 1394 ساعت ساعت 10 و 58 دقیقه و 04 ثانیه',
+            dt=datetime(2015, 9, 17, 10, 58, 4)
+        ),
+        param(
+            date_string=u'سه شنبه 17 شهریور 1394 ساعت ساعت 18 و 21 دقیقه و 44 ثانیه',
+            dt=datetime(2015, 9, 8, 18, 21, 44)
+        ),
         param(date_string=u'پنجشنبه 11 تیر 1394', dt=datetime(2015, 7, 2, 0, 0)),
-        param(date_string=u'پنجشنبه 26 شهریور 1394 ساعت ساعت 11 و 01 دقیقه', dt=datetime(2015, 9, 17, 11, 1)),
+        param(
+            date_string=u'پنجشنبه 26 شهریور 1394 ساعت ساعت 11 و 01 دقیقه',
+            dt=datetime(2015, 9, 17, 11, 1)
+        ),
     ])
     def test_get_date(self, date_string, dt):
         self.when_date_is_given(date_string)

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -59,7 +59,7 @@ class TestJalaliParser(BaseTestCase):
         self.assertEqual(digit, self.translated)
 
     def then_date_parsed_is(self, datetime):
-        self.assertEqual(datetime, self.result[0])
+        self.assertEqual(datetime, self.result['date_obj'])
 
     def then_numeral_parsed_is(self, datetime):
         self.assertEqual(datetime, self.translated)

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -7,34 +7,7 @@ from datetime import datetime
 
 from dateparser.calendars.jalali import JalaliCalendar
 from dateparser.calendars.jalali_parser import jalali_parser
-from dateparser.calendars.jalali import validate_time
 from tests import BaseTestCase
-
-
-class TestValidateTime(BaseTestCase):
-    def setUp(self):
-        super(TestValidateTime, self).setUp()
-        self.result = NotImplemented
-        self.time_string = NotImplemented
-
-    def when_date_is_given(self, time_string):
-        self.time_string = time_string
-        self.result = validate_time(time_string)
-
-    def then_time_is_parsed_as(self, time):
-        self.assertEqual(time, self.result)
-
-    @parameterized.expand([
-        param(time_string='9 ساعت 10 دقیقه 30 ثانیه', time='9:10:30'),
-        param(time_string='09 ساعت 10 دقیقه 30 ثانیه', time='09:10:30'),
-        param(time_string='09 ساعت 0 دقیقه 0 ثانیه', time='09:0:0'),
-        param(time_string='09 ساعت 00 دقیقه', time='09:00:00'),
-        param(time_string='00 دقیقه', time='00:00:00'),
-        param(time_string='15 دقیقه 30 ثانیه', time='00:15:30'),
-    ])
-    def test_validate_time(self, time_string, time):
-        self.when_date_is_given(time_string)
-        self.then_time_is_parsed_as(time)
 
 
 class TestJalaliParser(BaseTestCase):

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -5,8 +5,31 @@ from nose_parameterized import parameterized, param
 from datetime import datetime
 
 from dateparser.calendars.jalali import JalaliCalendar
-from dateparser.calendars.jalali_parser import jalali_parser
+from dateparser.calendars.jalali_parser import jalali_parser, PersianDate
 from tests import BaseTestCase
+
+
+class TestPersianDate(BaseTestCase):
+    def setUp(self):
+        super(TestPersianDate, self).setUp()
+        self.persian_date = NotImplemented
+
+    def when_date_is_given(self, year, month, day):
+        self.persian_date = PersianDate(year, month, day)
+
+    def then_weekday_is(self, weekday):
+        print self.persian_date.weekday(), weekday
+        self.assertEqual(self.persian_date.weekday(), weekday)
+
+    @parameterized.expand([
+        param(year=1348, month=1, day=3, weekday=0),
+        param(year=1348, month=2, day=28, weekday=0),
+        param(year=1348, month=3, day=27, weekday=2),
+        param(year=1348, month=4, day=11, weekday=3),
+    ])
+    def test_weekday(self, year, month, day, weekday):
+        self.when_date_is_given(year, month, day)
+        self.then_weekday_is(weekday)
 
 
 class TestJalaliParser(BaseTestCase):

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -59,7 +59,7 @@ class TestJalaliParser(BaseTestCase):
         self.assertEqual(digit, self.translated)
 
     def then_date_parsed_is(self, datetime):
-        self.assertEqual(datetime, self.result)
+        self.assertEqual(datetime, self.result[0])
 
     def then_numeral_parsed_is(self, datetime):
         self.assertEqual(datetime, self.translated)

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -18,7 +18,6 @@ class TestPersianDate(BaseTestCase):
         self.persian_date = PersianDate(year, month, day)
 
     def then_weekday_is(self, weekday):
-        print self.persian_date.weekday(), weekday
         self.assertEqual(self.persian_date.weekday(), weekday)
 
     @parameterized.expand([


### PR DESCRIPTION
PR for https://github.com/scrapinghub/dateparser/issues/125

Summary of changes:

- Used parser class from dateparser.parser.py
- Used convertdate package for jalali calendar
- Used umalqurra  package for hijri calendar (convertdate returns date that have +- 1 or 0 offset of umalquura dates. There is a pull request for this issue https://github.com/fitnr/convertdate/issues/5 , until that PR is merged, umalqurra package will be used)
- Both `JalaliCalendar` and `HijriCalendar`'s `get_date` now return `{'date_obj': <datetime> , 'period': <str>}`

