### PR TITLE
new defaults for tzaware dates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ what timezone is relative base.
     >>> parse('2 minutes ago', settings={'RETURN_AS_TIMEZONE_AWARE': True})
     datetime.datetime(2017, 3, 11, 4, 25, 24, 152670, tzinfo=<DstTzInfo 'Asia/Karachi' PKT+5:00:00 STD>)
 
-In case, you want to compute relative dates in UTC instead of default system local timezone, you can use `TIMEZONE` setting.
+In case, you want to compute relative dates in UTC instead of default system's local timezone, you can use `TIMEZONE` setting.
 
     >>> parse('4 minutes ago', settings={'TIMEZONE': 'UTC'})
     datetime.datetime(2017, 3, 10, 23, 27, 59, 647248, tzinfo=<StaticTzInfo 'UTC'>)

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -6,7 +6,7 @@ settings:
     SKIP_TOKENS_PARSER: ["t", "year", "hour", "minute"]
     TIMEZONE: 'local'
     TO_TIMEZONE: False
-    RETURN_AS_TIMEZONE_AWARE: False
+    RETURN_AS_TIMEZONE_AWARE: 'default'
     NORMALIZE: True
     RELATIVE_BASE: False
     DATE_ORDER: MDY

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -36,7 +36,7 @@ class DateParser(object):
         if settings.TO_TIMEZONE:
             date_obj = apply_timezone(date_obj, settings.TO_TIMEZONE)
 
-        if not settings.RETURN_AS_TIMEZONE_AWARE and ptz is None:
+        if not settings.RETURN_AS_TIMEZONE_AWARE or ptz is None:
             date_obj = date_obj.replace(tzinfo=None)
 
         return date_obj, period

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -25,18 +25,27 @@ class DateParser(object):
 
         date_obj, period = parse(date_string, settings=settings)
 
-        if ptz is not None:
+        _settings_tz = settings.TIMEZONE.lower()
+
+        if ptz:
             date_obj = ptz.localize(date_obj)
-        elif 'local' in settings.TIMEZONE.lower():
-            stz = get_localzone()
-            date_obj = stz.localize(date_obj)
+            if 'local' not in _settings_tz:
+                date_obj = apply_timezone(date_obj, settings.TIMEZONE)
         else:
-            date_obj = localize_timezone(date_obj, settings.TIMEZONE)
+            if 'local' in _settings_tz:
+                stz = get_localzone()
+                date_obj = stz.localize(date_obj)
+            else:
+                date_obj = localize_timezone(date_obj, settings.TIMEZONE)
 
         if settings.TO_TIMEZONE:
             date_obj = apply_timezone(date_obj, settings.TO_TIMEZONE)
 
-        if not settings.RETURN_AS_TIMEZONE_AWARE or ptz is None:
+        if (
+            not settings.RETURN_AS_TIMEZONE_AWARE or
+            (settings.RETURN_AS_TIMEZONE_AWARE and
+             'default' == settings.RETURN_AS_TIMEZONE_AWARE and not ptz)
+        ):
             date_obj = date_obj.replace(tzinfo=None)
 
         return date_obj, period

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -36,7 +36,7 @@ class DateParser(object):
         if settings.TO_TIMEZONE:
             date_obj = apply_timezone(date_obj, settings.TO_TIMEZONE)
 
-        if not settings.RETURN_AS_TIMEZONE_AWARE:
+        if not settings.RETURN_AS_TIMEZONE_AWARE and ptz is None:
             date_obj = date_obj.replace(tzinfo=None)
 
         return date_obj, period

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -107,7 +107,7 @@ class FreshnessDateDataParser(object):
             ):
                 date = date.replace(tzinfo=None)
 
-        # self.now = None
+        self.now = None
         return date, period
 
     def _parse_date(self, date_string):

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -8,8 +8,9 @@ from tzlocal import get_localzone
 
 from dateutil.relativedelta import relativedelta
 
-from dateparser.utils import apply_timezone, localize_timezone
+from dateparser.utils import apply_timezone, localize_timezone, strip_braces
 from .parser import time_parser
+from .timezone_parser import pop_tz_offset_from_string
 
 
 _UNITS = r'year|month|week|day|hour|minute|second'
@@ -48,6 +49,11 @@ class FreshnessDateDataParser(object):
 
         _time = self._parse_time(date_string, settings)
 
