### PR TITLE
Parsing completely invalid or unsupported dates should not give current date

### DIFF
--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -27,7 +27,10 @@ class DateParser(object):
 
         _settings_tz = settings.TIMEZONE.lower()
 
-        if ptz:
+        if date_obj is None:
+            return date_obj, period
+        
+        elif ptz:
             date_obj = ptz.localize(date_obj)
             if 'local' not in _settings_tz:
                 date_obj = apply_timezone(date_obj, settings.TIMEZONE)

--- a/dateparser/languages/language.py
+++ b/dateparser/languages/language.py
@@ -50,8 +50,6 @@ class Language(object):
             word = word.lower()
             if word in dictionary:
                 words[i] = dictionary[word] or ''
-            elif re.match('^\W+$',word):
-                raise ValueError('Invalid date string')
         if "in" in words:
             words = self._clear_future_words(words)
 

--- a/dateparser/languages/language.py
+++ b/dateparser/languages/language.py
@@ -50,6 +50,8 @@ class Language(object):
             word = word.lower()
             if word in dictionary:
                 words[i] = dictionary[word] or ''
+            elif not re.match('^\d+$',word):
+                raise ValueError('Invalid date string')
         if "in" in words:
             words = self._clear_future_words(words)
 

--- a/dateparser/languages/language.py
+++ b/dateparser/languages/language.py
@@ -50,7 +50,7 @@ class Language(object):
             word = word.lower()
             if word in dictionary:
                 words[i] = dictionary[word] or ''
-            elif not re.match('^\d+$',word):
+            elif re.match('^\W+$',word):
                 raise ValueError('Invalid date string')
         if "in" in words:
             words = self._clear_future_words(words)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -203,7 +203,7 @@ class _parser(object):
     def __init__(self, tokens, settings):
         self.settings = settings
         self.tokens = list(tokens)
-        self.filtered_tokens = [t for t in self.tokens if int(t[1]) <= 1]
+        self.filtered_tokens = [t for t in self.tokens if t[1] <= 1]
 
         self.unset_tokens = []
 
@@ -554,7 +554,7 @@ class tokenizer(object):
         if self._isnonword(chara):
             return 2, not self._isnonword(charb)
 
-        return '', True
+        return 3, True
 
     def tokenize(self):
         token = ''

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -203,7 +203,7 @@ class _parser(object):
     def __init__(self, tokens, settings):
         self.settings = settings
         self.tokens = list(tokens)
-        self.filtered_tokens = [t for t in self.tokens if t[1] <= 1]
+        self.filtered_tokens = [t for t in self.tokens if int(t[1]) <= 1]
 
         self.unset_tokens = []
 

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -452,6 +452,8 @@ class _parser(object):
     def parse(cls, datestring, settings):
         tokens = tokenizer(datestring)
         po = cls(tokens.tokenize(), settings)
+        if not po.filtered_tokens:
+            return None,None
         dateobj = po._results()
 
         # correction for past, future if applicable

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -431,6 +431,17 @@ class TestDateDataParser(BaseTestCase):
         self.then_period_is('day')
         self.then_parsed_datetime_is(expected_result)
 
+    @parameterized.expand([
+    param(date_string="੨੦੧੭-੦੧-੧੬",languages=['en','es','he','hi','bn','be','ar','fr','fi']),
+    param(date_string="१४-२",languages=['en','es','he']),
+    param(date_string="႐႑႒",languages=['bn','be','ar','fr','fi']),
+    param(date_string="౨౩౪",languages=['bn','be','ar','fr','fi','bg','pt']),
+    ])
+    def test_dates_with_numerals_in_other_languages_are_not_parsed(self, date_string, languages):
+        self.given_parser(languages=languages)
+        self.when_date_string_is_parsed(date_string)
+        self.then_date_is_not_parsed()
+
     def given_now(self, year, month, day, **time):
         datetime_mock = Mock(wraps=datetime)
         datetime_mock.utcnow = Mock(return_value=datetime(year, month, day, **time))
@@ -503,6 +514,9 @@ class TestDateDataParser(BaseTestCase):
 
     def then_parsed_date_has_timezone(self):
         self.assertTrue(hasattr(self.result['date_obj'], 'tzinfo'))
+
+    def then_date_is_not_parsed(self):
+        self.assertIsNone(self.result['date_obj'])
 
 
 class TestParserInitialization(BaseTestCase):

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -434,8 +434,8 @@ class TestDateDataParser(BaseTestCase):
     @parameterized.expand([
     param(date_string="੨੦੧੭-੦੧-੧੬",languages=['en','es','he','hi','bn','be','ar','fr','fi']),
     param(date_string="१४-२",languages=['en','es','he']),
-    param(date_string="႐႑႒",languages=['bn','be','ar','fr','fi']),
-    param(date_string="౨౩౪",languages=['bn','be','ar','fr','fi','bg','pt']),
+    param(date_string="႐႑-႒",languages=['bn','be','ar','fr','fi']),
+    param(date_string="౨౩-౪",languages=['bn','be','ar','fr','fi','bg','pt']),
     ])
     def test_dates_with_numerals_in_other_languages_are_not_parsed(self, date_string, languages):
         self.given_parser(languages=languages)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -436,6 +436,10 @@ class TestDateDataParser(BaseTestCase):
     param(date_string="१४-२",languages=['en','es','he']),
     param(date_string="႐႑-႒",languages=['bn','be','ar','fr','fi']),
     param(date_string="౨౩-౪",languages=['bn','be','ar','fr','fi','bg','pt']),
+    param(date_string="੨੦੧੭੦੧੧੬",languages=['en','es','he','hi','bn','be','ar','fr','fi']),
+    param(date_string="१४२",languages=['en','es','he']),
+    param(date_string="႐႑႒",languages=['bn','be','ar','fr','fi']),
+    param(date_string="౨౩౪",languages=['bn','be','ar','fr','fi','bg','pt']),    
     ])
     def test_dates_with_numerals_in_other_languages_are_not_parsed(self, date_string, languages):
         self.given_parser(languages=languages)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -160,7 +160,7 @@ class TestNoSpaceParser(BaseTestCase):
 
     def then_date_exactly_is(self, expected_date):
         self.assertEqual(self.result[0], expected_date)
-    
+
     def then_period_exactly_is(self, expected_period):
         self.assertEqual(self.result[1], expected_period)
 
@@ -182,6 +182,16 @@ class TestParser(BaseTestCase):
         self.given_settings(settings={'STRICT_PARSING': True})
         self.then_error_is_raised_when_date_is_parsed(date_string)
 
+    @parameterized.expand([
+    param(date_string=u"@@@##$@!@!"),
+    param(date_string=u"@-@-@"),
+    param(date_string=u"@@-#$##"),
+    ])
+    def test_completely_invalid_dates_are_not_parsed(self, date_string):
+        self.given_parser()
+        self.when_date_is_parsed(date_string)
+        self.then_date_is_not_parsed()
+
     def given_parser(self):
         self.parser = _parser
 
@@ -192,6 +202,13 @@ class TestParser(BaseTestCase):
     def then_error_is_raised_when_date_is_parsed(self, date_string):
         with self.assertRaises(ValueError):
             self.parser.parse(date_string, self.settings)
+
+    @apply_settings
+    def when_date_is_parsed(self, date_string, settings = None):
+        self.result = self.parser.parse(date_string, settings)
+
+    def then_date_is_not_parsed(self):
+        self.assertIsNone(self.result[0])
 
 
 class TestTimeParser(BaseTestCase):


### PR DESCRIPTION
Attempted to resolve issue #275 by adding error statement in the case where date string is invalid with respect to current language support.