### PR TITLE
changed parse behaviour when TIMEZONE is None

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -51,6 +51,9 @@ class Settings(object):
             setattr(self, key, value)
 
     def replace(self, **kwds):
+        if 'TIMEZONE' in kwds and kwds['TIMEZONE'] is None:
+            del kwds['TIMEZONE']
+
         for k, v in six.iteritems(kwds):
             if v is None:
                 raise TypeError('Invalid {{"{}": {}}}'.format(k, v))

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -30,6 +30,8 @@ class DateParser(object):
         elif 'local' in settings.TIMEZONE.lower():
             stz = get_localzone()
             date_obj = stz.localize(date_obj)
+            if settings.RETURN_AS_TIMEZONE_AWARE:
+                date_obj = date_obj.replace(tzinfo=None)
         else:
             date_obj = localize_timezone(date_obj, settings.TIMEZONE)
 


### PR DESCRIPTION
When **RETURN_AS_TIMEZONE_AWARE** is  **True** and **TIMEZONE** is **None**, function parse gives error **TypeError('Invalid {{"{}": {}}}'.format(k, v)) TypeError: Invalid {"TIMEZONE": None}**. But as mentioned in latest docs _**if TIMEZONE is set to None and RETURN_AS_TIMEZONE_AWARE to True, a tz aware date will only be returned if timezone is detected in the string**_. It is related to issue #278 . 







