### PR TITLE
Stabilize tests at midnight

### DIFF
--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -342,15 +342,16 @@ class TestDateDataParser(BaseTestCase):
         param(' Yesterday \n', days_ago=1),
         param('Ontem', days_ago=1),
         param('Ieri', days_ago=1),
+        param(u'вчера', days_ago=1),
+        param(u'снощи', days_ago=1),
         # Day before yesterday
         param('the day before yesterday', days_ago=2),
         param('The DAY before Yesterday', days_ago=2),
         param('Anteontem', days_ago=2),
-        param('Avant-hier', days_ago=2),
-        param(u'вчера', days_ago=1),
-        param(u'снощи', days_ago=1)
+        param('Avant-hier', days_ago=2)
     ])
     def test_temporal_nouns_are_parsed(self, date_string, days_ago):
+        self.given_now(2019, 7, 21)
         self.given_parser()
         self.when_date_string_is_parsed(date_string)
         self.then_date_was_parsed()
@@ -489,11 +490,12 @@ class TestDateDataParser(BaseTestCase):
         self.then_returned_tuple_is(expected_result)
 
     def given_now(self, year, month, day, **time):
+        now = datetime(year, month, day, **time)
         datetime_mock = Mock(wraps=datetime)
-        datetime_mock.utcnow = Mock(return_value=datetime(year, month, day, **time))
-        self.add_patch(
-            patch('dateparser.date_parser.datetime', new=datetime_mock)
-        )
+        datetime_mock.utcnow = Mock(return_value=now)
+        datetime_mock.now = Mock(return_value=now)
+        datetime_mock.today = Mock(return_value=now)
+        self.add_patch(patch('dateparser.date.datetime', new=datetime_mock))
 
     def given_parser(self, restrict_to_languages=None, **params):
         self.parser = date.DateDataParser(languages=restrict_to_languages, **params)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from parameterized import parameterized, param
 from tests import BaseTestCase
@@ -6,6 +6,8 @@ from dateparser.search.search import DateSearchWithDetection
 from dateparser.search import search_dates
 from dateparser.conf import Settings, apply_settings
 import datetime
+
+today = datetime.datetime.today()
 
 
 class TestTranslateSearch(BaseTestCase):
@@ -419,8 +421,8 @@ class TestTranslateSearch(BaseTestCase):
                ('February 1st', datetime.datetime(2017, 2, 1, 0, 0))]),
         param('en', '2014 was good! October was excellent!'
                     ' Friday, 21 was especially good!',
-              [('2014', datetime.datetime(2014, datetime.datetime.today().month, datetime.datetime.today().day, 0, 0)),
-               ('October', datetime.datetime(2014, 10, datetime.datetime.today().day, 0, 0)),
+              [('2014', datetime.datetime(2014, today.month, today.day, 0, 0)),
+               ('October', datetime.datetime(2014, 10, today.day, 0, 0)),
                ('Friday, 21', datetime.datetime(2014, 10, 21, 0, 0))]),
 
         # Russian
@@ -462,7 +464,7 @@ class TestTranslateSearch(BaseTestCase):
                ('July 13th', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2014, 7, 14, 0, 0))]),
         param('en', '2014. July 13th July 14th',
-              [('2014', datetime.datetime(2014, datetime.datetime.today().month, datetime.datetime.today().day, 0, 0)),
+              [('2014', datetime.datetime(2014, today.month, today.day, 0, 0)),
                ('July 13th', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2014, 7, 14, 0, 0))]),
         param('en', 'July 13th 2014 July 14th 2014',
@@ -475,16 +477,15 @@ class TestTranslateSearch(BaseTestCase):
               [('July 13th, 2014', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th, 2014', datetime.datetime(2014, 7, 14, 0, 0))]),
         param('en', '2014. July 12th, July 13th, July 14th',
-              [('2014', datetime.datetime(2014, datetime.datetime.today().month, datetime.datetime.today().day, 0, 0)),
+              [('2014', datetime.datetime(2014, today.month, today.day, 0, 0)),
                ('July 12th', datetime.datetime(2014, 7, 12, 0, 0)),
                ('July 13th', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2014, 7, 14, 0, 0))]),
         # Swedish
         param('sv', '1938–1939 marscherade tyska soldater i Österrike samtidigt som '
                     'österrikiska soldater marscherade i Berlin.',
-              [('1938', datetime.datetime(1938, datetime.datetime.today().month, datetime.datetime.today().day, 0, 0)),
-               ('1939', datetime.datetime(1939,
-                                          datetime.datetime.today().month, datetime.datetime.today().day, 0, 0))]),
+              [('1938', datetime.datetime(1938, today.month, today.day, 0, 0)),
+               ('1939', datetime.datetime(1939, today.month, today.day, 0, 0))]),
         # German
         param('de', 'Verteidiger der Stadt kapitulierten am 2. Mai 1945. Am 8. Mai 1945 (VE-Day) trat '
                     'bedingungslose Kapitulation der Wehrmacht in Kraft',


### PR DESCRIPTION
Ensure that tests that compare times around now use identical now.

---

I was running the tests at midnight and noticed some failures.