### PR TITLE
Included positional argument in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ deps =
     -rrequirements.txt
     -rtests/requirements.txt
 commands =
-    nosetests -v --with-coverage --cover-package=dateparser tests
+    nosetests -v --with-coverage --cover-package=dateparser {posargs:tests}


### PR DESCRIPTION
With this change it is possible to run specific tests using tox. For example:
`tox -e py36 -- tests/test_utils_strptime.py:TestStrptime`