### PR TITLE
Fix incomplete dates when STRICT_PARSING is True

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -134,7 +134,7 @@ class _no_spaces_parser(object):
     def _filter_datetime_format(self, date_order):
         return filter(
             lambda dt: dt.lower().startswith(date_order),
-            self.date_formats
+            self.date_formats[date_order]
         )
 
     @classmethod

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -131,6 +131,12 @@ class _no_spaces_parser(object):
             '%d%y%m': sorted(self._all, key=lambda x: x.lower().startswith('%d%y%m'), reverse=True),
         }
 
+    def _filter_datetime_format(self, date_order):
+        return filter(
+            lambda dt: dt.lower().startswith(date_order),
+            self.date_formats
+        )
+
     @classmethod
     def _get_period(cls, format_string):
         for pname, pdrv in sorted(cls.period.items(), key=lambda x: x[0]):
@@ -154,9 +160,13 @@ class _no_spaces_parser(object):
         else:
             order = cls._default_order
         nsp = cls()
+        if settings.STRICT_PARSING:
+            date_formats = nsp._filter_datetime_format(order)
+        else:
+            date_formats = nsp.date_formats[order]
         ambiguous_date = None
         for token, _ in tokens.tokenize():
-            for fmt in nsp.date_formats[order]:
+            for fmt in date_formats:
                 try:
                     dt = strptime(token, fmt), cls._get_period(fmt)
                     if len(str(dt[0].year)) < 4:

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -11,11 +11,17 @@ from dateparser.utils.strptime import strptime
 
 
 NSP_COMPATIBLE = re.compile(r'\D+')
+NSP_DIGITS = re.compile(r'\d+')
 MERIDIAN = re.compile(r'am|pm')
 MICROSECOND = re.compile(r'\d{1,6}')
+NSP_MIN_DIGITS = 6
 
 
 def no_space_parser_eligibile(datestring):
+    src = NSP_DIGITS.search(datestring)
+    if not src or len(src.group()) < NSP_MIN_DIGITS:
+        return False
+
     src = NSP_COMPATIBLE.search(datestring)
     if not src or ':' == src.group():
         return True

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -11,17 +11,11 @@ from dateparser.utils.strptime import strptime
 
 
 NSP_COMPATIBLE = re.compile(r'\D+')
-NSP_DIGITS = re.compile(r'\d+')
 MERIDIAN = re.compile(r'am|pm')
 MICROSECOND = re.compile(r'\d{1,6}')
-NSP_MIN_DIGITS = 6
 
 
 def no_space_parser_eligibile(datestring):
-    src = NSP_DIGITS.search(datestring)
-    if not src or len(src.group()) < NSP_MIN_DIGITS:
-        return False
-
     src = NSP_COMPATIBLE.search(datestring)
     if not src or ':' == src.group():
         return True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,7 +121,7 @@ class TestNoSpaceParser(BaseTestCase):
     ])
     def test_min_input_date_is_not_parsed(self, date_string):
         self.given_parser()
-        self.given_settings(settings={'DATE_ORDER': ''})
+        self.given_settings()
         self.when_date_is_parsed(date_string)
         self.then_date_is_not_parsed()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -307,6 +307,27 @@ class TestNoSpaceParser(BaseTestCase):
         self.when_get_period_is_called(format_string)
         self.then_returned_period_is(expected_period)
 
+    @parameterized.expand([
+        param(
+            date_order="%m%d%y",
+            expected_formats=[
+                '%m%d%Y', '%m%d%y', '%m%d%Y%H%M%S.%f', '%m%d%Y%H%M%S', '%m%d%Y%H%M',
+                '%m%d%Y%H', '%m%d%y%H%M%S.%f', '%m%d%y%H%M%S', '%m%d%y%H%M', '%m%d%y%H'
+            ]
+        ),
+        param(
+            date_order="%d%m%y",
+            expected_formats=[
+                '%d%m%Y', '%d%m%y', '%d%m%Y%H%M%S.%f', '%d%m%Y%H%M%S', '%d%m%Y%H%M',
+                '%d%m%Y%H', '%d%m%y%H%M%S.%f', '%d%m%y%H%M%S', '%d%m%y%H%M', '%d%m%y%H'
+            ]
+        ),
+    ])
+    def test_filter_datetime_format_function(self, date_order, expected_formats):
+        self.given_parser()
+        self.when_filter_datetime_format_is_called(date_order)
+        self.then_filtered_date_formats_are(expected_formats)
+
     def given_parser(self):
         self.parser = _no_spaces_parser
 
@@ -323,11 +344,17 @@ class TestNoSpaceParser(BaseTestCase):
     def when_get_period_is_called(self, format_string):
         self.result = self.parser._get_period(format_string)
 
+    def when_filter_datetime_format_is_called(self, date_order):
+        self.result = self.parser()._filter_datetime_format(date_order)
+
     def then_date_exactly_is(self, expected_date):
         self.assertEqual(self.result[0], expected_date)
 
     def then_period_exactly_is(self, expected_period):
         self.assertEqual(self.result[1], expected_period)
