### PR TITLE
wip:settings validation

### DIFF
--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -2,7 +2,7 @@
 __version__ = '0.7.6'
 
 from .date import DateDataParser
-from .conf import apply_settings
+from .conf import apply_settings, _check_settings
 
 _default_parser = DateDataParser()
 
@@ -47,6 +47,7 @@ def parse(date_string, date_formats=None, languages=None, locales=None, region=N
     parser = _default_parser
 
     if languages or locales or region or not settings._default:
+        _check_settings(settings)
         parser = DateDataParser(languages=languages, locales=locales,
                                 region=region, settings=settings)
 

--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -2,7 +2,7 @@
 __version__ = '0.7.6'
 
 from .date import DateDataParser
-from .conf import apply_settings, _check_settings
+from .conf import apply_settings
 
 _default_parser = DateDataParser()
 
@@ -47,7 +47,6 @@ def parse(date_string, date_formats=None, languages=None, locales=None, region=N
     parser = _default_parser
 
     if languages or locales or region or not settings._default:
-        _check_settings(settings)
         parser = DateDataParser(languages=languages, locales=locales,
                                 region=region, settings=settings)
 

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -98,8 +98,6 @@ class SettingValidationError(ValueError):
 
 
 def check_settings(settings):
-    # move this checks to be performed inside DateDataParser constructor??
-
     settings_values = {
         # Date order
         'DATE_ORDER': {

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -5,6 +5,7 @@ import six
 
 from .utils import registry
 
+
 @registry
 class Settings(object):
     """Control and configure default parsing behavior of dateparser.
@@ -84,3 +85,40 @@ def apply_settings(f):
 
         return f(*args, **kwargs)
     return wrapper
+
+
+def _check_settings(settings):
+    valid_values = {
+        'PREFER_DATES_FROM': {
+            'values': ('past', 'future', 'current_period'),
+            'default': 'current_period',
+            'raise_error': False
+        },
+        'PREFER_DAY_OF_MONTH': {
+            'values': ('current', 'first', 'last'),
+            'default': 'current',
+            'raise_error': False
+        },
+        'DATE_ORDER': {
+            'values': ('MDY', 'MYD', 'DMY', 'DYM', 'YDM', 'YMD'),
+            # TODO: extract from parser.py --> resolve_date_order --> chart?
+            'default': 'MDY',
+            'raise_error': True
+        }
+    }
+
+    for setting, val in valid_values.items():
+        if getattr(settings, setting) not in valid_values[setting]['values']:
+            message = \
+                "\"{}\" is not a valid value for {}, it should be: '{}' " \
+                "or '{}'. Using default behaviour: '{}'".format(
+                    getattr(settings, setting),
+                    setting,
+                    "', '".join(val['values'][:-1]),
+                    val['values'][-1],
+                    val['default']
+                )
+
+            if val['raise_error']:
+                raise ValueError(message)
+            print(message)  # TODO: change to logger

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -12,7 +12,7 @@ from dateutil.relativedelta import relativedelta
 from dateparser.date_parser import date_parser
 from dateparser.freshness_date_parser import freshness_date_parser
 from dateparser.languages.loader import LocaleDataLoader
-from dateparser.conf import apply_settings
+from dateparser.conf import apply_settings, check_settings
 from dateparser.timezone_parser import pop_tz_offset_from_string
 from dateparser.utils import apply_timezone_from_settings, \
     set_correct_day_from_settings
@@ -349,6 +349,8 @@ class DateDataParser(object):
 
         if not locales and use_given_order:
             raise ValueError("locales must be given if use_given_order is True")
+
+        check_settings(settings)
 
         self._settings = settings
         self.try_previous_locales = try_previous_locales

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -140,6 +140,7 @@ class InvalidSettingsTest(BaseTestCase):
             test_func(settings={'TO_TIMEZONE': None})
 
     def test_error_is_raised_for_invalid_type_settings(self):
+        # TODO: check
         test_func = apply_settings(test_function)
         try:
             test_func(settings=['current_period', False, 'current'])


### PR DESCRIPTION
I think we should add warnings if the values of the settings are not the expected. 

I have done this PR to illustrate the idea of a common framework to do it.


Examples:
```
>>> dateparser.parse('3 days', settings={'PREFER_DAY_OF_MONTH': 'aaaa'}) 
"aaaa" is not a valid value for PREFER_DAY_OF_MONTH, it should be: 'current', 'first' or 'last'. Using default behaviour: 'current'
datetime.datetime(2020, 3, 4, 16, 36, 3, 322839)
```

```
>>> dateparser.parse('3 days', settings={'PREFER_DATES_FROM': 'afuture'})
"afuture" is not a valid value for PREFER_DATES_FROM, it should be: 'past', 'future' or 'current_period'. Using default behaviour: 'current_period'
datetime.datetime(2020, 3, 10, 16, 37, 25, 516574)
```

```
>>> dateparser.parse('03/04/05', settings={'DATE_ORDER': 'DEE'}) 
ValueError: "DEE" is not a valid value for DATE_ORDER, it should be: 'MDY', 'MYD', 'DMY', 'DYM', 'YDM' or 'YMD'. Using default behaviour: 'MDY'
```


Let me know what you think or any idea you have.