### PR TITLE
fix tests when running in a different timezone than UTC

### DIFF
--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -704,13 +704,13 @@ class TestTimestampParser(BaseTestCase):
     def test_timestamp_in_milliseconds(self):
         self.assertEqual(
             date.get_date_from_timestamp(u'1570308760263', None),
-            datetime.utcfromtimestamp(1570308760).replace(microsecond=263000)
+            datetime.fromtimestamp(1570308760).replace(microsecond=263000)
         )
 
     def test_timestamp_in_microseconds(self):
         self.assertEqual(
             date.get_date_from_timestamp(u'1570308760263111', None),
-            datetime.utcfromtimestamp(1570308760).replace(microsecond=263111)
+            datetime.fromtimestamp(1570308760).replace(microsecond=263111)
         )
 
     @parameterized.expand([


### PR DESCRIPTION
As `get_date_from_timestamp` uses `datetime.fromtimestamp` it should be used in the tests (instead of `datetime.utcfromtimestamp`) to avoid them to break when running in different timezones.