### PR TITLE
s/nose_parameterized/parameterized

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 mock
 nose
-nose-parameterized
+parameterized
 six
 coverage

--- a/tests/test_clean_api.py
+++ b/tests/test_clean_api.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from datetime import date, datetime
 
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 import dateparser
 from tests import BaseTestCase

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from itertools import chain
 import regex as re
 import six
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from dateparser.languages import default_loader
 from dateparser.data import language_locale_dict

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 
 from mock import Mock, patch
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 import six
 
 import dateparser

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from functools import wraps
 
 from mock import patch, Mock
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 import dateparser.timezone_parser
 from dateparser.date import DateDataParser, date_parser

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -8,7 +8,7 @@ import pytz
 
 from dateutil.relativedelta import relativedelta
 from mock import Mock, patch
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 import dateparser
 from dateparser.date import DateDataParser, freshness_date_parser

--- a/tests/test_hijri.py
+++ b/tests/test_hijri.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import six
 import unittest
 
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 # umalqurra does not support Python3 yet
 # see https://github.com/tytkal/python-hijiri-ummalqura/pull/5

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from datetime import datetime
 
 from dateparser.calendars.jalali import JalaliCalendar

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from io import StringIO
 
 import logging
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 from dateparser.languages import default_loader, Locale
 from dateparser.languages.validation import LanguageValidator

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from operator import attrgetter
 import six
 import regex as re

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,6 @@
 from datetime import datetime, time
 
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from tests import BaseTestCase
 
 from dateparser.parser import tokenizer

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,6 @@
 ﻿# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from tests import BaseTestCase
 from dateparser.search.search import DateSearchWithDetection
 from dateparser.search import search_dates

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from datetime import datetime, tzinfo
 
 from tests import BaseTestCase

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timedelta
 
 from mock import Mock, patch
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 import dateparser.timezone_parser
 from dateparser.timezone_parser import pop_tz_offset_from_string, get_local_tz_offset

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import itertools
 
 from datetime import datetime
 from tests import BaseTestCase
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from dateparser.utils import (
     find_date_separator, localize_timezone, apply_timezone,
     apply_timezone_from_settings, registry

--- a/tests/test_utils_strptime.py
+++ b/tests/test_utils_strptime.py
@@ -1,5 +1,5 @@
 import locale
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from datetime import datetime
 
 from tests import BaseTestCase


### PR DESCRIPTION
"The nose-parameterized package is deprecated and has been renamed to parameterized."
I simply followed the instructions from https://pypi.python.org/pypi/nose-parameterized.