+
+    def then_filtered_date_formats_are(self, expected_formats):
+        self.assertEqual(self.result, expected_formats)
 
     def then_date_is_not_parsed(self):
         self.assertIsNone(self.result)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -116,16 +116,6 @@ class TestNoSpaceParser(BaseTestCase):
         self.then_date_is_not_parsed()
 
     @parameterized.expand([
-        param(date_string=u"11117"),
-        param(date_string=u"2011"),
-    ])
-    def test_min_input_date_is_not_parsed(self, date_string):
-        self.given_parser()
-        self.given_settings()
-        self.when_date_is_parsed(date_string)
-        self.then_date_is_not_parsed()
-
-    @parameterized.expand([
         param(
             date_string=u"201115",
             expected_date=datetime(2015, 11, 20),
@@ -169,6 +159,12 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
         param(
+            date_string=u"12595",
+            expected_date=datetime(1995, 12, 5),
+            date_order='MDY',
+            expected_period='day',
+        ),
+        param(
             date_string=u"459712:15:07.54",
             expected_date=datetime(4597, 12, 15, 0, 7),
             date_order='MDY',
@@ -187,6 +183,12 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
         param(
+            date_string=u"21813",
+            expected_date=datetime(2018, 2, 13),
+            date_order='MYD',
+            expected_period='day',
+        ),
+        param(
             date_string=u"12937886",
             expected_date=datetime(2937, 1, 8, 8, 6),
             date_order='MYD',
@@ -195,6 +197,12 @@ class TestNoSpaceParser(BaseTestCase):
         param(
             date_string=u"20151211",
             expected_date=datetime(2015, 12, 11),
+            date_order='YMD',
+            expected_period='day',
+        ),
+        param(
+            date_string=u"18216",
+            expected_date=datetime(2018, 2, 16),
             date_order='YMD',
             expected_period='day',
         ),
@@ -211,8 +219,20 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
         param(
+            date_string=u"14271",
+            expected_date=datetime(2014, 1, 27),
+            date_order='YDM',
+            expected_period='day',
+        ),
+        param(
             date_string=u"2010111110:11",
             expected_date=datetime(2010, 11, 11, 10, 1, 1),
+            date_order='YDM',
+            expected_period='day',
+        ),
+        param(
+            date_string=u"10:11:2",
+            expected_date=datetime(2010, 2, 11, 0, 0),
             date_order='YDM',
             expected_period='day',
         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -117,6 +117,19 @@ class TestNoSpaceParser(BaseTestCase):
 
     @parameterized.expand([
         param(
+            date_string=u"2017",
+        ),
+        param(
+            date_string=u"2011",
+        ),
+    ])
+    def test_error_is_raised_when_incomplete_dates_given(self, date_string):
+        self.given_parser()
+        self.given_settings(settings={'STRICT_PARSING': True})
+        self.then_error_is_raised_when_date_is_parsed(date_string)
+
+    @parameterized.expand([
+        param(
             date_string=u"201115",
             expected_date=datetime(2015, 11, 20),
             date_order='DMY',
@@ -321,6 +334,10 @@ class TestNoSpaceParser(BaseTestCase):
 
     def then_returned_period_is(self, expected_period):
         self.assertEqual(self.result, expected_period)
+
+    def then_error_is_raised_when_date_is_parsed(self, date_string):
+        with self.assertRaises(ValueError):
+            self.parser.parse(date_string, self.settings)
 
 
 class TestParser(BaseTestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -354,7 +354,7 @@ class TestNoSpaceParser(BaseTestCase):
         self.assertEqual(self.result[1], expected_period)
 
     def then_filtered_date_formats_are(self, expected_formats):
-        self.assertEqual(self.result, expected_formats)
+        self.assertEqual([x for x in self.result], expected_formats)
 
     def then_date_is_not_parsed(self):
         self.assertIsNone(self.result)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -116,6 +116,16 @@ class TestNoSpaceParser(BaseTestCase):
         self.then_date_is_not_parsed()
 
     @parameterized.expand([
+        param(date_string=u"11117"),
+        param(date_string=u"2011"),
+    ])
+    def test_min_input_date_is_not_parsed(self, date_string):
+        self.given_parser()
+        self.given_settings(settings={'DATE_ORDER': ''})
+        self.when_date_is_parsed(date_string)
+        self.then_date_is_not_parsed()
+
+    @parameterized.expand([
         param(
             date_string=u"201115",
             expected_date=datetime(2015, 11, 20),
@@ -159,12 +169,6 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
         param(
-            date_string=u"12595",
-            expected_date=datetime(1995, 12, 5),
-            date_order='MDY',
-            expected_period='day',
-        ),
-        param(
             date_string=u"459712:15:07.54",
             expected_date=datetime(4597, 12, 15, 0, 7),
             date_order='MDY',
@@ -183,12 +187,6 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
         param(
-            date_string=u"21813",
-            expected_date=datetime(2018, 2, 13),
-            date_order='MYD',
-            expected_period='day',
-        ),
-        param(
             date_string=u"12937886",
             expected_date=datetime(2937, 1, 8, 8, 6),
             date_order='MYD',
@@ -197,12 +195,6 @@ class TestNoSpaceParser(BaseTestCase):
         param(
             date_string=u"20151211",
             expected_date=datetime(2015, 12, 11),
-            date_order='YMD',
-            expected_period='day',
-        ),
-        param(
-            date_string=u"18216",
-            expected_date=datetime(2018, 2, 16),
             date_order='YMD',
             expected_period='day',
         ),
@@ -219,20 +211,8 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
         param(
-            date_string=u"14271",
-            expected_date=datetime(2014, 1, 27),
-            date_order='YDM',
-            expected_period='day',
-        ),
-        param(
             date_string=u"2010111110:11",
             expected_date=datetime(2010, 11, 11, 10, 1, 1),
-            date_order='YDM',
-            expected_period='day',
-        ),
-        param(
-            date_string=u"10:11:2",
-            expected_date=datetime(2010, 2, 11, 0, 0),
             date_order='YDM',
             expected_period='day',
         ),


### PR DESCRIPTION
Add check to only try to parse complete dates if the date string has at least 6 digits.
Fix cases when it's impossible to guess the date
Ex: 
Date: 11117
Possible dates: 11/01/17 or 01/11/17 or 11/11/07

So I suggest a minimum length of 6 to parse complete dates.

Closes #356 