### PR TITLE
WIP: implement missing info

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -219,13 +219,17 @@ class _DateLocaleParser(object):
             if self._settings.PREFER_LOCALE_DATE_ORDER:
                 if 'DATE_ORDER' not in self._settings._mod_settings:
                     self._settings.DATE_ORDER = self.locale.info.get('date_order', _order)
-            date_obj, period = date_parser.parse(
+            date_obj, period, extra = date_parser.parse(
                 self._get_translated_date(), settings=self._settings)
             self._settings.DATE_ORDER = _order
-            return {
+            result = {
                 'date_obj': date_obj,
                 'period': period,
             }
+            if extra:
+                result['extra'] = extra
+            return result
+
         except ValueError:
             self._settings.DATE_ORDER = _order
             return None
@@ -271,7 +275,7 @@ class _DateLocaleParser(object):
     def _is_valid_date_obj(self, date_obj):
         if not isinstance(date_obj, dict):
             return False
-        if len(date_obj) != 2:
+        if len(date_obj) != 2 and len(date_obj) != 3:
             return False
         if 'date_obj' not in date_obj or 'period' not in date_obj:
             return False

--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -23,7 +23,7 @@ class DateParser(object):
         date_string = strip_braces(date_string)
         date_string, ptz = pop_tz_offset_from_string(date_string)
 
-        date_obj, period = parse(date_string, settings=settings)
+        date_obj, period, extra = parse(date_string, settings=settings)
 
         _settings_tz = settings.TIMEZONE.lower()
 
@@ -48,7 +48,7 @@ class DateParser(object):
         ):
             date_obj = date_obj.replace(tzinfo=None)
 
-        return date_obj, period
+        return date_obj, period, extra
 
 
 date_parser = DateParser()


### PR DESCRIPTION
I did a proof of concept to add the missing parts ("year", "month" or "day") to the result of `DateDataParser.get_date_data()`.

This could be a fix for https://github.com/scrapinghub/dateparser/issues/424, https://github.com/scrapinghub/dateparser/issues/553 and https://github.com/scrapinghub/dateparser/issues/700.

Of course **tests are not passing**, it's just a PoC to discuss it.


-----

### Precedents: 
Sometimes there is a part of a date that it's missing: "22 may", "1994", etc. and there are people interested in knowing the missing part/s to be able to print / handle the result. Examples coming from the issues:

When doing:

```python
>>> from dateparser import parse
>>> print(parse('2017'))
2017-06-18 00:00:00
```
to be able to print just:
```bash
2017
```
and when doing 

```python
>>> print(parse('2017 Jan'))
2017-01-18 00:00:00
```

to be able to print:

```bash
2017-01
```

### Feasibility
As `dateparser.parse()` returns a `datetime` object, and it's not possible to return those parts with zero (example from the mentioned issues: `datetime.datetime(2015, 12, 0, 0, 0)`), we can't just do it.

However, as we can use directly the `DateDataParser.get_date_data()` method and it returns more information (`locale`,  `period`, etc.), we could add another field with the missing parts (if applicable).

I added an `extra` field containing the `missing` field. We could probably simplify this, adding the `missing` field directly.


### Code snippets with the implementation from this PR:

This:

```python
from dateparser.date import DateDataParser
p = DateDataParser()

print(p.get_date_data("22 may"))
```

will print:

```bash
{'date_obj': datetime.datetime(2020, 5, 22, 0, 0), 'period': 'day', 'extra': {'missing': ['year']}, 'locale': 'en'}
```

And this:

```python
print(p.get_date_data("1999"))
```

will print:
```bash
{'date_obj': datetime.datetime(1999, 6, 26, 0, 0), 'period': 'year', 'extra': {'missing': ['day', 'month']}, 'locale': 'en'}
```

With this, we could just do something like:
```python
from dateparser.date import DateDataParser
p = DateDataParser()

def print_date_obj(result):
    missing = result.get('extra', {}).get('missing', [])
    if not missing:
        date_format = '%Y-%m-%d'
    elif 'day' and 'month' in missing:
        date_format = '%Y'
    elif 'day' in missing:
        date_format = '%Y-%m'
    elif 'year' in missing:
        date_format = '%m-%d'

   ...

    print(result.get('date_obj').strftime(date_format))


result = p.get_date_data("22 may")

if result['date_obj']:
    print_date_obj(result)

```


### Feedback

This PR can't be merged as-is, we should work on the tests and add more scenarios. Apart from that, it should be merged after merging this: https://github.com/scrapinghub/dateparser/pull/715  (and we should fix the conflicts) 


## Let me know what you think about this approach and if you see any blocker.