### PR TITLE
fix translate keep_formatting

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -141,7 +141,8 @@ class Locale(object):
                     date_string_tokens[i] = pattern.sub(replacement, word)
             else:
                 if word in dictionary:
-                    date_string_tokens[i] = dictionary[word] or ''
+                    fallback = word if keep_formatting and not word.isalpha() else ''
+                    date_string_tokens[i] = dictionary[word] or fallback
         if "in" in date_string_tokens:
             date_string_tokens = self._clear_future_words(date_string_tokens)
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -4,15 +4,33 @@ from __future__ import unicode_literals
 from io import StringIO
 
 import logging
+
+import pytest
 from parameterized import parameterized, param
 
 from dateparser.languages import default_loader, Locale
 from dateparser.languages.validation import LanguageValidator
-from dateparser.conf import apply_settings
+from dateparser.conf import apply_settings, settings
 from dateparser.search.detection import AutoDetectLanguage, ExactLanguages
 from dateparser.utils import normalize_unicode
 
 from tests import BaseTestCase
+
+
+class TestLocaleTranslation:
+
+    @pytest.mark.parametrize("date_string,expected,locale,keep_formatting", [
+        ('December 04, 1999, 11:04:59 PM', 'december 04, 1999, 11:04:59 pm', 'en', True),
+        ('December 04, 1999, 11:04:59 PM', 'december 04 1999 11:04:59 pm', 'en', False),
+        ('23 März, 18:37', '23 march, 18:37', 'de', True),
+        ('23 März 18:37', '23 march 18:37', 'de', False),
+    ])
+    def test_keep_formatting(self, date_string, expected, locale, keep_formatting):
+        result = default_loader.get_locale(locale).translate(
+            date_string=date_string, keep_formatting=keep_formatting, settings=settings
+        )
+        print(result)
+        assert expected == result
 
 
 class TestBundledLanguages(BaseTestCase):


### PR DESCRIPTION
When parsing a string it is "translated". When doing it, the commas are missed, and because of that some date formats in the `base-formats` parser doesn't work.


**Before this change:**

```python
>>> dateparser.parse('December 04, 1999, 11:04:59 PM', settings={'PARSERS': ['base-formats']})

```

It should work because `'%B %d, %Y, %I:%M:%S %p'` is the first date format when trying with `base-formats, but it doesn't.

**After this change:**

```python
>>> dateparser.parse('December 04, 1999, 11:04:59 PM', settings={'PARSERS': ['base-formats']})
datetime.datetime(1999, 12, 4, 23, 4, 59)
```