### PR TITLE
Require Parts of Date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,138 @@ You can extract dates from longer strings of text. They are returned as list of 
 .. automodule:: dateparser.search
    :members: search_dates
 
+Settings
+========
+
+:mod:`dateparser`'s parsing behavior can be configured by supplying settings as a dictionary to `settings` argument in `dateparser.parse` or :class:`DateDataParser <dateparser.date.DateDataParser>` constructor.
+
+All supported `settings` with their usage examples are given below:
+
+
+Date Order
+++++++++++
+
+``DATE_ORDER`` specifies the order in which date components `year`, `month` and `day` are expected while parsing ambiguous dates. It defaults to `MDY` which translates to `month` first, `day` second and `year` last order. Characters `M`, `D` or `Y` can be shuffled to meet required order. For example, `DMY` specifies `day` first, `month` second and `year` last order:
+
+    >>> parse('15-12-18 06:00')  # assumes default order: MDY
+    datetime.datetime(2018, 12, 15, 6, 0)  # since 15 is not a valid value for Month, it is swapped with Day's
+    >>> parse('15-12-18 06:00', settings={'DATE_ORDER': 'YMD'})
+    datetime.datetime(2015, 12, 18, 6, 0)
+
+``PREFER_LANGUAGE_DATE_ORDER`` defaults to `True`. Most languages have a default `DATE_ORDER` specified for them. For example, for French it is `DMY`:
+
+   >>> # parsing ambiguous date
+   >>> parse('02-03-2016')  # assumes english language, uses MDY date order
+   datetime.datetime(2016, 3, 2, 0, 0)
+   >>> parse('le 02-03-2016')  # detects french, hence, uses DMY date order
+   datetime.datetime(2016, 3, 2, 0, 0)
+
+.. note:: There's no language level default `DATE_ORDER` associated with `en` language. That's why it assumes `MDY` which is :obj:``settings <dateparser.conf.settings>`` default. If the language has a default `DATE_ORDER` associated, supplying custom date order will not be applied unless we set `PREFER_LANGUAGE_DATE_ORDER` to `False`:
+
+    >>> parse('le 02-03-2016', settings={'DATE_ORDER': 'MDY'})
+    datetime.datetime(2016, 3, 2, 0, 0)  # MDY didn't apply
+
+    >>> parse('le 02-03-2016', settings={'DATE_ORDER': 'MDY', 'PREFER_LANGUAGE_DATE_ORDER': False})
+    datetime.datetime(2016, 2, 3, 0, 0)  # MDY worked!
+
+
+Timezone Related Configurations
++++++++++++++++++++++++++++++++
+
+
+``TIMEZONE`` defaults to local timezone. When specified, resultant :class:`datetime <datetime.datetime>` is localized with the given timezone.
+
+    >>> parse('January 12, 2012 10:00 PM', settings={'TIMEZONE': 'US/Eastern'})
+    datetime.datetime(2012, 1, 12, 22, 0)
+
+``TO_TIMEZONE`` defaults to None. When specified, resultant :class:`datetime <datetime.datetime>` converts according to the supplied timezone:
+
+    >>> settings = {'TIMEZONE': 'UTC', 'TO_TIMEZONE': 'US/Eastern'}
+    >>> parse('January 12, 2012 10:00 PM', settings=settings)
+    datetime.datetime(2012, 1, 12, 17, 0)
+
+``RETURN_AS_TIMEZONE_AWARE`` is a flag to toggle between timezone aware/naive dates:
+
+    >>> parse('30 mins ago', settings={'RETURN_AS_TIMEZONE_AWARE': True})
+    datetime.datetime(2017, 3, 13, 1, 43, 10, 243565, tzinfo=<DstTzInfo 'Asia/Karachi' PKT+5:00:00 STD>)
+
+    >>> parse('12 Feb 2015 10:56 PM EST', settings={'RETURN_AS_TIMEZONE_AWARE': False})
+    datetime.datetime(2015, 2, 12, 22, 56)
+
+
+
+Handling Incomplete Dates
++++++++++++++++++++++++++
+
+``PREFER_DAY_OF_MONTH`` This option comes handy when the date string is missing the day part. It defaults to ``current`` and can have ``first`` and ``last`` denoting first and last day of months respectively as values:
+
+    >>> from dateparser import parse
+    >>> parse(u'December 2015')  # default behavior
+    datetime.datetime(2015, 12, 16, 0, 0)
+    >>> parse(u'December 2015', settings={'PREFER_DAY_OF_MONTH': 'last'})
+    datetime.datetime(2015, 12, 31, 0, 0)
+    >>> parse(u'December 2015', settings={'PREFER_DAY_OF_MONTH': 'first'})
+    datetime.datetime(2015, 12, 1, 0, 0)
+
+``PREFER_DATES_FROM`` defaults to `current_period` and can have `past` and `future` as values.
+
+If date string is missing some part, this option ensures consistent results depending on the `past` or `future` preference, for example, assuming current date is `June 16, 2015`:
+
+    >>> from dateparser import parse
+    >>> parse(u'March')
+    datetime.datetime(2015, 3, 16, 0, 0)
+    >>> parse(u'March', settings={'PREFER_DATES_FROM': 'future'})
+    datetime.datetime(2016, 3, 16, 0, 0)
+    >>> # parsing with preference set for 'past'
+    >>> parse('August', settings={'PREFER_DATES_FROM': 'past'})
+    datetime.datetime(2015, 8, 15, 0, 0)
+
+``RELATIVE_BASE`` allows setting the base datetime to use for interpreting partial or relative date strings.
+Defaults to the current date and time.
+
+For example, assuming current date is `June 16, 2015`:
+
+    >>> from dateparser import parse
+    >>> parse(u'14:30')
+    datetime.datetime(2015, 6, 16, 14, 30)
+    >>> parse(u'14:30', settings={'RELATIVE_BASE': datetime.datetime(2020, 1, 1)})
+    datetime.datetime(2020, 1, 1, 14, 30)
+    >>> parse(u'tomorrow', settings={'RELATIVE_BASE': datetime.datetime(2020, 1, 1)})
+    datetime.datetime(2020, 1, 2, 0, 0)
+
+``STRICT_PARSING`` defaults to `False`.
+
+When set to `True` if missing any of `day`, `month` or `year` parts, it does not return any result altogether.:
+
+    >>> parse(u'March', settings={'STRICT_PARSING': True})
+    None
+
+``REQUIRE_PARTS`` This option ensures results are dates that have some specified part. It defaults to `None` and can include ``day``, ``month`` and/or ``year``.
+
+For example, assuming current date is `June 16, 2019`:
+
+    >>> parse(u'2012') # default behavior
+    datetime.datetime(2012, 6, 16, 0, 0)
+    >>> parse(u'2012', settings={'REQUIRE_PARTS': 'month'})
+    None
+    >>> parse(u'March 2012', settings={'REQUIRE_PARTS': 'day'})
+    None
+    >>> parse(u'March 12, 2012', settings={'REQUIRE_PARTS': 'day'})
+    datetime.datetime(2012, 3, 12, 0, 0)
+    >>> parse(u'March 12, 2012', settings={'REQUIRE_PARTS': 'day,month,year'})
+    datetime.datetime(2012, 3, 12, 0, 0)
+
+
+Language Detection
+++++++++++++++++++
+
+``SKIP_TOKENS`` is a ``list`` of tokens to discard while detecting language. Defaults to ``['t']`` which skips T in iso format datetime string .e.g. ``2015-05-02T10:20:19+0000``.:
+
+    >>> from dateparser.date import DateDataParser
+    >>> DateDataParser(settings={'SKIP_TOKENS': ['de']}).get_date_data(u'27 Haziran 1981 de')  # Turkish (at 27 June 1981)
+    {'date_obj': datetime.datetime(1981, 6, 27, 0, 0), 'period': 'day'}
+
+
 Dependencies
 ============
 

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -334,6 +334,16 @@ class _parser(object):
                 errors.append('Year')
             if errors:
                 raise ValueError('%s not found in the date string' % ''.join(errors))
