### PR TITLE
improve performance by ridding of the 'any'

### DIFF
--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -46,7 +46,7 @@ def parse(date_string, date_formats=None, languages=None, locales=None, region=N
     """
     parser = _default_parser
 
-    if any([languages, locales, region, not settings._default]):
+    if languages or locales or region or not settings._default:
         parser = DateDataParser(languages=languages, locales=locales,
                                 region=region, settings=settings)
 

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -109,8 +109,7 @@ class Dictionary(object):
 
         match_relative_regex = self._get_match_relative_regex_cache()
         for token in tokens:
-            if any([match_relative_regex.match(token),
-                    token in self, token.isdigit()]):
+            if token.isdigit() or match_relative_regex.match(token) or token in self:
                 continue
             else:
                 return False


### PR DESCRIPTION
Some improvements in `are_tokens_valid()`

* Instead of checking all the possibilities, then creating a `list` and then checking if any of them is `True`, we can change this approach to use `or`: in this way we don't need to evaluate all the possibilities, as soon as one of them matches it doesn't need to continue checking the other. 
* I reordered the "checks" from less expensive to more expensive `[isdigit() --> regex --> contains ("in")]`. (using this criterion as it doesn't have any sense to talk about "the most common").


On the other hand, similarly, I changed the "any" in the `parse()` function as we don't need to evaluate all the possibilities, we can stop as soon as the first condition is met.
.