### PR TITLE
Changing parse behaviour for 8 digit date

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -25,11 +25,6 @@ def no_space_parser_eligibile(datestring):
 
     return False
 
-def is_8_digit_number(datestring):
-    if EIGHT_DIGIT.match(datestring) is None:
-        return False
-    return True
-
 def get_unresolved_attrs(parser_object):
     attrs = ['year', 'month', 'day']
     seen = []
@@ -153,7 +148,7 @@ class _no_spaces_parser(object):
     def _find_best_matching_date(cls, datestring):
         for fmt in cls._preferred_formats_ordered_8_digit:
             try:
-                dt = strptime(datestring, fmt), cls._get_period(fmt)
+                dt = strptime(datestring, fmt), cls._get_period(fmt)                
                 if len(str(dt[0].year)) == 4:
                     return dt
             except:
@@ -173,7 +168,7 @@ class _no_spaces_parser(object):
             order = resolve_date_order(settings.DATE_ORDER)
         else:
             order = cls._default_order
-            if is_8_digit_number(datestring):
+            if bool(EIGHT_DIGIT.match(datestring)):
                 dt = cls._find_best_matching_date(datestring)
                 if dt is not None:    
                     return dt               

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -25,6 +25,7 @@ def no_space_parser_eligibile(datestring):
 
     return False
 
+
 def get_unresolved_attrs(parser_object):
     attrs = ['year', 'month', 'day']
     seen = []
@@ -93,6 +94,7 @@ class _time_parser(object):
         else:
             raise ValueError('%s does not seem to be a valid time string' % _timestring)
 
+
 time_parser = _time_parser()
 
 
@@ -106,7 +108,7 @@ class _no_spaces_parser(object):
 
     _preferred_formats = ['%Y%m%d%H%M', '%Y%m%d%H%M%S', '%Y%m%d%H%M%S.%f']
 
-    _preferred_formats_ordered_8_digit = ['%m%d%Y' , '%d%m%Y' , '%Y%m%d' , '%Y%d%m' , '%m%Y%d' , '%d%Y%m']
+    _preferred_formats_ordered_8_digit = ['%m%d%Y', '%d%m%Y', '%Y%m%d', '%Y%d%m', '%m%Y%d', '%d%Y%m']
 
     _timeformats = ['%H%M%S.%f', '%H%M%S', '%H%M', '%H']
 
@@ -122,7 +124,7 @@ class _no_spaces_parser(object):
         self._all = (self._dateformats +
                      [x+y for x in self._dateformats for y in self._timeformats] +
                      self._timeformats)
-        
+
         self.date_formats = {
             '%m%d%y': (
                 self._preferred_formats +
@@ -148,13 +150,13 @@ class _no_spaces_parser(object):
     def _find_best_matching_date(cls, datestring):
         for fmt in cls._preferred_formats_ordered_8_digit:
             try:
-                dt = strptime(datestring, fmt), cls._get_period(fmt)                
+                dt = strptime(datestring, fmt), cls._get_period(fmt)
                 if len(str(dt[0].year)) == 4:
                     return dt
             except:
                 pass
         return None
-        
+
     @classmethod
     def parse(cls, datestring, settings):
         if not no_space_parser_eligibile(datestring):
@@ -170,8 +172,8 @@ class _no_spaces_parser(object):
             order = cls._default_order
             if bool(EIGHT_DIGIT.match(datestring)):
                 dt = cls._find_best_matching_date(datestring)
-                if dt is not None:    
-                    return dt               
+                if dt is not None:
+                    return dt
         nsp = cls()
         ambiguous_date = None
         for token, _ in tokens.tokenize():

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -170,7 +170,7 @@ class _no_spaces_parser(object):
             order = resolve_date_order(settings.DATE_ORDER)
         else:
             order = cls._default_order
-            if bool(EIGHT_DIGIT.match(datestring)):
+            if EIGHT_DIGIT.match(datestring):
                 dt = cls._find_best_matching_date(datestring)
                 if dt is not None:
                     return dt

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,7 +98,6 @@ class TestNoSpaceParser(BaseTestCase):
         self.when_date_is_parsed('2013 25 12')
         self.then_date_is_not_parsed()
 
-
     @parameterized.expand([
         param(
             date_string=u":",
@@ -270,7 +269,6 @@ class TestNoSpaceParser(BaseTestCase):
         self.then_date_exactly_is(expected_date)
         self.then_period_exactly_is(expected_period)
 
-
     @parameterized.expand([
         param(
             date_string=u"20110101",
@@ -290,6 +288,16 @@ class TestNoSpaceParser(BaseTestCase):
         param(
             date_string=u"20202001",
             expected_date=datetime(2020, 1, 20),
+            expected_period='day',
+        ),
+        param(
+            date_string=u"20202020",
+            expected_date=datetime(2002, 2, 2, 0, 2),
+            expected_period='day',
+        ),
+        param(
+            date_string=u"12345678",
+            expected_date=datetime(1234, 5, 6, 7, 8),
             expected_period='day',
         ),
     ])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -270,6 +270,36 @@ class TestNoSpaceParser(BaseTestCase):
         self.then_date_exactly_is(expected_date)
         self.then_period_exactly_is(expected_period)
 
+
+    @parameterized.expand([
+        param(
+            date_string=u"20110101",
+            expected_date=datetime(2011, 1, 1),
+            expected_period='day',
+        ),
+        param(
+            date_string=u"01201702",
+            expected_date=datetime(1702, 1, 20),
+            expected_period='day',
+        ),
+        param(
+            date_string=u"01202020",
+            expected_date=datetime(2020, 1, 20),
+            expected_period='day',
+        ),
+        param(
+            date_string=u"20202001",
+            expected_date=datetime(2020, 1, 20),
+            expected_period='day',
+        ),
+    ])
+    def test_best_order_used_if_date_order_not_supplied_to_8_digit_numbers(self, date_string, expected_date, expected_period):
+        self.given_parser()
+        self.given_settings(settings={'DATE_ORDER': ''})
+        self.when_date_is_parsed(date_string)
+        self.then_date_exactly_is(expected_date)
+        self.then_period_exactly_is(expected_period)
+
     @parameterized.expand([
         param(date_string=u"12345678901234567890", date_order='YMD'),
         param(date_string=u"987654321234567890123456789", date_order='DMY'),


### PR DESCRIPTION
Fixes #618 
An attempt at #618 , the objective is to improve the parsing of dates of the form XXXXXXXX (Any 8 digit number).

Updated parsing results after this fix

- ` 20202001  datetime.datetime(2020, 1, 20, 0, 0)`
- ` 01201702  datetime.datetime(1702, 1, 20, 0, 0)`
- ` 01202020  datetime.datetime(2020, 1, 20, 0, 0)`
- ` 20202020  datetime.datetime(2002, 2, 2, 0, 2)`

For the last case `20202020` it's going back to the default behavior. 