### PR TITLE
add _mod_settings to settings and fix DATE_ORDER

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -24,6 +24,7 @@ class Settings(object):
 
     _default = True
     _pyfile_data = None
+    _mod_settings = dict()
 
     def __init__(self, settings=None):
         if settings:
@@ -50,7 +51,7 @@ class Settings(object):
         for key, value in iterable:
             setattr(self, key, value)
 
-    def replace(self, **kwds):
+    def replace(self, mod_settings=None, **kwds):
         for k, v in six.iteritems(kwds):
             if v is None:
                 raise TypeError('Invalid {{"{}": {}}}'.format(k, v))
@@ -59,6 +60,8 @@ class Settings(object):
             kwds.setdefault(x, getattr(self, x))
 
         kwds['_default'] = False
+        if mod_settings:
+            kwds['_mod_settings'] = mod_settings
 
         return self.__class__(settings=kwds)
 
@@ -69,13 +72,11 @@ settings = Settings()
 def apply_settings(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        kwargs['settings'] = kwargs.get('settings', settings)
-
-        if kwargs['settings'] is None:
-            kwargs['settings'] = settings
+        mod_settings = kwargs.get('settings')
+        kwargs['settings'] = mod_settings or settings
 
         if isinstance(kwargs['settings'], dict):
-            kwargs['settings'] = settings.replace(**kwargs['settings'])
+            kwargs['settings'] = settings.replace(mod_settings=mod_settings, **kwargs['settings'])
 
         if not isinstance(kwargs['settings'], Settings):
             raise TypeError(

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -214,10 +214,9 @@ class _DateLocaleParser(object):
 
     def _try_parser(self):
         _order = self._settings.DATE_ORDER
-        _default_date_order = self._settings._pyfile_data.get('DATE_ORDER')
         try:
             if self._settings.PREFER_LOCALE_DATE_ORDER:
-                if _order == _default_date_order:
+                if 'DATE_ORDER' not in self._settings._mod_settings:
                     self._settings.DATE_ORDER = self.locale.info.get('date_order', _order)
             date_obj, period = date_parser.parse(
                 self._get_translated_date(), settings=self._settings)

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -694,6 +694,10 @@ class TestDateParser(BaseTestCase):
         param('10.1.2019', expected=datetime(2019, 1, 10, 0, 0), languages=['de']),
         param('10.1.2019', expected=datetime(2019, 10, 1, 0, 0),
               settings={'DATE_ORDER': 'MDY'}),
+        param('03/11/2559 05:13', datetime(2559, 3, 11, 5, 13), languages=["th"],
+              settings={"DATE_ORDER": "MDY"}),
+        param('03/15/2559 05:13', datetime(2559, 3, 15, 5, 13), languages=["th"],
+              settings={"DATE_ORDER": "MDY"})
     ])
     def test_if_settings_provided_date_order_is_retained(
         self, date_string, expected=None, languages=None, settings=None


### PR DESCRIPTION
At this moment we don't know which settings are modified directly by a `settings` parameter.

Implementing this we can access to the `settings._mod_settings` to know which fields have been expressly modified by using a `settings` parameter.

Moreover, with this we can fix this bug: https://github.com/scrapinghub/dateparser/issues/589 thas was introduced when fixing this https://github.com/scrapinghub/dateparser/issues/551 (PR: https://github.com/scrapinghub/dateparser/pull/558).

Both things are addressed in this PR.

Fixes #589