### PR TITLE
Add a assertWarns to avoid unnecessary messages.

### DIFF
--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -302,7 +302,10 @@ class TestParseWithFormatsFunction(BaseTestCase):
         param(date_string='25-03-14', date_formats='%d-%m-%y', expected_result=datetime(2014, 3, 25)),
     ])
     def test_should_support_a_string_as_date_formats(self, date_string, date_formats, expected_result):
-        self.when_date_is_parsed_with_formats(date_string, date_formats)
+        if six.PY2:
+            self.when_date_is_parsed_with_formats(date_string, date_formats)
+        else:
+            self.when_date_is_parsed_with_formats_and_raise_warn(date_string, date_formats)
         self.then_date_was_parsed()
         self.then_parsed_period_is('day')
         self.then_parsed_date_is(expected_result)
@@ -318,6 +321,11 @@ class TestParseWithFormatsFunction(BaseTestCase):
 
     def when_date_is_parsed_with_formats(self, date_string, date_formats, custom_settings=None):
         self.result = date.parse_with_formats(date_string, date_formats, custom_settings or settings)
+
+    def when_date_is_parsed_with_formats_and_raise_warn(self, date_string, date_formats, custom_settings=None):
+        # Just available for Python 3
+        with self.assertWarns(FutureWarning):
+            self.result = date.parse_with_formats(date_string, date_formats, custom_settings or settings)
 
     def then_date_was_not_parsed(self):
         self.assertIsNotNone(self.result)


### PR DESCRIPTION
This PR propose create a new method that assert Warnings
to avoid print on screen the future warns.

This patch just work for Python3, becuase ssertWarns` isn't
available for Python2.

Closes: #688 