+        date_string = strip_braces(date_string)
+        date_string, ptz = pop_tz_offset_from_string(date_string)
+
+        _settings_tz = settings.TIMEZONE.lower()
+
         def apply_time(dateobj, timeobj):
             if not isinstance(_time, time):
                 return dateobj
@@ -58,20 +64,34 @@ class FreshnessDateDataParser(object):
             )
 
         if settings.RELATIVE_BASE:
-            if 'local' not in settings.TIMEZONE.lower():
-                self.now = localize_timezone(
-                    settings.RELATIVE_BASE, settings.TIMEZONE)
-            else:
-                self.now = settings.RELATIVE_BASE
-                if not self.now.tzinfo:
-                    self.now = self.get_local_tz().localize(self.now)
+            self.now = settings.RELATIVE_BASE
 
-        elif 'local' in settings.TIMEZONE.lower():
-            self.now = datetime.now(self.get_local_tz())
+            if 'local' not in _settings_tz:
+                self.now = localize_timezone(self.now, settings.TIMEZONE)
+
+            if ptz:
+                if self.now.tzinfo:
+                    self.now = self.now.astimezone(ptz)
+                else:
+                    self.now = ptz.localize(self.now)
+
+            if not self.now.tzinfo:
+                self.now = self.get_local_tz().localize(self.now)
+
+        elif ptz:
+            _now = datetime.now(ptz)
+
+            if 'local' in _settings_tz:
+                self.now = _now
+            else:
+                self.now = apply_timezone(_now, settings.TIMEZONE)
 
         else:
-            utc_dt = datetime.utcnow()
-            self.now = apply_timezone(utc_dt, settings.TIMEZONE)
+            if 'local' not in _settings_tz:
+                utc_dt = datetime.utcnow()
+                self.now = apply_timezone(utc_dt, settings.TIMEZONE)
+            else:
+                self.now = datetime.now(self.get_local_tz())
 
         date, period = self._parse_date(date_string)
 
@@ -82,10 +102,8 @@ class FreshnessDateDataParser(object):
 
             if (
                 not settings.RETURN_AS_TIMEZONE_AWARE or
-                (
-                    settings.RETURN_AS_TIMEZONE_AWARE and
-                    'default' == settings.RETURN_AS_TIMEZONE_AWARE
-                )
+                (settings.RETURN_AS_TIMEZONE_AWARE and
+                 'default' == settings.RETURN_AS_TIMEZONE_AWARE and not ptz)
             ):
                 date = date.replace(tzinfo=None)
 

--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -6,6 +6,7 @@ import unicodedata
 
 import regex as re
 import ruamel.yaml as yaml
+from tzlocal import get_localzone
 from pytz import UTC, timezone, UnknownTimeZoneError
 
 from dateparser.timezone_parser import _tz_offsets, StaticTzInfo
@@ -135,6 +136,25 @@ def apply_timezone(date_time, tz_string):
         new_datetime = apply_tzdatabase_timezone(date_time, tz_string)
 
     return new_datetime
+
+
+def apply_timezone_from_settings(date_obj, settings):
+    tz = get_localzone()
+    if settings is None:
+        return date_obj
+
+    if 'local' in settings.TIMEZONE.lower():
+        date_obj = tz.localize(date_obj)
+    else:
+        date_obj = localize_timezone(date_obj, settings.TIMEZONE)
+
+    if settings.TO_TIMEZONE:
+        date_obj = apply_timezone(date_obj, settings.TO_TIMEZONE)
+
+    if settings.RETURN_AS_TIMEZONE_AWARE is not True:
+        date_obj = date_obj.replace(tzinfo=None)
+
+    return date_obj
 
 
 def registry(cls):

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,7 +9,7 @@ from the same source.
 to control language detection behavior.
 
 The instance of :class:`DateDataParser <dateparser.date.DateDataParser>` reduces the number
-of applicable languages, until only one or no language is left. It 
+of applicable languages, until only one or no language is left. It
 assumes the previously detected language for all the subsequent dates supplied.
 
 This class wraps around the core :mod:`dateparser` functionality, and by default
@@ -54,13 +54,13 @@ Date Order
 ``PREFER_LANGUAGE_DATE_ORDER`` defaults to `True`. Most languages have a default `DATE_ORDER` specified for them. For example, for French it is `DMY`:
 
    >>> # parsing ambiguous date
