### PR TITLE
DateDataParser - return detected language

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -9,7 +9,6 @@ import regex as re
 from dateutil.relativedelta import relativedelta
 
 from dateparser.date_parser import date_parser
-from dateparser.parser import parse
 from dateparser.freshness_date_parser import freshness_date_parser
 from dateparser.languages.loader import LanguageDataLoader
 from dateparser.languages.detection import AutoDetectLanguage, ExactLanguages
@@ -188,7 +187,7 @@ class _DateLanguageParser(object):
         return freshness_date_parser.get_date_data(self._get_translated_date(), self._settings)
 
     def _try_parser(self):
-        _order = self._settings.DATE_ORDER 
+        _order = self._settings.DATE_ORDER
         try:
             if self._settings.PREFER_LANGUAGE_DATE_ORDER:
                 self._settings.DATE_ORDER = self.language.info.get('dateorder', _order)
@@ -351,7 +350,7 @@ class DateDataParser(object):
             return res
 
         if self._settings.NORMALIZE:
-           date_string = normalize_unicode(date_string)
+            date_string = normalize_unicode(date_string)
 
         date_string = sanitize_date(date_string)
 
@@ -360,12 +359,13 @@ class DateDataParser(object):
             parsed_date = _DateLanguageParser.parse(
                 language, date_string, date_formats, settings=self._settings)
             if parsed_date:
+                parsed_date['language'] = language.shortname
                 return parsed_date
         else:
-            return {'date_obj': None, 'period': 'day'}
+            return {'date_obj': None, 'period': 'day', 'language': None}
 
     def get_date_tuple(self, *args, **kwargs):
-        date_tuple = collections.namedtuple('DateData', 'date_obj period')
+        date_tuple = collections.namedtuple('DateData', 'date_obj period language')
         date_data = self.get_date_data(*args, **kwargs)
         return date_tuple(**date_data)
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -353,6 +353,23 @@ class TestDateDataParser(BaseTestCase):
         self.then_parsed_dates_are(list(dates_to_parse.values()))
 
     @parameterized.expand([
+        param(date_string=u'11 Marzo, 2014', language='es'),
+        param(date_string=u'13 Septiembre, 2014', language='es'),
+        param(date_string=u'Сегодня', language='ru'),
+        param(date_string=u'Avant-hier', language='fr'),
+        param(date_string=u'Anteontem', language='pt'),
+        param(date_string=u'ธันวาคม 11, 2014, 08:55:08 PM', language='th'),
+        param(date_string=u'Anteontem', language='pt'),
+        param(date_string=u'14 aprilie 2014', language='ro'),
+        param(date_string=u'11 Ağustos, 2014', language='tr'),
+        param(date_string=u'pon 16. čer 2014 10:07:43', language='cs'),
+    ])
+    def test_returned_detected_language_should_be(self, date_string, language):
+        self.given_parser()
+        self.when_date_string_is_parsed(date_string)
+        self.then_detected_language(language)
+
+    @parameterized.expand([
         param("2014-10-09T17:57:39+00:00"),
     ])
     def test_get_date_data_should_not_strip_timezone_info(self, date_string):
@@ -454,6 +471,9 @@ class TestDateDataParser(BaseTestCase):
     def then_date_was_parsed(self):
         self.assertIsNotNone(self.result['date_obj'])
 
+    def then_date_language(self):
+        self.assertIsNotNone(self.result['language'])
+
     def then_date_is_n_days_ago(self, days):
         today = datetime.utcnow().date()
         expected_date = today - timedelta(days=days)
@@ -464,6 +484,9 @@ class TestDateDataParser(BaseTestCase):
 
     def then_parsed_dates_are(self, expected_dates):
         self.assertEqual(expected_dates, [result['date_obj'].date() for result in self.multiple_results])
+
+    def then_detected_language(self, language):
+        self.assertEqual(language, self.result['language'])
 
     def then_period_is(self, day):
         self.assertEqual(day, self.result['period'])


### PR DESCRIPTION
PR for issue https://github.com/scrapinghub/dateparser/issues/210
Added `language` field to dictionary returned by `get_date_data` method

```
>>> DateDataParser().get_date_data('11 Setembro 2015')
{'date_obj': datetime.datetime(2015, 9, 11, 0, 0), 'period': 'day', 'language': 'pt'}
```