### PR TITLE
Add 'UT' timezone

### DIFF
--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -402,6 +402,7 @@ timezone_info_list = [
              ('ULAT', 28800),
              ('URAST', 18000),
              ('URAT', 18000),
+             ('UT', 0),
              ('UTC', 0),
              ('UYHST', -9000),
              ('UYST', -7200),

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -43,6 +43,7 @@ class TestTZPopping(BaseTestCase):
         param('April 10, 2016 at 12:00:00 UTC-02:00', -2),
         param('April 10, 2016 at 12:00:00 GMT-9:30', -9.5),
         param('April 10, 2016 at 12:00:00 UTC-09:30', -9.5),
+        param('Thu, 24 Nov 2016 16:03:00 UT', 0),
     ])
     def test_extracting_valid_offset(self, initial_string, expected_offset):
         self.given_string(initial_string)


### PR DESCRIPTION
Adding support for 'UT' timezone, I have seen this being used in a few cases, i.e: http://feeds.businesswire.com/BW/Data_Management-rss

`pubDate>Thu, 24 Nov 2016 16:03:00 UT</pubDate>`