### PR TITLE
Fix ZeroDivisionError in search_dates

### DIFF
--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -56,8 +56,11 @@ class ExactLanguageSearch:
                     not_parsed += 1
                 if not any(char.isdigit() for char in possible_substrings_splits[i][j]):
                     num_substrings_without_digits += 1
-            rating.append([num_substrings, float(not_parsed)/float(num_substrings),
-                           float(num_substrings_without_digits)/float(num_substrings)])
+            rating.append([
+                num_substrings,
+                0 if not_parsed == 0 else (float(not_parsed)/float(num_substrings)),
+                0 if num_substrings_without_digits == 0 else (
+                    float(num_substrings_without_digits)/float(num_substrings))])
             best_index, best_rating = min(enumerate(rating), key=lambda p: (p[1][1], p[1][0], p[1][2]))
         return possible_parsed_splits[best_index], possible_substrings_splits[best_index]
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -648,7 +648,13 @@ class TestTranslateSearch(BaseTestCase):
         param(text='Привет',
               languages=['en'],
               settings=None,
-              expected=None)
+              expected=None),
+
+        # ZeroDivisionError
+        param(text='01.09 – 03.09.2017',
+              languages=None,
+              settings={'STRICT_PARSING': True},
+              expected=[('03.09.2017', datetime.datetime(2017, 3, 9, 0, 0))]),
     ])
     def test_date_search_function(self, text, languages, settings, expected):
         result = search_dates(text, languages=languages, settings=settings)


### PR DESCRIPTION
Fixes #401

Some inputs give ZeroDivisionError for search_dates with strict parsing:

```
In [8]: search_dates('01.09 – 03.09.2017', settings={'STRICT_PARSING': True})
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-8-2ef691059336> in <module>()
----> 1 search_dates('01.09 – 03.09.2017', settings={'STRICT_PARSING': True})

~/shub/dateparser/dateparser/search/__init__.py in search_dates(text, languages, settings)
     31
     32         """
---> 33     result = _search_with_detection.search_dates(text=text, languages=languages, settings=settings)
     34     if result['Dates']:
     35         return result['Dates']

~/shub/dateparser/dateparser/conf.py in wrapper(*args, **kwargs)
     79                 "settings can only be either dict or instance of Settings class")
     80
---> 81         return f(*args, **kwargs)
     82     return wrapper

~/shub/dateparser/dateparser/search/search.py in search_dates(self, text, languages, settings)
    219             return {'Language': None, 'Dates': None}
    220         return {'Language': language_shortname, 'Dates': self.search.search_parse(language_shortname, text,
--> 221                                                                                   settings=settings)}

~/shub/dateparser/dateparser/search/search.py in search_parse(self, shortname, text, settings)
    151             parser = DateDataParser(languages=['en'], settings=settings)
    152             parsed, substrings = self.parse_found_objects(parser=parser, to_parse=translated,
--> 153                                                           original=original, translated=translated, settings=settings)
    154         else:
    155             parser = DateDataParser(languages=[shortname], settings=settings)

~/shub/dateparser/dateparser/search/search.py in parse_found_objects(self, parser, to_parse, original, translated, settings)
    138                             possible_parsed.append(current_parsed)
    139                             possible_substrings.append(current_substrings)
--> 140                         parsed_best, substrings_best = self.choose_best_split(possible_parsed, possible_substrings)
    141                         for k in range(len(parsed_best)):
    142                             if parsed_best[k]['date_obj']:

~/shub/dateparser/dateparser/search/search.py in choose_best_split(self, possible_parsed_splits, possible_substrings_splits)
     57                 if not any(char.isdigit() for char in possible_substrings_splits[i][j]):
     58                     num_substrings_without_digits += 1
---> 59             rating.append([num_substrings, float(not_parsed)/float(num_substrings),
     60                            float(num_substrings_without_digits)/float(num_substrings)])
     61             best_index, best_rating = min(enumerate(rating), key=lambda p: (p[1][1], p[1][0], p[1][2]))

ZeroDivisionError: float division by zero
```

This PR adds a tests and fixes the error