### PR TITLE
Fix History formatting, not well readable on Github

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,25 +7,29 @@ History
 ------------------
 
 Features added during Google Summer of Code 2017:
+
 * Harvesting language data from Unicode CLDR database (https://github.com/unicode-cldr/cldr-json), which includes over 200 locales (#321) - authored by Sarthak Maddan.
-See full currently supported locale list in README.
+  See full currently supported locale list in README.
 * Extracting dates from longer strings of text (#324) - authored by Elena Zakharova.
-Special thanks for their awesome contributions!
+  Special thanks for their awesome contributions!
 
 
 New features:
+
 * Added (independently from CLDR) Georgian (#308) and Swedish (#305)
 
 Improvements:
+
 * Improved support of Chinese (#359), Thai (#345), French (#301, #304), Russian (#302)
 * Removed ruamel.yaml from dependencies (#374). This should reduce the number of installation issues and improve performance as the result of moving away from YAML as basic data storage format.
-Note that YAML is still used as format for support language files.
+  Note that YAML is still used as format for support language files.
 * Improved performance through using pre-compiling frequent regexes and lazy loading of data (#293, #294, #295, #315)
 * Extended tests (#316, #317, #318, #323)
 * Updated nose_parameterized to its current package, parameterized (#381)
 
 
 Planned for next release:
+
 * Full language and locale names
 * Performance and stability improvements
 * Documentation improvements
@@ -35,6 +39,7 @@ Planned for next release:
 ------------------
 
 New features:
+
 * Consistent parsing in terms of true python representation of date string. See #281
 * Added support for Bangla, Bulgarian and Hindi languages.
 
@@ -46,6 +51,7 @@ Improvements:
 * Improved support for cn, es, dutch languages. See #274, #272, #285
 
 Packaging:
+
 * Make calendars extras to be used at the time of installation if need to use calendars feature.
 
 
@@ -66,6 +72,7 @@ Improvements:
 
 0.5.0 (2016-09-26)
 ------------------
+
 New features:
 
 * `DateDataParser` now also returns detected language in the result dictionary.
@@ -82,6 +89,7 @@ Improvements:
 
 0.4.0 (2016-06-17)
 ------------------
+
 New features:
 
 * Support for Language based date order preference while parsing ambiguous dates.
@@ -101,6 +109,7 @@ Improvements:
 
 0.3.5 (2016-04-27)
 ------------------
+
 New features:
 
 * Danish language support.
@@ -120,12 +129,14 @@ Improvements:
 
 0.3.4 (2016-03-03)
 ------------------
+
 Improvements:
 
 * Fixed broken version 0.3.3 by excluding latest python-dateutil version.
 
 0.3.3 (2016-02-29)
 ------------------
+
 New features:
 
 * Finnish language support.
@@ -138,6 +149,7 @@ Improvements:
 
 0.3.2 (2016-01-25)
 ------------------
+
 New features:
 
 * Added Hijri Calendar support.
@@ -154,6 +166,7 @@ Improvements:
 
 0.3.1 (2015-10-28)
 ------------------
+
 New features:
 
 * Support for Jalali Calendar.
@@ -170,6 +183,7 @@ Improvements:
 
 0.3.0 (2015-07-29)
 ------------------
+
 New features:
 
 * Compatibility with Python 3 and PyPy.
@@ -182,6 +196,7 @@ Improvements:
 
 0.2.1 (2015-07-13)
 ------------------
+
 * Support for generic parsing of dates with UTC offset.
 * Support for Tagalog/Filipino dates.
 * Improved support for French and Spanish dates.
@@ -189,6 +204,7 @@ Improvements:
 
 0.2.0 (2015-06-17)
 ------------------
+
 * Easy to use `parse` function
 * Languages definitions using YAML.
 * Using translation based approach for parsing non-english languages. Previously, :mod:`dateutil.parserinfo` was used for language definitions.


### PR DESCRIPTION
While checking the changelog to see what changed recently, I found it hard to parse on Github. 
It's because RST is a bit picky regarding vertical spacing, and adding a few blank lines should fix it.