### PR TITLE
add support for subscript and superscript numbers

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -151,7 +151,7 @@ class Locale(object):
     def _translate_numerals(self, date_string):
         date_string_tokens = NUMERAL_PATTERN.split(date_string)
         for i, token in enumerate(date_string_tokens):
-            if token.isdigit():
+            if token.isdecimal():
                 date_string_tokens[i] = str(int(token)).zfill(len(token))
                 if isinstance(date_string_tokens[i], bytes):
                     date_string_tokens[i] = date_string_tokens[i].decode('utf-8')

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -599,6 +599,11 @@ class TestDateParser(BaseTestCase):
         param('16:10', expected=datetime(2015, 2, 15, 16, 10), period='day'),
         param('2014', expected=datetime(2014, 2, 15), period='year'),
         param('2008', expected=datetime(2008, 2, 15), period='year'),
+        # subscript and superscript dates
+        param('²⁰¹⁵', expected=datetime(2015, 2, 15), period='year'),
+        param('²⁹/⁰⁵/²⁰¹⁵', expected=datetime(2015, 5, 29), period='day'),
+        param('₁₅/₀₂/₂₀₂₀', expected=datetime(2020, 2, 15), period='day'),
+        param('₃₁ December', expected=datetime(2015, 12, 31), period='day'),
     ])
     def test_extracted_period(self, date_string, expected=None, period=None):
         self.given_local_tz_offset(0)


### PR DESCRIPTION
Partial fix for https://github.com/scrapinghub/dateparser/issues/680

Ref: difference between `isdecimal()` and `isdigit()`: https://stackoverflow.com/questions/22789392/str-isdecimal-and-str-isdigit-difference-example#answer-22789660