### PR TITLE
fix self.filtered_tokens bug that cause an exception for some characters in datestring

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -189,7 +189,7 @@ class _parser(object):
     def __init__(self, tokens, settings):
         self.settings = settings
         self.tokens = list(tokens)
-        self.filtered_tokens = [t for t in self.tokens if t[1] <= 1]
+        self.filtered_tokens = [t for t in self.tokens if isinstance(t[1],int) and t[1] <= 1]
 
         self.unset_tokens = []
 


### PR DESCRIPTION
I use jalali parser for parse some jalali datetime string in my crawler.  it throws an exception for this string: "۱۳۹۸/۰۶/۳۱ در  ۱۴:۵۲"  because of "در" word. in line 192 of dateparser/parser.py , when use t[1] < 1 , for that word, tokens contain ('د','') and ('ر','') items and for these items, t[1] is str , not int. then it cause an exception. 'در' == "at" 