### PR TITLE
capture timezone info for dates search

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 from dateutil import parser
 
-from dateparser.timezone_parser import pop_tz_offset_from_string
+from dateparser.timezone_parser import pop_tz_offset_from_string, is_word_match_any_tz
 from dateparser.utils import normalize_unicode, combine_dicts
 
 from .dictionary import Dictionary, NormalizedDictionary, ALWAYS_KEEP_TOKENS
@@ -205,6 +205,9 @@ class Locale(object):
                         translated_chunk.append(dictionary[word.strip('()\"\'{}[],.،')])
                     original_chunk.append(original_tokens[i])
                 elif self._token_with_digits_is_ok(word):
+                    translated_chunk.append(word)
+                    original_chunk.append(original_tokens[i])
+                elif translated_chunk and is_word_match_any_tz(word):
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
                 else:

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -207,7 +207,8 @@ class Locale(object):
                 elif self._token_with_digits_is_ok(word):
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
-                elif translated_chunk and is_word_match_any_tz(word):
+                # Use original token because is_word_match_any_tz is case sensitive
+                elif translated_chunk and is_word_match_any_tz(original_tokens[i]):
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
                 else:

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 from dateutil import parser
 
-from dateparser.timezone_parser import pop_tz_offset_from_string, is_word_match_any_tz
+from dateparser.timezone_parser import pop_tz_offset_from_string, word_is_tz
 from dateparser.utils import normalize_unicode, combine_dicts
 
 from .dictionary import Dictionary, NormalizedDictionary, ALWAYS_KEEP_TOKENS
@@ -207,8 +207,8 @@ class Locale(object):
                 elif self._token_with_digits_is_ok(word):
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
-                # Use original token because is_word_match_any_tz is case sensitive
-                elif translated_chunk and is_word_match_any_tz(original_tokens[i]):
+                # Use original token because word_is_tz is case sensitive
+                elif translated_chunk and word_is_tz(original_tokens[i]):
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
                 else:

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -44,6 +44,16 @@ def pop_tz_offset_from_string(date_string, as_offset=True):
         return date_string, None
 
 
+def is_word_match_any_tz(word):
+    # The regex only interests in timezone not at the beginning
+    word = ' ' + word
+    for name, info in _tz_offsets:
+        timezone_re = info['regex']
+        if timezone_re.match(word):
+            return True
+    return False
+
+
 def convert_to_local_tz(datetime_obj, datetime_tz_offset):
     return datetime_obj - datetime_tz_offset + local_tz_offset
 

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -44,7 +44,7 @@ def pop_tz_offset_from_string(date_string, as_offset=True):
         return date_string, None
 
 
-def is_word_match_any_tz(word):
+def word_is_tz(word):
     return bool(_search_regex.match(word))
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -252,8 +252,9 @@ class TestTranslateSearch(BaseTestCase):
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # Dutch
-        param('nl', 'Sinds 1 juli 2014 is hij burgemeester van Changwon geweest',
-              [('1 juli 2014', datetime.datetime(2014, 7, 1, 0, 0))],
+        param('nl', ' De meest dramatische uitbreiding van het conflict vond plaats op 22 juni 1941 met de '
+                    'Duitse aanval op de Sovjet-Unie.',
+              [('22 juni 1941', datetime.datetime(1941, 6, 22, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # English
@@ -285,8 +286,10 @@ class TestTranslateSearch(BaseTestCase):
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # French
-        param('fr', 'Consultez tous les articles et vidéos publiés le 15 septembre 2002 sur Le Monde ou parus dans le journal',
-              [('le 15 septembre 2002', datetime.datetime(2002, 9, 15, 0, 0))],
+        param('fr', 'La 2e Guerre mondiale, ou Deuxième Guerre mondiale4, est un conflit armé à '
+                    'l\'échelle planétaire qui dura du 1 septembre 1939 au 2 septembre 1945.',
+              [('1 septembre 1939', datetime.datetime(1939, 9, 1, 0, 0)),
+               ('2 septembre 1945', datetime.datetime(1945, 9, 2, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # Hebrew

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 from parameterized import parameterized, param
 from tests import BaseTestCase
+from dateparser.timezone_parser import StaticTzInfo
 from dateparser.search.search import DateSearchWithDetection
 from dateparser.search import search_dates
 from dateparser.conf import Settings, apply_settings
@@ -34,6 +35,7 @@ class TestTranslateSearch(BaseTestCase):
     @parameterized.expand([
         param('en', "Sep 03 2014"),
         param('en', "friday, 03 september 2014"),
+        param('en', 'Aug 06, 2018 05:05 PM CDT'),
         # Chinese
         param('zh', "1年11个月"),
         param('zh', "1年11個月"),
@@ -250,9 +252,8 @@ class TestTranslateSearch(BaseTestCase):
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # Dutch
-        param('nl', ' De meest dramatische uitbreiding van het conflict vond plaats op 22 juni 1941 met de '
-                    'Duitse aanval op de Sovjet-Unie.',
-              [('22 juni 1941', datetime.datetime(1941, 6, 22, 0, 0))],
+        param('nl', 'Sinds 1 juli 2014 is hij burgemeester van Changwon geweest',
+              [('1 juli 2014', datetime.datetime(2014, 7, 1, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # English
@@ -267,6 +268,11 @@ class TestTranslateSearch(BaseTestCase):
               [('July 13th', datetime.datetime(2000, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2000, 7, 14, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
+        param('en', 'last updated Aug 06, 2018 05:05 PM CDT',
+              [(
+                  'Aug 06, 2018 05:05 PM CDT',
+                  datetime.datetime(2018, 8, 6, 17, 5, tzinfo=StaticTzInfo('CDT', datetime.timedelta(seconds=-18000))))],
+              settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # Filipino / Tagalog
         param('tl', 'Maraming namatay sa mga Hapon hanggang sila\'y sumuko noong Agosto 15, 1945.',
@@ -279,10 +285,8 @@ class TestTranslateSearch(BaseTestCase):
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # French
-        param('fr', 'La 2e Guerre mondiale, ou Deuxième Guerre mondiale4, est un conflit armé à '
-                    'l\'échelle planétaire qui dura du 1 septembre 1939 au 2 septembre 1945.',
-              [('1 septembre 1939', datetime.datetime(1939, 9, 1, 0, 0)),
-               ('2 septembre 1945', datetime.datetime(1945, 9, 2, 0, 0))],
+        param('fr', 'Consultez tous les articles et vidéos publiés le 15 septembre 2002 sur Le Monde ou parus dans le journal',
+              [('le 15 septembre 2002', datetime.datetime(2002, 9, 15, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # Hebrew


### PR DESCRIPTION
`dateparser.search.search_dates` does not capture timezone info while `dateparser.parse` does. (See #488 )
Added timezone support for the search.

It may bring some false positives if the text contains a word stands for a timezone but not intent to