-   >>> parse('02-03-2016')  # assumes english language, uses MDY date order 
+   >>> parse('02-03-2016')  # assumes english language, uses MDY date order
    datetime.datetime(2016, 3, 2, 0, 0)
    >>> parse('le 02-03-2016')  # detects french, hence, uses DMY date order
    datetime.datetime(2016, 3, 2, 0, 0)
 
 .. note:: There's no language level default `DATE_ORDER` associated with `en` language. That's why it assumes `MDY` which is :obj:``settings <dateparser.conf.settings>`` default. If the language has a default `DATE_ORDER` associated, supplying custom date order will not be applied unless we set `PREFER_LANGUAGE_DATE_ORDER` to `False`:
-   
+
     >>> parse('le 02-03-2016', settings={'DATE_ORDER': 'MDY'})
     datetime.datetime(2016, 3, 2, 0, 0)  # MDY didn't apply
 
@@ -82,7 +82,7 @@ Timezone Related Configurations
     >>> parse('January 12, 2012 10:00 PM', settings=settings)
     datetime.datetime(2012, 1, 12, 17, 0)
 
-``RETURN_AS_TIMEZONE_AWARE`` is a flag to turn on timezone aware dates if timezone is detected or specified.:
+``RETURN_AS_TIMEZONE_AWARE`` is a flag to turn on timezone aware dates:
 
     >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True})
     datetime.datetime(2015, 2, 13, 3, 56, tzinfo=<StaticTzInfo 'UTC'>)
@@ -90,13 +90,6 @@ Timezone Related Configurations
     >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': 'EST'})
     datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)
 
-    if `TIMEZONE` is set to `None` and `RETURN_AS_TIMEZONE_AWARE` to `True`, a tz aware date will only be returned if timezone is detected in the string.
-
-    >>> parse('12 Feb 2015 10:56 PM', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': None})
-    datetime.datetime(2015, 2, 12, 22, 56)
-
-    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': None})
-    datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)
 
 
 Handling Incomplete Dates
@@ -125,7 +118,7 @@ If date string is missing some part, this option ensures consistent results depe
     >>> parse('August', settings={'PREFER_DATES_FROM': 'past'})
     datetime.datetime(2015, 8, 15, 0, 0)
 
-``RELATIVE_BASE`` allows setting the base datetime to use for interpreting partial or relative date strings. 
+``RELATIVE_BASE`` allows setting the base datetime to use for interpreting partial or relative date strings.
 Defaults to the current date and time.
 
 For example, assuming current date is `June 16, 2015`:
@@ -154,4 +147,3 @@ Language Detection
     >>> from dateparser.date import DateDataParser
     >>> DateDataParser(settings={'SKIP_TOKENS': ['de']}).get_date_data(u'27 Haziran 1981 de')  # Turkish (at 27 June 1981)
     {'date_obj': datetime.datetime(1981, 6, 27, 0, 0), 'period': 'day'}
-

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,6 +71,7 @@ Date Order
 Timezone Related Configurations
 +++++++++++++++++++++++++++++++
 
+
 ``TIMEZONE`` defaults to local timezone. When specified, resultant :class:`datetime <datetime.datetime>` is localized with the given timezone.
 
     >>> parse('January 12, 2012 10:00 PM', settings={'TIMEZONE': 'US/Eastern'})
@@ -82,13 +83,13 @@ Timezone Related Configurations
     >>> parse('January 12, 2012 10:00 PM', settings=settings)
     datetime.datetime(2012, 1, 12, 17, 0)
 
-``RETURN_AS_TIMEZONE_AWARE`` is a flag to turn on timezone aware dates:
+``RETURN_AS_TIMEZONE_AWARE`` is a flag to toggle between timezone aware/naive dates:
 
-    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True})
-    datetime.datetime(2015, 2, 13, 3, 56, tzinfo=<StaticTzInfo 'UTC'>)
+    >>> parse('30 mins ago', settings={'RETURN_AS_TIMEZONE_AWARE': True})
+    datetime.datetime(2017, 3, 13, 1, 43, 10, 243565, tzinfo=<DstTzInfo 'Asia/Karachi' PKT+5:00:00 STD>)
 
-    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': 'EST'})
-    datetime.datetime(2015, 2, 12, 22, 56, tzinfo=<StaticTzInfo 'EST'>)
+    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': False})
+    datetime.datetime(2015, 2, 12, 22, 56)
 
 
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -16,6 +16,7 @@ from dateparser import date
 from dateparser.date import get_last_day_of_month
 from dateparser.languages.loader import LanguageDataLoader
 from dateparser.languages.loader import default_language_loader
