### PR TITLE
Fix: 'Week' and 'Sunday' problem in ID locale

### DIFF
--- a/dateparser/data/date_translation_data/id.py
+++ b/dateparser/data/date_translation_data/id.py
@@ -95,7 +95,6 @@ info = {
         "bln"
     ],
     "week": [
-        "minggu",
         "mgg"
     ],
     "day": [
@@ -202,7 +201,8 @@ info = {
         ],
         "\\1 week ago": [
             "(\\d+) minggu yang lalu",
-            "(\\d+) mgg lalu"
+            "(\\d+) mgg lalu",
+            "(\\d+) minggu lalu"
         ],
         "in \\1 day": [
             "dalam (\\d+) hari",
@@ -234,6 +234,9 @@ info = {
         "\\1 second ago": [
             "(\\d+) detik yang lalu",
             "(\\d+) dtk lalu"
+        ],
+        "\\1 week": [
+            "(\\d+) minggu"
         ]
     },
     "locale_specific": {},

--- a/dateparser_data/cldr_language_data/date_translation_data/id.json
+++ b/dateparser_data/cldr_language_data/date_translation_data/id.json
@@ -91,7 +91,6 @@
         "bln"
     ],
     "week": [
-        "minggu",
         "mgg"
     ],
     "day": [

--- a/dateparser_data/supplementary_language_data/date_translation_data/id.yaml
+++ b/dateparser_data/supplementary_language_data/date_translation_data/id.yaml
@@ -28,3 +28,9 @@ relative-type:
         - sehari
     0 second ago:
         - baru saja
+
+relative-type-regex:
+    \1 week ago:
+        - (\d+) minggu lalu
+    \1 week:
+        - (\d+) minggu

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -103,9 +103,13 @@ class TestBundledLanguages(BaseTestCase):
         # Tagalog
         param('tl', "Biyernes Hulyo 3, 2015", "friday july 3 2015"),
         param('tl', "Pebrero 5, 2015 7:00 pm", "february 5 2015 7:00 pm"),
+
         # Indonesian
         param('id', "06 Sep 2015", "06 september 2015"),
         param('id', "07 Feb 2015 20:15", "07 february 2015 20:15"),
+        param('id', "Minggu, 18 Mar 2018 07:30", "sunday 18 march 2018 07:30"),
+        param('id', "3 minggu yang lalu", "3 week ago"),
+        param('id', "5 minggu", "5 week"),
 
         # Miscellaneous
         param('en', "2014-12-12T12:33:39-08:00", "2014-12-12 12:33:39-08:00"),


### PR DESCRIPTION
Add new rule for 'week' and remove existing 'week' translation from Indonesia (id)
This should fix #398

Translation removed:
`week`: `minggu`
reason: in Indonesia language, `minggu` as standalone word is more likely to be translated into `sunday`

Rule added:
\1 week ago:
  - (\d+) minggu lalu
\1 week:
  - (\d+) minggu
reason: to mitigate the missing translation of week, I've hard-coded the most probable sentence which the word `minggu` translated as `week`