### PR TITLE
Test files integrity

### DIFF
--- a/tests/test_dateparser_data_integrity.py
+++ b/tests/test_dateparser_data_integrity.py
@@ -1,0 +1,13 @@
+import os
+
+from scripts.write_complete_data import write_complete_data
+
+
+def test_dateparser_data_integrity():
+    files = write_complete_data(in_memory=True)
+
+    for filename in files:
+        with open(filename, 'rb') as f:
+            assert (
+                f.read().strip() == files[filename].strip()
+            ), "The content of the file \"{}\" doesn't match the content of the generating file.".format(filename)

--- a/tests/test_dateparser_data_integrity.py
+++ b/tests/test_dateparser_data_integrity.py
@@ -1,5 +1,3 @@
-import os
-
 from scripts.write_complete_data import write_complete_data
 
 
@@ -10,4 +8,5 @@ def test_dateparser_data_integrity():
         with open(filename, 'rb') as f:
             assert (
                 f.read().strip() == files[filename].strip()
-            ), "The content of the file \"{}\" doesn't match the content of the generating file.".format(filename)
+            ), "The content of the file \"{}\" doesn't match the content" \
+               " of the generated file.".format(filename)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     -rrequirements.txt
     -rscripts/requirements.txt
     -rtests/requirements.txt
-    -rscripts/requirements.txt
 commands =
     pytest --cov=dateparser {posargs: tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     -rrequirements.txt
     -rscripts/requirements.txt
     -rtests/requirements.txt
+    -rscripts/requirements.txt
 commands =
     pytest --cov=dateparser {posargs: tests}
 


### PR DESCRIPTION
I added a test to check that the content of the files generated by the `write_complete_data` script is correct. This is to avoid merging changes in the `.py` files not reflected in the YAML files (and hopefully the travis pipeline will notify the PR user).


When reviewing please, note that this PR contains this other PR inside: https://github.com/scrapinghub/dateparser/pull/662/