### PR TITLE
Version 0.14 of ruamel.yaml causes an import error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'python-dateutil',
-        'ruamel.yaml',
+        'ruamel.yaml<0.14',
         'pytz',
         'regex',
         'tzlocal',


### PR DESCRIPTION
 I'll include the text in a new issue. Using an earlier version fixes the issue, which the PR will make the setup do. I see there is a branch for pinned version in requirements, and that seems like a much better long term strategy for package stability. Thanks for your efforts! 👍 