### PR TITLE
Fixa "X days ago" in norwegian, and more

### DIFF
--- a/dateparser/data/date_translation_data/nb.py
+++ b/dateparser/data/date_translation_data/nb.py
@@ -93,15 +93,18 @@ info = {
     ],
     "week": [
         "uke",
-        "u"
+        "u",
+        "uker"
     ],
     "day": [
         "dag",
-        "d"
+        "d",
+        "dager"
     ],
     "hour": [
         "time",
-        "t"
+        "t",
+        "timer"
     ],
     "minute": [
         "minutt",
@@ -197,7 +200,8 @@ info = {
         ],
         "\\1 day ago": [
             "for (\\d+) døgn siden",
-            "for (\\d+) d siden"
+            "for (\\d+) d siden",
+            "for (\\d+) dager siden"
         ],
         "in \\1 hour": [
             "om (\\d+) time",
@@ -235,6 +239,12 @@ info = {
             "name": "nb-SJ"
         }
     },
+    "ago": [
+        "siden"
+    ],
+    "in": [
+        "om"
+    ],
     "skip": [
         " ",
         ".",

--- a/dateparser_data/supplementary_language_data/date_translation_data/nb.yaml
+++ b/dateparser_data/supplementary_language_data/date_translation_data/nb.yaml
@@ -1,0 +1,15 @@
+week:
+    - uker
+day:
+    - dager
+hour:
+    - timer
+
+ago:
+    - siden
+in:
+    - om
+
+relative-type-regex:
+  \1 day ago:
+      - for (\d+) dager siden

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ nose
 parameterized
 six
 coverage
+flake8

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1415,6 +1415,13 @@ class TestBundledLanguages(BaseTestCase):
         param('nb', "om 6 timer", "in 6 hour"),
         param('nb', "om 2 måneder", "in 2 month"),
         param('nb', "forrige uke", "1 week ago"),
+        param('nb', "for 3 dager siden", "3 day ago"),
+        param('nb', "for 3 timer siden", "3 hour ago"),
+        param('nb', '3 dager siden', '3 day ago'),
+        param('nb', "3 mnd siden", "3 month ago"),
+        param('nb', "2 uker siden", "2 week ago"),
+        param('nb', "1 uke siden", "1 week ago"),
+        param('nb', "10 timer siden", "10 hour ago"),
         # nd
         param('nd', "kusasa", "in 1 day"),
         param('nd', "izolo", "1 day ago"),


### PR DESCRIPTION
Here's a new PR (succeeding https://github.com/scrapinghub/dateparser/pull/592) implementing "X days ago", adding also some missing pluralis words such as "hours", "days", and more into a new `nb.yaml` file as requested.

I also noticed `flake8` was not required in the project although it is documented that it should be used, so I added it.

Please have a look, thanks!