+from dateparser.conf import settings
 
 from tests import BaseTestCase
 
@@ -269,7 +270,7 @@ class TestParseWithFormatsFunction(BaseTestCase):
         self.add_patch(patch('dateparser.date.datetime', new=datetime_mock))
 
     def when_date_is_parsed_with_formats(self, date_string, date_formats):
-        self.result = date.parse_with_formats(date_string, date_formats)
+        self.result = date.parse_with_formats(date_string, date_formats, settings)
 
     def then_date_was_not_parsed(self):
         self.assertIsNotNone(self.result)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -404,6 +404,7 @@ class TestDateDataParser(BaseTestCase):
         self.when_date_string_is_parsed(date_string)
         self.then_date_was_parsed()
         self.then_period_is('day')
+        self.result['date_obj'] = self.result['date_obj'].replace(tzinfo=None)
         self.then_parsed_datetime_is(expected_result)
 
     @parameterized.expand([

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -211,12 +211,12 @@ class TestDateParser(BaseTestCase):
         param('[Sept] 04, 2014.', datetime(2014, 9, 4)),
         param('Tuesday Jul 22, 2014', datetime(2014, 7, 22)),
         param('Tues 9th Aug, 2015', datetime(2015, 8, 9)),
-        param('10:04am EDT', datetime(2012, 11, 13, 10, 4)),
+        param('10:04am', datetime(2012, 11, 13, 10, 4)),
         param('Friday', datetime(2012, 11, 9)),
         param('November 19, 2014 at noon', datetime(2014, 11, 19, 12, 0)),
         param('December 13, 2014 at midnight', datetime(2014, 12, 13, 0, 0)),
-        param('Nov 25 2014 10:17 pm EST', datetime(2014, 11, 25, 22, 17)),
-        param('Wed Aug 05 12:00:00 EDT 2015', datetime(2015, 8, 5, 12, 0)),
+        param('Nov 25 2014 10:17 pm', datetime(2014, 11, 25, 22, 17)),
+        param('Wed Aug 05 12:00:00 2015', datetime(2015, 8, 5, 12, 0)),
         param('April 9, 2013 at 6:11 a.m.', datetime(2013, 4, 9, 6, 11)),
         param('Aug. 9, 2012 at 2:57 p.m.', datetime(2012, 8, 9, 14, 57)),
         param('December 10, 2014, 11:02:21 pm', datetime(2014, 12, 10, 23, 2, 21)),
@@ -381,12 +381,12 @@ class TestDateParser(BaseTestCase):
         # English dates
         param('[Sept] 04, 2014.', datetime(2014, 9, 4)),
         param('Tuesday Jul 22, 2014', datetime(2014, 7, 22)),
-        param('10:04am EDT', datetime(2012, 11, 13, 10, 4)),
+        param('10:04am', datetime(2012, 11, 13, 10, 4)),
         param('Friday', datetime(2012, 11, 9)),
         param('November 19, 2014 at noon', datetime(2014, 11, 19, 12, 0)),
         param('December 13, 2014 at midnight', datetime(2014, 12, 13, 0, 0)),
-        param('Nov 25 2014 10:17 pm EST', datetime(2014, 11, 25, 22, 17)),
-        param('Wed Aug 05 12:00:00 EDT 2015', datetime(2015, 8, 5, 12, 0)),
+        param('Nov 25 2014 10:17 pm', datetime(2014, 11, 25, 22, 17)),
+        param('Wed Aug 05 12:00:00 2015', datetime(2015, 8, 5, 12, 0)),
         param('April 9, 2013 at 6:11 a.m.', datetime(2013, 4, 9, 6, 11)),
         param('Aug. 9, 2012 at 2:57 p.m.', datetime(2012, 8, 9, 14, 57)),
         param('December 10, 2014, 11:02:21 pm', datetime(2014, 12, 10, 23, 2, 21)),
@@ -539,6 +539,7 @@ class TestDateParser(BaseTestCase):
         self.when_date_is_parsed(date_string)
         self.then_date_was_parsed_by_date_parser()
         self.then_period_is('day')
+        self.then_timezone_parsed_is('UTC')
         self.then_date_obj_exactly_is(expected)
 
     @parameterized.expand([
@@ -554,6 +555,7 @@ class TestDateParser(BaseTestCase):
         self.when_date_is_parsed(date_string)
         self.then_date_was_parsed_by_date_parser()
         self.then_period_is('day')
+        self.then_timezone_parsed_is('UTC')
         self.then_date_obj_exactly_is(expected)
 
     def test_empty_dates_string_is_not_parsed(self):
@@ -702,6 +704,7 @@ class TestDateParser(BaseTestCase):
         self.given_parser(languages=languages, settings={'PREFER_LANGUAGE_DATE_ORDER': False})
         self.when_date_is_parsed(date_string)
         self.then_date_was_parsed_by_date_parser()
+        self.result['date_obj'] = self.result['date_obj'].replace(tzinfo=None)
         self.then_date_obj_exactly_is(expected)
 
     @parameterized.expand([
@@ -797,6 +800,10 @@ class TestDateParser(BaseTestCase):
     def then_date_was_parsed_by_date_parser(self):
         self.assertNotEqual(NotImplemented, self.date_result, "Date was not parsed")
         self.assertEqual(self.result['date_obj'], self.date_result[0])
+
+    def then_timezone_parsed_is(self, tzstr):
+        self.assertTrue(tzstr in self.result['date_obj'].tzinfo.tzname(''))
+        self.result['date_obj'] = self.result['date_obj'].replace(tzinfo=None)
 
 
 if __name__ == '__main__':

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -751,7 +751,7 @@ class TestDateParser(BaseTestCase):
     ])
     def test_parse_timestamp(self, date_string, expected):
         self.given_local_tz_offset(0)
-        self.given_parser()
+        self.given_parser(settings={'TO_TIMEZONE': 'UTC'})
         self.when_date_is_parsed(date_string)
         self.then_date_obj_exactly_is(expected)
 

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -569,7 +569,7 @@ class TestDateParser(BaseTestCase):
         param('Fri, 09 Sep 2005 13:51:39 +0000', 'GMT', datetime(2005, 9, 9, 13, 51, 39)),
     ])
     def test_dateparser_shoult_return_date_in_setting_timezone_if_timezone_info_present_both_in_datestring_and_given_in_settings(self, date_string, setting_timezone, expected):
-        self.given_parser(settings={'TO_TIMEZONE': setting_timezone})
+        self.given_parser(settings={'TIMEZONE': setting_timezone})
         self.when_date_is_parsed(date_string)
         self.then_date_was_parsed_by_date_parser()
         self.then_period_is('day')

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -15,6 +15,7 @@ from dateparser.date import DateDataParser, date_parser
 from dateparser.date_parser import DateParser
 from dateparser.languages import default_language_loader
 from dateparser.languages.detection import AutoDetectLanguage, ExactLanguages
+from dateparser.timezone_parser import StaticTzInfo
 from dateparser.conf import settings
 from dateparser.utils import normalize_unicode
 
@@ -746,7 +747,7 @@ class TestDateParser(BaseTestCase):
         param('1484823450', expected=datetime(2017, 1, 19, 10, 57, 30)),
         param('1436745600000', expected=datetime(2015, 7, 13, 0, 0)),
         param('1015673450', expected=datetime(2002, 3, 9, 11, 30, 50)),
-        param('2016-09-23T02:54:32.845Z', expected=datetime(2016, 9, 23, 2, 54, 32, 845000))
+        param('2016-09-23T02:54:32.845Z', expected=datetime(2016, 9, 23, 2, 54, 32, 845000, tzinfo=StaticTzInfo('Z', timedelta(0))))
     ])
     def test_parse_timestamp(self, date_string, expected):
         self.given_local_tz_offset(0)

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -777,22 +777,18 @@ class TestFreshnessDateDataParser(BaseTestCase):
         self.then_time_is(time)
 
     def test_freshness_date_with_to_timezone_setting(self):
