### PR TITLE
add python 3.8 support and clean old tests references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
       dist: xenial
+    - python: 3.8
+      env: TOXENV=py38
+      dist: xenial
 
 install:
 - pip install -U wheel

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -87,7 +87,6 @@ Ready to contribute? Here's how to set up `dateparser` for local development.
     $ pip install -r tests/requirements.txt # install test dependencies
     $ pip install -r scripts/requirements.txt # install script dependencies
     $ flake8 dateparser tests
-    $ nosetests
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv. (Note that we use ``max-line-length = 100`` for flake8, this is configured in ``setup.cfg`` file.)

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ help:
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "clean-test - remove test and coverage artifacts"
 	@echo "lint - check style with flake8"
-	@echo "test - run tests quickly with the default Python"
-	@echo "test-all - run tests on every Python version with tox"
+	@echo "test - run tests on every Python version with tox"
 	@echo "coverage - check code coverage quickly with the default Python"
 	@echo "docs - generate Sphinx HTML documentation, including API docs"
 	@echo "release - package and upload a release"
@@ -36,9 +35,6 @@ lint:
 	flake8 dateparser tests --config=./flake8
 
 test:
-	python setup.py test
-
-test-all:
 	tox
 
 coverage:

--- a/setup.py
+++ b/setup.py
@@ -44,15 +44,14 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
-    test_suite='nose.collector',
-    tests_require=test_requirements
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, pypy
+envlist = py27, py35, py36, py37, py38, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Add Python 3.8 support and clean some references to the old test suite.