### PR TITLE
add jalali parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -465,11 +465,12 @@ Supported Calendars
 
 * Persian Jalali calendar. For more information, refer to `Persian Jalali Calendar <https://en.wikipedia.org/wiki/Iranian_calendars#Zoroastrian_calendar>`_.
 
-* Hijri/Islamic Calendar. For more information, refer to `Hijri Calendar <https://en.wikipedia.org/wiki/Islamic_calendar>`_.
-
     >>> from dateparser.calendars.jalali import JalaliCalendar
     >>> JalaliCalendar(u'جمعه سی ام اسفند ۱۳۸۷').get_date()
     {'date_obj': datetime.datetime(2009, 3, 20, 0, 0), 'period': 'day'}
+
+
+* Hijri/Islamic Calendar. For more information, refer to `Hijri Calendar <https://en.wikipedia.org/wiki/Islamic_calendar>`_.
 
     >>> from dateparser.calendars.hijri import HijriCalendar
     >>> HijriCalendar(u'17-01-1437 هـ 08:30 مساءً').get_date()

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -9,6 +9,7 @@ import six
 import regex as re
 from dateutil.relativedelta import relativedelta
 
+from dateparser.calendars.jalali import JalaliCalendar
 from dateparser.date_parser import date_parser
 from dateparser.freshness_date_parser import freshness_date_parser
 from dateparser.languages.loader import LocaleDataLoader
@@ -179,6 +180,7 @@ class _DateLocaleParser(object):
             'custom-formats': self._try_given_formats,
             'absolute-time': self._try_parser,
             'base-formats': self._try_hardcoded_formats,
+            'jalali': self._try_jalali_calendar,
         }
         unknown_parsers = set(self._settings.PARSERS) - set(self._parsers.keys())
         if unknown_parsers:
@@ -255,6 +257,9 @@ class _DateLocaleParser(object):
             )
         except TypeError:
             return None
+
+    def _try_jalali_calendar(self):
+        return JalaliCalendar(self.date_string).get_date()
 
     def _get_translated_date(self):
         if self._translated_date is None:

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -362,6 +362,7 @@ class DateDataParser(object):
         self.locales = locales
         self.region = region
         self.previous_locales = set()
+        self.default_locales = None
 
     def get_date_data(self, date_string, date_formats=None):
         """
@@ -418,6 +419,11 @@ class DateDataParser(object):
 
         date_string = sanitize_date(date_string)
 
+        if 'jalali' in self._settings.PARSERS:
+            # add 'fa' as a default locale when using the jalali parser
+            locale_loader = self._get_locale_loader()
+            self.default_locales = [locale_loader.get_locale('fa')]
+
         for locale in self._get_applicable_locales(date_string):
             parsed_date = _DateLocaleParser.parse(
                 locale, date_string, date_formats, settings=self._settings)
@@ -458,6 +464,10 @@ class DateDataParser(object):
                 for s in date_strings():
                     if self._is_applicable_locale(locale, s):
                         yield locale
+
+        if self.default_locales:
+            for locale in self.default_locales:
+                yield locale
 
         for locale in self._get_locale_loader().get_locales(
                 languages=self.languages, locales=self.locales, region=self.region,

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -589,6 +589,16 @@ class TestDateParser(BaseTestCase):
         self.then_date_obj_exactly_is(expected)
 
     @parameterized.expand([
+        # Jalali dates
+        param(u'جمعه سی ام اسفند ۱۳۸۷', expected=datetime(2009, 3, 20, 0, 0)),
+        param(u'۱۳۹۸/۰۶/۳۱ در ۱۴:۵۲', expected=datetime(2019, 9, 22, 14, 52)),
+    ])
+    def test_jalali_parser(self, date_string, expected):
+        self.given_parser(settings={'PARSERS': ['jalali']})
+        self.when_date_is_parsed(date_string)
+        self.then_date_obj_exactly_is(expected)
+
+    @parameterized.expand([
         param('10 December', expected=datetime(2015, 12, 10), period='day'),
         param('March', expected=datetime(2015, 3, 15), period='month'),
         param('April', expected=datetime(2015, 4, 15), period='month'),


### PR DESCRIPTION
As we implemented the `PARSERS` settings I thought that it could be a good idea to add an optional `jalali` parser.

In this way, it shouldn't be necessary to do this (as explained in the docs):
```
from dateparser.calendars.jalali import JalaliCalendar
JalaliCalendar(<jalali-string>).get_date()
```

And we could directly do this:
```
>>> dateparser.parse("۱۳۹۸/۰۶/۳۱ در ۱۴:۵۲", settings={'PARSERS': ['jalali']})  
datetime.datetime(2019, 9, 22, 14, 52)
```

(My idea is not to include it in the default parsers list, and to allow to enable it by changing the settings or through the settings param)

The current implementation I've done it's working for the example above, however, it's not working for this example:
```
>>> dateparser.parse(u'جمعه سی ام اسفند ۱۳۸۷', settings={'PARSERS': ['jalali']})
```

However, using the `JaliliCalendar` directly works for both examples:
```
>>> from dateparser.calendars.jalali import JalaliCalendar
>>> JalaliCalendar(u'جمعه سی ام اسفند ۱۳۸۷').get_date()
{'date_obj': datetime.datetime(2009, 3, 20, 0, 0), 'period': 'day'}

```

As far as I see this is due to the fact that before calling the parsers, in `get_date_data` we try to decide which language is used, and while the first example is correctly detected as Persian (`fa`), the second example is not detected as Persian and it returns an empty date object.

I'm not sure what to do. We could improve the Persian support, but maybe it doesn't make sense if we don't need to know that it's Persian to use the new `jalili` parser. 

What do you think? any feedback? @Gallaecio 

Thanks in advance


P.S: Of course, my idea after deciding how to proceed is to do the same with the Hijri calendar.