### PR TITLE
memoize `get_tz_offsets` to improve runtime performance of short-lived scripts

### DIFF
--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -8,7 +8,7 @@ from tzlocal import get_localzone
 from pytz import UTC, timezone, UnknownTimeZoneError
 from collections import OrderedDict
 
-from dateparser.timezone_parser import _tz_offsets, StaticTzInfo
+from dateparser.timezone_parser import get_tz_offsets, StaticTzInfo
 
 
 def strip_braces(date_string):
@@ -76,7 +76,7 @@ def localize_timezone(date_time, tz_string):
     try:
         tz = timezone(tz_string)
     except UnknownTimeZoneError as e:
-        for name, info in _tz_offsets:
+        for name, info in get_tz_offsets():
             if info['regex'].search(' %s' % tz_string):
                 tz = StaticTzInfo(name, info['offset'])
                 break
@@ -96,7 +96,7 @@ def apply_tzdatabase_timezone(date_time, pytz_string):
 
 
 def apply_dateparser_timezone(utc_datetime, offset_or_timezone_abb):
-    for name, info in _tz_offsets:
+    for name, info in get_tz_offsets():
         if info['regex'].search(' %s' % offset_or_timezone_abb):
             tz = StaticTzInfo(name, info['offset'])
             return utc_datetime.astimezone(tz)


### PR DESCRIPTION
I am working on a small project that uses dateparser and noticed that the invocation of my script was taking around 500ms on my local machine to do a very small amount of work.  I took a look at what cProfile had to say and narrowed things down to the compilation of hundreds of regular expressions to be used for the calculation of timezone offsets.

This PR provides an alternative to calculating them up front by using the generator in every situation that `_tz_offsets` was used previously.   For the case where every offset regex needs to be compiled, the results are cached so that later iteration is fast.