### PR TITLE
Faster parsing of invalid inputs when no locale is given

### DIFF
--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -19,6 +19,7 @@ KNOWN_WORD_TOKENS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday',
 
 PARENTHESES_PATTERN = re.compile(r'[\(\)]')
 NUMERAL_PATTERN = re.compile(r'(\d+)')
+KEEP_TOKEN_PATTERN = re.compile(r"^.*[^\W_].*$", flags=re.U)
 
 
 class UnknownTokenError(Exception):
@@ -170,7 +171,7 @@ class Dictionary(object):
         return (
             keep_formatting or
             (token in ALWAYS_KEEP_TOKENS) or
-            re.match(r"^.*[^\W_].*$", token, re.U)
+            KEEP_TOKEN_PATTERN.match(token)
         )
 
     def _get_sorted_words_from_cache(self):

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -178,9 +178,9 @@ class Dictionary(object):
                 self._settings.registry_key not in self._sorted_words_cache or
                 self.info['name'] not in self._sorted_words_cache[self._settings.registry_key]
            ):
-            self._sorted_words_cache[self._settings.registry_key] = {
-                self.info['name']: sorted([key for key in self], key=len, reverse=True)
-            }
+            self._sorted_words_cache.setdefault(
+                self._settings.registry_key, {})[self.info['name']] = \
+                sorted([key for key in self], key=len, reverse=True)
         return self._sorted_words_cache[self._settings.registry_key][self.info['name']]
 
     def _get_split_regex_cache(self):
@@ -197,9 +197,9 @@ class Dictionary(object):
             regex = r"^(.*?)({})(.*)$".format(known_words_group)
         else:
             regex = r"^(.*?(?:\A|\W|_|\d))({})((?:\Z|\W|_|\d).*)$".format(known_words_group)
-        self._split_regex_cache[self._settings.registry_key] = {
-            self.info['name']: re.compile(regex, re.UNICODE | re.IGNORECASE)
-        }
+        self._split_regex_cache.setdefault(
+            self._settings.registry_key, {})[self.info['name']] = \
+            re.compile(regex, re.UNICODE | re.IGNORECASE)
 
     def _get_sorted_relative_strings_from_cache(self):
         if (
@@ -207,10 +207,10 @@ class Dictionary(object):
             self.info['name'] not in self._sorted_relative_strings_cache[self._settings.registry_key]
            ):
 
-            self._sorted_relative_strings_cache[self._settings.registry_key] = {
-                self.info['name']: sorted([PARENTHESES_PATTERN.sub('', key) for key in
-                                          self._relative_strings], key=len, reverse=True)
-            }
+            self._sorted_relative_strings_cache.setdefault(
+                self._settings.registry_key, {})[self.info['name']] = \
+                sorted([PARENTHESES_PATTERN.sub('', key) for key in
+                        self._relative_strings], key=len, reverse=True)
         return self._sorted_relative_strings_cache[self._settings.registry_key][self.info['name']]
 
     def _get_split_relative_regex_cache(self):
@@ -228,9 +228,9 @@ class Dictionary(object):
             regex = "({})".format(known_relative_strings_group)
         else:
             regex = "(?<=(?:\\A|\\W|_))({})(?=(?:\\Z|\\W|_))".format(known_relative_strings_group)
-        self._split_relative_regex_cache[self._settings.registry_key] = {
-            self.info['name']: re.compile(regex, re.UNICODE | re.IGNORECASE)
-        }
+        self._split_relative_regex_cache.setdefault(
+            self._settings.registry_key, {})[self.info['name']] = \
+            re.compile(regex, re.UNICODE | re.IGNORECASE)
 
     def _get_match_relative_regex_cache(self):
         if (
@@ -244,9 +244,9 @@ class Dictionary(object):
     def _construct_match_relative_regex(self):
         known_relative_strings_group = "|".join(self._get_sorted_relative_strings_from_cache())
         regex = "^({})$".format(known_relative_strings_group)
-        self._match_relative_regex_cache[self._settings.registry_key] = {
-            self.info['name']: re.compile(regex, re.UNICODE | re.IGNORECASE)
-        }
+        self._match_relative_regex_cache.setdefault(
+            self._settings.registry_key, {})[self.info['name']] = \
+            re.compile(regex, re.UNICODE | re.IGNORECASE)
 
 
 class NormalizedDictionary(Dictionary):


### PR DESCRIPTION
Fixes #426 

3 commits are unrelated, but all give speed improvements (first two give the most). Overall speedup on ``not a date`` input is about 10x, from ~150ms to ~12-15ms, and good speed is achieved already at the second call, not after ~3-5th like before. 
be9b92d is a minimal fix, but this issue also affects ``BaseLanguageDetector``, so for a more extended fix I could try removing ``strip_timezone`` argument from ``Locale.is_applicable`` altogether and fixing all callers, but I'm not sure if it's worth it without knowing how language detectors are used.