### PR TITLE
Fix GMT and UTC parsing

### DIFF
--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -8,14 +8,15 @@ timezone_info_list = [
         'regex_patterns':
             [r'(.)%s$',],
         'replace':
-            [(r'UTC', r''),
-             (r':', r''),
-             (r':|UTC', r''),
-             (r'UTC', r'GMT'),
+            [
              (r'(?:UTC|GMT)\\(\+|\-)0(\d):00', r'(?:UTC|GMT)\\\1\2'),   # UTC+n, UTC-n, GMT+n, GMT-n
              (r'(?:UTC|GMT)\\(\+|\-)0(\d):(\d{2})', r'(?:UTC|GMT)\\\1\2:\3'),   # UTC+n:mm, UTC-n:mm,GMT+n:mm, GMT-n:mm
              (r'(?:UTC|GMT)\\(\+|\-)(\d{2}):00', r'(?:UTC|GMT)\\\1\2'),     # UTC+nn, UTC-nn, GMT+nn, GMT-nn
-             (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})', r'(?:UTC|GMT)\1\2\3.*'),     # UTC+nnmm, , UTC-nnmm, GMT+nnmm, GMT-nnmm
+             (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})', r'(?:UTC|GMT)\1\2:?\3.*'),     # UTC+nnmm, , UTC-nnmm, GMT+nnmm, GMT-nnmm
+             (r'UTC', r''),
+             (r':', r''),
+             (r':|UTC', r''),
+             (r'UTC', r'GMT'),
             ],
         'timezones':
             [(r'UTC\-12:00', -43200),

--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -11,13 +11,12 @@ timezone_info_list = [
             [(r'UTC', r''),
              (r':', r''),
              (r':|UTC', r''),
-             (r'UTC\\(\+|\-)0(\d):00', r'UTC\\\1\2'), # UTC+n, UTC-n
-             (r'UTC\\(\+|\-)0(\d):(\d\d)', r'UTC\\\1\2:\3'), # UTC+n:mm, UTC-n:mm
              (r'UTC', r'GMT'),
-             (r'UTC\\(\+|\-)0(\d):00', r'GMT\\\1\2'), # GMT+n, GMT-n
-             (r'UTC\\(\+|\-)0(\d):(\d\d)', r'GMT\\\1\2:\3'), # GMT+n:mm, GMT-n:mm
-             (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})\$', r'(?:UTC|GMT)\1\2\3.*'), # GMT+nnmm
-             ],
+             (r'(?:UTC|GMT)\\(\+|\-)0(\d):00', r'(?:UTC|GMT)\\\1\2'),   # UTC+n, UTC-n, GMT+n, GMT-n
+             (r'(?:UTC|GMT)\\(\+|\-)0(\d):(\d{2})', r'(?:UTC|GMT)\\\1\2:\3'),   # UTC+n:mm, UTC-n:mm,GMT+n:mm, GMT-n:mm
+             (r'(?:UTC|GMT)\\(\+|\-)(\d{2}):00', r'(?:UTC|GMT)\\\1\2'),     # UTC+nn, UTC-nn, GMT+nn, GMT-nn
+             (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})', r'(?:UTC|GMT)\1\2\3.*'),     # UTC+nnmm, , UTC-nnmm, GMT+nnmm, GMT-nnmm
+            ],
         'timezones':
             [(r'UTC\-12:00', -43200),
              (r'UTC\-11:00', -39600),

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -47,6 +47,10 @@ class TestTZPopping(BaseTestCase):
         param('April 10, 2016 at 12:00:00 UTC-09:30', -9.5),
         param('Thu, 24 Nov 2016 16:03:00 UT', 0),
         param('Fri Sep 23 2016 10:34:51 GMT+0800 (CST)', 8),
+        param('Fri Sep 23 2016 10:34:51 GMT+12', 12),
+        param('Fri Sep 23 2016 10:34:51 UTC+13', 13),
+        param('Fri Sep 23 2016 10:34:51 GMT+1245 (CST)', 12.75),
+        param('Fri Sep 23 2016 10:34:51 UTC+1245', 12.75),
         param('2019-07-17T12:30:00.000-03:30', -3.5),
         param('2019-07-17T12:30:00.000-02:30', -2.5),
     ])


### PR DESCRIPTION
Fixes #615

- defined regex were unable to perform double digit parsing for GMT as well as UTC timezone inputs.
- eg: UTC +12, UTC +1245, GMT +13, GMT +0230


Added support for double-digit parsing.
fixed regex tuples to parse GMT timezone for (GMT|UTC)[-|+]nn and (GMT|UTC)[-|+]nmm format.