+        elif self.settings.REQUIRE_PARTSq:
+            errors = []
+            if 'day' in self.settings.REQUIRE_PARTS and not self.day:
+                errors.append('Day')
+            if 'month' in self.settings.REQUIRE_PARTS and not self.month:
+                errors.append('Month')
+            if 'year' in self.settings.REQUIRE_PARTS and not self.year:
+                errors.append('Year')
+            if errors:
+                raise ValueError('%s not found in the date string' % ''.join(errors))
 
         self._set_relative_base()
 

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -334,7 +334,7 @@ class _parser(object):
                 errors.append('Year')
             if errors:
                 raise ValueError('%s not found in the date string' % ''.join(errors))
-        elif self.settings.REQUIRE_PARTSq:
+        elif self.settings.REQUIRE_PARTS:
             errors = []
             if 'day' in self.settings.REQUIRE_PARTS and not self.day:
                 errors.append('Day')

--- a/dateparser_data/settings.py
+++ b/dateparser_data/settings.py
@@ -12,5 +12,6 @@ settings = {
     'DATE_ORDER': 'MDY',
     'PREFER_LOCALE_DATE_ORDER': True,
     'FUZZY': False,
-    'STRICT_PARSING': False
+    'STRICT_PARSING': False,
+    'REQUIRE_PARTS': None,
 }

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -126,7 +126,7 @@ For example, assuming current date is `June 16, 2015`:
 
     >>> from dateparser import parse
     >>> parse(u'14:30')
