### PR TITLE
remove base-formats parser

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -178,7 +178,6 @@ class _DateLocaleParser(object):
             'relative-time': self._try_freshness_parser,
             'custom-formats': self._try_given_formats,
             'absolute-time': self._try_parser,
-            'base-formats': self._try_hardcoded_formats,
         }
         unknown_parsers = set(self._settings.PARSERS) - set(self._parsers.keys())
         if unknown_parsers:
@@ -238,23 +237,6 @@ class _DateLocaleParser(object):
             self._get_translated_date_with_formatting(),
             self.date_formats, settings=self._settings
         )
-
-    def _try_hardcoded_formats(self):
-        hardcoded_date_formats = [
-            '%B %d, %Y, %I:%M:%S %p',
-            '%b %d, %Y at %I:%M %p',
-            '%d %B %Y %H:%M:%S',
-            '%A, %B %d, %Y',
-            '%Y-%m-%dT%H:%M:%S.%fZ'
-        ]
-        try:
-            return parse_with_formats(
-                self._get_translated_date_with_formatting(),
-                hardcoded_date_formats,
-                settings=self._settings
-            )
-        except TypeError:
-            return None
 
     def _get_translated_date(self):
         if self._translated_date is None:

--- a/dateparser_data/settings.py
+++ b/dateparser_data/settings.py
@@ -3,7 +3,6 @@ default_parsers = [
     'relative-time',
     'custom-formats',
     'absolute-time',
-    'base-formats',
 ]
 
 settings = {

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -168,14 +168,6 @@ The following parsers exist:
     (e.g. “May 4th”, “1991-05-17”). It takes into account settings such as
     ``DATE_ORDER`` or ``PREFER_LOCALE_DATE_ORDER``.
 
--   ``'base-formats'``: Parses dates that match one of the following date
-    formats::
-
-    %B %d, %Y, %I:%M:%S %p
-    %b %d, %Y at %I:%M %p
-    %d %B %Y %H:%M:%S
-    %A, %B %d, %Y
-    %Y-%m-%dT%H:%M:%S.%fZ
 
 :data:`dateparser.settings.default_parsers` contains the default value of
 ``PARSERS`` (the list above, in that order) and can be used to write code that


### PR DESCRIPTION
I've been playing around with the formats included in the `base-formats` parser (`_try_hardcoded_formats` method) and it seems that all of them are now fully supported by the `absolute-time` parser, so I think it doesn't have any sense to keep this parser, as it adds unnecessary complexity.

In fact, all the date formats with commas were not applied correctly: https://github.com/scrapinghub/dateparser/pull/720 and that means that only 3 of the past date formats were applied.


Examples:

`'%B %d, %Y, %I:%M:%S %p'`
```python
>>> dateparser.parse('Diciembre 04, 1999, 11:04:59 PM', settings={'PARSERS': ['absolute-time']})                                                                                       
datetime.datetime(1999, 12, 4, 23, 4, 59)

>>>  dateparser.parse('December 22, 2009, 11:04:59 AM', settings={'PARSERS': ['absolute-time']})                                                                                        
datetime.datetime(2009, 12, 22, 11, 4, 59)
```

`'%b %d, %Y at %I:%M %p'`
 ```python
>>> dateparser.parse('January 22, 2009 at 01:04 PM', settings={'PARSERS': ['absolute-time']})                                                                                          
datetime.datetime(2009, 1, 22, 13, 4)
```

`'%d %B %Y %H:%M:%S'`
```python
>>> dateparser.parse('21 February 2009 1:04:05', settings={'PARSERS': ['absolute-time']})                                                                                              
datetime.datetime(2009, 2, 21, 1, 4, 5)

```

`'%A, %B %d, %Y'`
```python
>>> dateparser.parse('Sunday, February 20, 2009', settings={'PARSERS': ['absolute-time']})                                                                                             
datetime.datetime(2009, 2, 20, 0, 0)

>>> dateparser.parse('Sunday, June 21, 2020', settings={'PARSERS': ['absolute-time']})                                                                                                 
datetime.datetime(2020, 6, 21, 0, 0)

>>> dateparser.parse('Saturday, June 21, 2020', settings={'PARSERS': ['absolute-time']})                                                                                               
datetime.datetime(2020, 6, 21, 0, 0)
```


`'%Y-%m-%dT%H:%M:%S.%fZ'`
```python
>>>  dateparser.parse('1984-02-01T23:02:01.000001', settings={'PARSERS': ['absolute-time']})                                                                               
datetime.datetime(1984, 2, 1, 23, 2, 1, 1)

>>> dateparser.parse('1984-02-01T23:02:01.100001', settings={'PARSERS': ['absolute-time']})                                                                             
datetime.datetime(1984, 2, 1, 23, 2, 1, 100001)
```