### PR TITLE
Strings with only separators must not be considered valid dates

### DIFF
--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -103,6 +103,10 @@ class Dictionary(object):
 
         :return: True if tokens are valid, False otherwise.
         """
+        has_only_keep_tokens = not set(tokens) - set(ALWAYS_KEEP_TOKENS)
+        if has_only_keep_tokens:
+            return False
+
         match_relative_regex = self._get_match_relative_regex_cache()
         for token in tokens:
             if any([match_relative_regex.match(token),

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -703,6 +703,20 @@ class TestDateParser(BaseTestCase):
         self.then_date_was_parsed_by_date_parser()
         self.then_date_obj_exactly_is(expected)
 
+    @parameterized.expand([
+        param('::', None),
+        param('..', None),
+        param('  ', None),
+        param('--', None),
+        param('//', None),
+        param('++', None),
+    ])
+    def test_parsing_strings_containing_only_separator_tokens(self, date_string, expected):
+        self.given_parser()
+        self.when_date_is_parsed(date_string)
+        self.then_period_is('day')
+        self.then_date_obj_exactly_is(expected)
+
     def given_local_tz_offset(self, offset):
         self.add_patch(
             patch.object(dateparser.timezone_parser,


### PR DESCRIPTION
Consider strings containing only separators as not valid, returning `None` when trying to parse it.

This should fix the first comment in #568 .