### PR TITLE
Fix Portuguese month/day ordering issue

### DIFF
--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -78,6 +78,7 @@ class TestDateParser(BaseTestCase):
         param('sexta-feira, 10 de junho de 2014 14:52', datetime(2014, 6, 10, 14, 52)),
         param('13 Setembro, 2014', datetime(2014, 9, 13)),
         param('Sab 3:03', datetime(2012, 11, 10, 3, 3)),
+        param('segunda 10-02-2015 4:06am', datetime(2015, 2, 10, 4, 6)),
         # Russian dates
         param('10 мая', datetime(2012, 5, 10)),  # forum.codenet.ru
         param('26 апреля', datetime(2012, 4, 26)),


### PR DESCRIPTION
There is a bug with Portuguese dates where dateparser switches the month and day ordering. This regression occurred sometime between v0.6.0 and v0.7.0.

Example text is "segunda 10-02-2015 4:06am", which should parse to "2015-02-10" but currently parses to "2015-10-02".