-    datetime.datetime(2015, 3, 16, 14, 30)
+    datetime.datetime(2015, 6, 16, 14, 30)
     >>> parse(u'14:30', settings={'RELATIVE_BASE': datetime.datetime(2020, 1, 1)})
     datetime.datetime(2020, 1, 1, 14, 30)
     >>> parse(u'tomorrow', settings={'RELATIVE_BASE': datetime.datetime(2020, 1, 1)})
@@ -138,6 +138,21 @@ When set to `True` if missing any of `day`, `month` or `year` parts, it does not
 
     >>> parse(u'March', settings={'STRICT_PARSING': True})
     None
+
+``REQUIRE_PARTS`` This option ensures results are dates that have some specified part. It defaults to `None` and can include ``day``, ``month`` and/or ``year``.
+
+For example, assuming current date is `June 16, 2019`:
+
+    >>> parse(u'2012') # default behavior
+    datetime.datetime(2012, 6, 16, 0, 0)
+    >>> parse(u'2012', settings={'REQUIRE_PARTS': 'month'})
+    None
+    >>> parse(u'March 2012', settings={'REQUIRE_PARTS': 'day'})
+    None
+    >>> parse(u'March 12, 2012', settings={'REQUIRE_PARTS': 'day'})
+    datetime.datetime(2012, 3, 12, 0, 0)
+    >>> parse(u'March 12, 2012', settings={'REQUIRE_PARTS': 'day,month,year'})
+    datetime.datetime(2012, 3, 12, 0, 0)
 
 
 Language Detection

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -338,6 +338,46 @@ class TestParser(BaseTestCase):
         self.then_error_is_raised_when_date_is_parsed(date_string)
 
     @parameterized.expand([
+        param(date_string=u"april 2010"),
+        param(date_string=u"11 March"),
+        param(date_string=u"March"),
+        param(date_string=u"31 2010"),
+        param(date_string=u"31/2010"),
+    ])
+    def test_error_is_raised_when_partially_complete_dates_given(self, date_string):
+        self.given_parser()
+        self.given_settings(settings={'REQUIRE_PARTS': 'day,month,year'})
+        self.then_error_is_raised_when_date_is_parsed(date_string)
+
+    @parameterized.expand([
+        param(date_string=u"april 2010"),
+        param(date_string=u"March"),
+        param(date_string=u"2010"),
+    ])
+    def test_error_is_raised_when_day_part_missing(self, date_string):
+        self.given_parser()
+        self.given_settings(settings={'REQUIRE_PARTS': 'day'})
+        self.then_error_is_raised_when_date_is_parsed(date_string)
+
+    @parameterized.expand([
+        param(date_string=u"31 2010"),
+        param(date_string=u"31/2010"),
+    ])
+    def test_error_is_raised_when_month_part_missing(self, date_string):
+        self.given_parser()
+        self.given_settings(settings={'REQUIRE_PARTS': 'month'})
+        self.then_error_is_raised_when_date_is_parsed(date_string)
+
+    @parameterized.expand([
+        param(date_string=u"11 March"),
+        param(date_string=u"March"),
+    ])
+    def test_error_is_raised_when_year_part_missing(self, date_string):
+        self.given_parser()
+        self.given_settings(settings={'REQUIRE_PARTS': 'year'})
+        self.then_error_is_raised_when_date_is_parsed(date_string)
+
+    @parameterized.expand([
         param(date_string=u"Januar"),
         param(date_string=u"56341819"),
         param(date_string=u"56341819 Febr"),


### PR DESCRIPTION
This was to address the issue I raised in #529. 

I've added to the settings `REQUIRE_PARTS` which takes a string that can include `'day'`, `'month'` and/or `'year'`. I added the setting to the documentation and also realised that there was some docs missing from the README page (with links that didn't go anywhere), so I copied over the documentation from `docs/usage.rst`.