### PR TITLE
Declare support for Python 3.7, drop EOL 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
       env: TOXENV=py27
     - python: pypy
       env: TOXENV=pypy
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
@@ -17,7 +15,6 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
       dist: xenial
-      sudo: true
 
 install:
 - pip install -U wheel

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     license="BSD",
     zip_safe=False,
     keywords='dateparser',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
@@ -45,10 +46,9 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy
+envlist = py27, py35, py36, py37, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.3 and 3.4 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

`sudo` is no longer needed on Travis CI: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration