### PR TITLE
Fix languge unique chars

### DIFF
--- a/dateparser/search/text_detection.py
+++ b/dateparser/search/text_detection.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from string import digits, punctuation
 from dateparser.search.detection import BaseLanguageDetector
 from dateparser.conf import apply_settings
 from dateparser.utils import normalize_unicode
 
 
 class FullTextLanguageDetector(BaseLanguageDetector):
+    SYMBOL_SET = set(list(digits + punctuation + ' ' + '–'))
+
     def __init__(self, languages):
         super(BaseLanguageDetector, self).__init__()
         self.languages = languages[:]
@@ -21,6 +24,7 @@ class FullTextLanguageDetector(BaseLanguageDetector):
 
         for char_set in self.language_chars:
             unique_chars = char_set
+            unique_chars -= self.SYMBOL_SET
             for other_char_set in self.language_chars:
                 if other_char_set != char_set:
                     unique_chars = unique_chars - other_char_set
@@ -28,9 +32,7 @@ class FullTextLanguageDetector(BaseLanguageDetector):
 
     def character_check(self, date_string, settings):
         date_string_set = set(date_string.lower())
-        symbol_set = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-                      " ", "/", "-", ")", "(", ".", ":", "\\", ",", "'"}
-        if date_string_set & symbol_set == date_string_set:
+        if date_string_set & self.SYMBOL_SET == date_string_set:
             self.languages = [self.languages[0]]
             return
         self.get_unique_characters(settings=settings)
@@ -47,7 +49,7 @@ class FullTextLanguageDetector(BaseLanguageDetector):
                           if j not in indices_to_pop]
 
     @apply_settings
-    def _best_language(self, date_string,  settings=None):
+    def _best_language(self, date_string, settings=None):
         self.character_check(date_string, settings)
         date_string = normalize_unicode(date_string.lower())
         if len(self.languages) == 1:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -628,6 +628,7 @@ class TestTranslateSearch(BaseTestCase):
                     'nhập Albania vào ngày 12 tháng 4 năm 1939.'),
 
         # only digits
+        # TODO: change to en once sentence splitting bug is fixed
         param('en', '2007'),
     ])
     def test_detection(self, shortname, text):
@@ -641,6 +642,12 @@ class TestTranslateSearch(BaseTestCase):
               expected=[('19 марта 2001', datetime.datetime(2001, 3, 19, 0, 0)),
                         ('20 марта', datetime.datetime(2001, 3, 20, 0, 0)),
                         ('21 марта', datetime.datetime(2001, 3, 21, 0, 0))]),
+
+        param(text='july 2018 - december 2020',
+              languages=['en', 'fr'],
+              settings={'PREFER_DAY_OF_MONTH': 'first'},
+              expected=[('july 2018', datetime.datetime(2018, 7, 1, 0, 0)),
+                        ('20 марта', datetime.datetime(2020, 8, 1, 0, 0))]),
 
         param(text='Em outubro de 1936, Alemanha e Itália formaram o Eixo Roma-Berlim.',
               languages=None,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -646,7 +646,7 @@ class TestTranslateSearch(BaseTestCase):
               languages=['en', 'fr'],
               settings={'PREFER_DAY_OF_MONTH': 'first'},
               expected=[('july 2018', datetime.datetime(2018, 7, 1, 0, 0)),
-                        ('20 марта', datetime.datetime(2020, 8, 1, 0, 0))]),
+                        ('december 2020', datetime.datetime(2020, 12, 1, 0, 0))]),
 
         param(text='Em outubro de 1936, Alemanha e Itália formaram o Eixo Roma-Berlim.',
               languages=None,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -628,7 +628,6 @@ class TestTranslateSearch(BaseTestCase):
                     'nhập Albania vào ngày 12 tháng 4 năm 1939.'),
 
         # only digits
-        # TODO: change to en once sentence splitting bug is fixed
         param('en', '2007'),
     ])
     def test_detection(self, shortname, text):


### PR DESCRIPTION
This PR fixed 1 bug and **introduces(unveils?) one bug**

##Bug # 1:
```python
In [7]: search_dates("july 2018 - december 2020", add_detected_language=True)
Out[7]:
[('july 2018', datetime.datetime(2018, 7, 13, 0, 0), 'en'),
 ('december 2020', datetime.datetime(2020, 12, 13, 0, 0), 'en')]

In [8]: search_dates("july 2018 - december 2020", add_detected_language=True, languages=['en','es'])
Out[8]:
[('july 2018', datetime.datetime(2018, 7, 13, 0, 0), 'en'),
 ('december 2020', datetime.datetime(2020, 12, 13, 0, 0), 'en')]

In [9]: search_dates("july 2018 - december 2020", add_detected_language=True, languages=['en','fr'])
Out[9]:
[('2018', datetime.datetime(2018, 5, 13, 0, 0), 'fr'),
 ('2020', datetime.datetime(2020, 5, 13, 0, 0), 'fr')]
```

As you can see, including some languages, like French **(in addition to English)** causes issues with finding dates. This is caused by the `character_check` / `get_unique_characters` methods, some languages had punctuations in their "unique characters", for example "-" for French or '.' for Thai.

Due to this reason the parser things that the text `July 2018 - December 2020` is in French and ignores the months.

This is fixed by making sure that punctuations don't get into the unique chars set.

##Bug # 2

```
In [11]: search_dates("01.09 – 03.09.2017", add_detected_language=True)
Out[11]:
[('01.09', datetime.datetime(2020, 1, 9, 0, 0), 'th'),
 ('03.09.2017', datetime.datetime(2017, 3, 9, 0, 0), 'th')]
```

After I fixed this issue I found another issue that was "hidden" before, the following test: https://github.com/scrapinghub/dateparser/blob/master/tests/test_search.py#L670
Only ever worked because of the previous bug, `01.09 – 03.09.2017` contains dots, so the parser thought it was in Thai, and used the specific Thai word splitter https://github.com/scrapinghub/dateparser/blob/master/dateparser/languages/locale.py#L256

Now that the parser correctly recognizes that the text is not in Thai (so English), it uses the English splitter that splits on dots, which screws up the date.

I tried fixing it as well but I wasn't successful, hopefully you can get it working with your experience with the codebase.

Obviously, due to the second bug, 1 test is failing