-        fp_mock = Mock(wraps=dateparser.freshness_date_parser.FreshnessDateDataParser)
-        fp_mock.get_local_tz = Mock(return_value=pytz.timezone('Asia/Karachi'))
+        _settings = settings.replace(**{
+            'TIMEZONE': 'local',
+            'TO_TIMEZONE': 'UTC',
+            'RELATIVE_BASE': datetime(2014, 9, 1, 10, 30)
+        })
 
-        parser = fp_mock()
-        result = parser.get_date_data(
-            '1 minute ago', settings=settings.replace(
-                **{
-                    'TIMEZONE': 'local',
-                    'TO_TIMEZONE': 'UTC',
-                    'RELATIVE_BASE': datetime(2014, 9, 1, 10, 30),
-                }
-            )
-        )
+        parser = dateparser.freshness_date_parser.FreshnessDateDataParser()
+        parser.get_local_tz = Mock(return_value=pytz.timezone('US/Eastern'))
+        result = parser.get_date_data('1 minute ago', _settings)
         result = result['date_obj']
         self.assertEqual(result.date(), date(2014, 9, 1))
-        self.assertEqual(result.time(), time(5, 29))
+        self.assertEqual(result.time(), time(14, 29))
 
     @parameterized.expand([
         param('2 hours ago', 'PKT', date(2014, 9, 1), time(13, 30)),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,26 +25,14 @@ class TimeZoneSettingsTest(BaseTestCase):
         self.confs = NotImplemented
 
     @parameterized.expand([
-        param('12 Feb 2015 10:30 PM +0100', datetime(2015, 2, 12, 21, 30)),
-        param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 21, 30)),
-        param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 15, 30)),
-        param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 13, 1, 30)),
-        ])
-    def test_should_return_tz_aware_dates(self, ds, dt):
-        self.given(ds)
-        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': True, 'TO_TIMEZONE': 'UTC'})
-        self.when_date_is_parsed()
-        self.then_date_is_tz_aware()
-        self.then_date_is(dt)
-
-    @parameterized.expand([
+        param('12 Feb 2015 10:30 PM +0100', datetime(2015, 2, 12, 22, 30), 'UTC\+01:00'),
         param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 16, 30), 'EST'),
         param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 20, 30), 'PKT'),
         param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 12, 20, 30), 'ACT'),
         ])
     def test_should_return_and_assert_tz(self, ds, dt, tz):
         self.given(ds)
