### PR TITLE
fix prefer dates from to exclude wrong words

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -128,8 +128,8 @@ class FreshnessDateDataParser(object):
         td = relativedelta(**kwargs)
         if (
             re.search(r'\bin\b', date_string) or
-            ('future' in prefer_dates_from and
-             not re.search(r'\bago\b', date_string))
+            re.search(r'\bfuture\b', prefer_dates_from) and
+            not re.search(r'\bago\b', date_string)
         ):
             date = self.now + td
         else:


### PR DESCRIPTION

At this moment if we use a wrong word in `PREFER_DATES_FROM` containing the word "future" (for example "afuture") the relative-time parser takes it as equivalent to "future". 

Now:
```
>>> dateparser.parse('3 days', settings={'PREFER_DATES_FROM': 'afuture'}) 
datetime.datetime(2020, 3, 10, 10, 40, 58, 68963)  # future (today is 7th)
```

After merging this PR: 
```
>>> dateparser.parse('3 days', settings={'PREFER_DATES_FROM': 'afuture'}) 
datetime.datetime(2020, 3, 4, 10, 40, 58, 68963) # past

```

As "afuture" is an invalid value, we shouldn't treat it as "future". 


I think we should add a warning when the value of `PREFER_DATES_FROM` is not `future` or `past`.