### PR TITLE
Prefer importlib over imp

### DIFF
--- a/dateparser/utils/strptime.py
+++ b/dateparser/utils/strptime.py
@@ -2,7 +2,7 @@ import sys
 if sys.version_info[0:2] < (3, 3):
     import imp
 else:
-    import importlib
+    import importlib.util
 import regex as re
 
 from datetime import datetime
@@ -34,8 +34,15 @@ def patch_strptime():
             'calendar_patched', *imp.find_module('_strptime')
         )
     else:
-        _strptime = importlib.import_module('_strptime')
-        _calendar = importlib.import_module('_strptime')
+        _strptime_spec = importlib.util.find_spec('_strptime')
+
+        _strptime = importlib.util.module_from_spec(_strptime_spec)
+        _strptime_spec.loader.exec_module(_strptime)
+        sys.modules['strptime_patched'] = _strptime
+
+        _calendar = importlib.util.module_from_spec(_strptime_spec)
+        _strptime_spec.loader.exec_module(_calendar)
+        sys.modules['calendar_patched'] = _calendar
 
     _strptime._getlang = lambda: ('en_US', 'UTF-8')
     _strptime.calendar = _calendar

--- a/dateparser/utils/strptime.py
+++ b/dateparser/utils/strptime.py
@@ -1,4 +1,8 @@
-import imp
+import sys
+if sys.versioninfo[0:2] < (3, 3):
+    import imp
+else:
+    import importlib
 import regex as re
 
 from datetime import datetime
@@ -21,14 +25,17 @@ def patch_strptime():
     For example, if system's locale is set to fr_FR. Parser won't recognize
     any date since all languages are translated to english dates.
     """
+    if sys.versioninfo[0:2] < (3, 3):
+        _strptime = imp.load_module(
+            'strptime_patched', *imp.find_module('_strptime')
+        )
 
-    _strptime = imp.load_module(
-        'strptime_patched', *imp.find_module('_strptime')
-    )
-
-    _calendar = imp.load_module(
-        'calendar_patched', *imp.find_module('_strptime')
-    )
+        _calendar = imp.load_module(
+            'calendar_patched', *imp.find_module('_strptime')
+        )
+    else:
+        _strptime = importlib.import_module('_strptime')
+        _calendar = importlib.import_module('_strptime')
 
     _strptime._getlang = lambda: ('en_US', 'UTF-8')
     _strptime.calendar = _calendar

--- a/dateparser/utils/strptime.py
+++ b/dateparser/utils/strptime.py
@@ -1,5 +1,5 @@
 import sys
-if sys.versioninfo[0:2] < (3, 3):
+if sys.version_info[0:2] < (3, 3):
     import imp
 else:
     import importlib
@@ -25,7 +25,7 @@ def patch_strptime():
     For example, if system's locale is set to fr_FR. Parser won't recognize
     any date since all languages are translated to english dates.
     """
-    if sys.versioninfo[0:2] < (3, 3):
+    if sys.version_info[0:2] < (3, 3):
         _strptime = imp.load_module(
             'strptime_patched', *imp.find_module('_strptime')
         )


### PR DESCRIPTION
Use importlib when available (python 3.4+), as imp was deprecated and can cause minor headaches when other code overrides import internals (usually by freezers such as pyinstaller) according to the newer spec