-        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': True, 'TIMEZONE': tz})
+        self.given_configurations({})
         self.when_date_is_parsed()
         self.then_date_is_tz_aware()
         self.then_date_is(dt)
@@ -54,10 +42,11 @@ class TimeZoneSettingsTest(BaseTestCase):
         param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 16, 30), 'EST'),
         param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 20, 30), 'PKT'),
         param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 12, 20, 30), 'ACT'),
+        param('12 Feb 2015 8:30 PM', datetime(2015, 2, 12, 20, 30), ''),
         ])
     def test_only_return_explicit_timezone(self, ds, dt, tz):
         self.given(ds)
-        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': True})
+        self.given_configurations({})
         self.when_date_is_parsed()
         self.then_date_is(dt)
         if tz:
@@ -65,6 +54,19 @@ class TimeZoneSettingsTest(BaseTestCase):
             self.then_timezone_is(tz)
         else:
             self.then_date_is_not_tz_aware()
+
+    @parameterized.expand([
+        param('12 Feb 2015 4:30 PM EST', datetime(2015, 2, 12, 16, 30),),
+        param('12 Feb 2015 8:30 PM PKT', datetime(2015, 2, 12, 20, 30),),
+        param('12 Feb 2015 8:30 PM ACT', datetime(2015, 2, 12, 20, 30),),
+        param('12 Feb 2015 8:30 PM +0100', datetime(2015, 2, 12, 20, 30),),
+        ])
+    def test_should_return_naive_if_RETURN_AS_TIMEZONE_AWARE_IS_FALSE(self, ds, dt):
+        self.given(ds)
+        self.given_configurations({'RETURN_AS_TIMEZONE_AWARE': False})
+        self.when_date_is_parsed()
+        self.then_date_is(dt)
+        self.then_date_is_not_tz_aware()
 
     def then_timezone_is(self, tzname):
         self.assertEqual(self.result.tzinfo.tzname(''), tzname)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,7 @@ from dateparser.conf import apply_settings
 
 from dateparser import parse
 
+
 def test_function(settings=None):
     return settings
 
@@ -72,7 +73,10 @@ class TimeZoneSettingsTest(BaseTestCase):
         self.given_ds = ds
 
     def given_configurations(self, confs):
-        self.confs = confs
+        if 'TIMEZONE' not in confs:
+            confs.update({'TIMEZONE': 'local'})
+
+        self.confs = settings.replace(**confs)
 
     def when_date_is_parsed(self):
         self.result = parse(self.given_ds, settings=(self.confs or {}))


### PR DESCRIPTION
If come across a timezone/utc-offset in string, dateparser returns tzware dates by default without having to set RETURN_AS_TIMEZONE_AWARE. Nainve dates can be returned by setting the said flag to false.

If a string has tz/offset and `TIMEZONE` setting is specified, dateparser parse tzaware date and convert it to timezone given in the settings.

fixes #278, #286, #242 