### PR TITLE
fix OverflowError in freshness dateparser

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -208,7 +208,10 @@ class _DateLocaleParser(object):
         }
 
     def _try_freshness_parser(self):
-        return freshness_date_parser.get_date_data(self._get_translated_date(), self._settings)
+        try:
+            return freshness_date_parser.get_date_data(self._get_translated_date(), self._settings)
+        except (OverflowError, ValueError):
+            return None
 
     def _try_parser(self):
         _order = self._settings.DATE_ORDER

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -1421,13 +1421,19 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('5000 years ago'),
         param('2014 years ago'),  # We've fixed .now in setUp
         param('{} months ago'.format(2013 * 12 + 9)),
+        param('123456789 hour'),
+        param('123456789123 hour'),
+        param('1234567 days'),
+        param('1234567891 days'),
+        param('12345678912 days'),
+        param('123455678976543 month'),
     ])
     def test_dates_not_supported_by_date_time(self, date_string):
         self.given_parser()
         self.given_date_string(date_string)
         self.when_date_is_parsed()
-        self.then_error_was_raised(ValueError, ['is out of range',
-                                                "('year must be in 1..9999'"])
+        self.then_error_was_not_raised()
+        self.assertEqual(None, self.result['date_obj'])
 
     @parameterized.expand([
         param('несколько секунд назад', boundary={'seconds': 45}, period='day'),


### PR DESCRIPTION
Fixes https://github.com/scrapinghub/dateparser/issues/685

~I pushed this branch with the tests failing to ask for your feedback.~

Until now, when entering some wrong values in the `relative-time` parser (aka `freshness_parser`), like `"4000 years ago"`, the `dateparser.parse()` raises a `ValueError` (this is validated in the tests). 

However, this is working only partially, as bigger values return an `OverflowError` (more context here: https://github.com/scrapinghub/dateparser/issues/685).

When fixing this I considered that we should always return `None` instead of a `ValueError` because when parsing long texts or in the middle of a script we don't want the `dateparser.parse()` method to raise an error ~, however, it's possible that some people use this behavior when entering a string like "X years ago", expecting an error when the year is not valid.~

~What do you think? It's ok to change the current logic? Should we reraise the `OverflowError` as a `ValueError`? In the first case, as it isn't backward compatible, should we release a major version (or wait until it is ready to be released)?~

@Gallaecio 

Update:
After checking this issue: https://github.com/scrapinghub/dateparser/issues/687 it seems obvious that we can't raise `ValueError`s because it breaks `search_dates`, etc. I know this won't be backward compatible, but I think it's the best solution. @Gallaecio , I would like to hear your opinion on this. Thanks in advance.


Fixes: https://github.com/scrapinghub/dateparser/issues/687

