### PR TITLE
Fix Collections ABCs deprecation warning

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -17,6 +17,12 @@ from dateparser.conf import apply_settings
 from dateparser.timezone_parser import pop_tz_offset_from_string
 from dateparser.utils import apply_timezone_from_settings
 
+try:
+    # Python 3
+    from collections.abc import Set
+except ImportError:
+    # Python 2.7
+    from collections import Set
 
 APOSTROPHE_LOOK_ALIKE_CHARS = [
     u'\N{RIGHT SINGLE QUOTATION MARK}',     # u'\u2019'
@@ -163,7 +169,7 @@ class _DateLocaleParser(object):
         if isinstance(date_formats, six.string_types):
             warn(self.DATE_FORMATS_ERROR_MESSAGE, FutureWarning)
             date_formats = [date_formats]
-        elif not (date_formats is None or isinstance(date_formats, (list, tuple, collections.Set))):
+        elif not (date_formats is None or isinstance(date_formats, (list, tuple, Set))):
             raise TypeError(self.DATE_FORMATS_ERROR_MESSAGE)
 
         self.locale = locale
@@ -317,10 +323,10 @@ class DateDataParser(object):
     def __init__(self, languages=None, locales=None, region=None, try_previous_locales=True,
                  use_given_order=False, settings=None):
 
-        if not isinstance(languages, (list, tuple, collections.Set)) and languages is not None:
+        if not isinstance(languages, (list, tuple, Set)) and languages is not None:
             raise TypeError("languages argument must be a list (%r given)" % type(languages))
 
-        if not isinstance(locales, (list, tuple, collections.Set)) and locales is not None:
+        if not isinstance(locales, (list, tuple, Set)) and locales is not None:
             raise TypeError("locales argument must be a list (%r given)" % type(locales))
 
         if not isinstance(region, six.string_types) and region is not None:

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -5,7 +5,13 @@ from dateparser.conf import apply_settings, Settings
 from dateparser.date import DateDataParser
 from dateparser.search.text_detection import FullTextLanguageDetector
 import regex as re
-import collections
+
+try:
+    # Python 3
+    from collections.abc import Set
+except ImportError:
+    # Python 2.7
+    from collections import Set
 
 RELATIVE_REG = re.compile("(ago|in|from now|tomorrow|today|yesterday)")
 
@@ -174,7 +180,7 @@ class DateSearchWithDetection:
         self.search = ExactLanguageSearch(self.loader)
 
     def detect_language(self, text, languages):
-        if isinstance(languages, (list, tuple, collections.Set)):
+        if isinstance(languages, (list, tuple, Set)):
 
             if all([language in self.available_language_map for language in languages]):
                 languages = [self.available_language_map[language] for language in languages]


### PR DESCRIPTION
With Python 3.7, I'm getting:

```
  /usr/local/lib/python3.7/site-packages/dateparser/date.py:319: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if not isinstance(languages, (list, tuple, collections.Set)) and languages is not None:
```
