### PR TITLE
Add 'time' to valid periods

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -17,6 +17,8 @@ class Settings(object):
     * `TIMEZONE`: defaults to `UTC`. Can be timezone abbreviation or any of `tz database name as given here <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
     * `RETURN_AS_TIMEZONE_AWARE`: return tz aware datetime objects in case timezone is detected in the date string.
     * `RELATIVE_BASE`: count relative date from this base date. Should be datetime object.
+    * `RETURN_TIME_AS_PERIOD`: returns period as `time` in case time component is detected in the date string.
+    Default: False.
     """
 
     _default = True

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -270,7 +270,7 @@ class _DateLocaleParser(object):
             return False
         if not date_obj['date_obj']:
             return False
-        if date_obj['period'] not in ('day', 'week', 'month', 'year'):
+        if date_obj['period'] not in ('time', 'day', 'week', 'month', 'year'):
             return False
 
         return True

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -276,6 +276,10 @@ class _parser(object):
                     setattr(self, attr, int(token))
 
     def _get_period(self):
+        if self.settings.RETURN_TIME_AS_PERIOD:
+            if getattr(self, 'time', None):
+                return 'time'
+
         for period in ['time', 'day']:
             if getattr(self, period, None):
                 return 'day'
@@ -445,8 +449,9 @@ class _parser(object):
 
         # correction for preference of day: beginning, current, end
         dateobj = po._correct_for_day(dateobj)
+        period = po._get_period()
 
-        return dateobj, po._get_period()
+        return dateobj, period
 
     def _parse(self, type, token, fuzzy, skip_component=None):
 

--- a/dateparser_data/settings.py
+++ b/dateparser_data/settings.py
@@ -12,5 +12,6 @@ settings = {
     'DATE_ORDER': 'MDY',
     'PREFER_LOCALE_DATE_ORDER': True,
     'FUZZY': False,
-    'STRICT_PARSING': False
+    'STRICT_PARSING': False,
+    'RETURN_TIME_AS_PERIOD': False,
 }

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -139,6 +139,13 @@ When set to `True` if missing any of `day`, `month` or `year` parts, it does not
     >>> parse(u'March', settings={'STRICT_PARSING': True})
     None
 
+``RETURN_TIME_AS_PERIOD`` returns `time` as period in date object, if time component was present in date string.
+Defaults to `False`.
+
+    >>> ddp = DateDataParser(settings={'RETURN_TIME_AS_PERIOD': True})
+    >>> ddp.get_date_data(u'vr jan 24, 2014 12:49')
+    {'date_obj': datetime.datetime(2014, 1, 24, 12, 49), 'period': 'time', 'locale': 'nl'}
+
 
 Language Detection
 ++++++++++++++++++

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -650,6 +650,7 @@ class TestDateLocaleParser(BaseTestCase):
         param(date_obj={'period': 'hour'}),
         param(date_obj=[datetime(2007, 1, 22, 0, 0), 'day']),
         param(date_obj={'date_obj': None, 'period': 'day'}),
+        param(date_obj={'date': datetime(2018, 1, 10, 2, 0), 'period': 'time'}),
     ])
     def test_is_valid_date_obj(self, date_obj):
         self.given_parser(language=['en'], date_string='10 jan 2000',

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -606,6 +606,60 @@ class TestDateParser(BaseTestCase):
         self.then_period_is(period)
 
     @parameterized.expand([
+        param('12th December 2019 19:00', expected=datetime(2019, 12, 12, 19, 0), period='time'),
+        param('9 Jan 11 0:00', expected=datetime(2011, 1, 9, 0, 0), period='time'),
+    ])
+    def test_period_is_time_if_return_time_as_period_setting_applied_and_time_component_present(
+        self, date_string, expected=None, period=None
+    ):
+        self.given_parser(settings={'RETURN_TIME_AS_PERIOD': True})
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.then_date_obj_exactly_is(expected)
+        self.then_period_is(period)
+
+    @parameterized.expand([
+        param('16:00', expected=datetime(2018, 12, 13, 16, 0), period='time'),
+        param('Monday 7:15 AM', expected=datetime(2018, 12, 10, 7, 15), period='time'),
+    ])
+    def test_period_is_time_if_return_time_as_period_and_relative_base_settings_applied_and_time_component_present(
+        self, date_string, expected=None, period=None
+    ):
+        self.given_parser(settings={'RETURN_TIME_AS_PERIOD': True,
+                                    'RELATIVE_BASE': datetime(2018, 12, 13, 15, 15)})
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.then_date_obj_exactly_is(expected)
+        self.then_period_is(period)
+
+    @parameterized.expand([
+        param('12th March 2010', expected=datetime(2010, 3, 12, 0, 0), period='day'),
+        param('21-12-19', expected=datetime(2019, 12, 21, 0, 0), period='day'),
+    ])
+    def test_period_is_day_if_return_time_as_period_setting_applied_and_time_component_is_not_present(
+        self, date_string, expected=None, period=None
+    ):
+        self.given_parser(settings={'RETURN_TIME_AS_PERIOD': True})
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.then_date_obj_exactly_is(expected)
+        self.then_period_is(period)
+
+    @parameterized.expand([
+        param('16:00', expected=datetime(2017, 1, 10, 16, 0), period='day'),
+        param('Monday 7:15 AM', expected=datetime(2017, 1, 9, 7, 15), period='day'),
+    ])
+    def test_period_is_day_if_return_time_as_period_setting_not_applied(
+        self, date_string, expected=None, period=None
+    ):
+        self.given_parser(settings={'RETURN_TIME_AS_PERIOD': False,
+                                    'RELATIVE_BASE': datetime(2017, 1, 10, 15, 15)})
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.then_date_obj_exactly_is(expected)
+        self.then_period_is(period)
+
+    @parameterized.expand([
         param('15-12-18 06:00', expected=datetime(2015, 12, 18, 6, 0), order='YMD'),
         param('15-18-12 06:00', expected=datetime(2015, 12, 18, 6, 0), order='YDM'),
         param('10-11-12 06:00', expected=datetime(2012, 10, 11, 6, 0), order='MDY'),


### PR DESCRIPTION
Use `time` period as signal that time has been parsed in date string.

Closes https://github.com/scrapinghub/dateparser/issues/313.