### PR TITLE
possible fix of 'ago' problem in Russian

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -22,6 +22,10 @@ class FreshnessDateDataParser(object):
     def __init__(self):
         self.now = None
 
+    def remove_wrong_kwargs_from_string(self, date_string):
+        date_string = re.sub('(?:^\d+\s+)(year)$', '', date_string)
+        return date_string
+
     def _are_all_words_units(self, date_string):
         skip = [_UNITS,
                 r'ago|in|\d+',
@@ -93,7 +97,7 @@ class FreshnessDateDataParser(object):
             else:
                 self.now = datetime.now(self.get_local_tz())
 
-        date, period = self._parse_date(date_string)
+        date, period = self._parse_date(self.remove_wrong_kwargs_from_string(date_string))
 
         if date:
             date = apply_time(date, _time)


### PR DESCRIPTION
'_2000 год_' in Russian is '_year 2000_'
Before was parsed as '_2000 years ago_'
``` 
parse('2000 год')
datetime.datetime(17, 8, 3, 18, 44, 48, 222615)
```
After
``` 
parse('2000 год')
datetime.datetime(2000, 8, 3, 0, 0)
```
