### PR TITLE
Fix flake8 line length e501

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -21,7 +21,7 @@ class Settings(object):
     Default: False.
     * `PARSERS`: list of date parsers to use, in order of preference. Default:
     :attr:`dateparser.settings.default_parsers`.
-    """
+    """ # noqa E501
 
     _default = True
     _pyfile_data = None

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -14,14 +14,15 @@ class Settings(object):
     * `PREFER_DATES_FROM`: defaults to `current_period`. Options are `future` or `past`.
     * `PREFER_DAY_OF_MONTH`: defaults to `current`. Could be `first` and `last` day of month.
     * `SKIP_TOKENS`: defaults to `['t']`. Can be any string.
-    * `TIMEZONE`: defaults to `UTC`. Can be timezone abbreviation or any of `tz database name as given here <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
+    * `TIMEZONE`: defaults to `UTC`. Can be timezone abbreviation or any of
+      `tz database name as given here <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_.
     * `RETURN_AS_TIMEZONE_AWARE`: return tz aware datetime objects in case timezone is detected in the date string.
     * `RELATIVE_BASE`: count relative date from this base date. Should be datetime object.
     * `RETURN_TIME_AS_PERIOD`: returns period as `time` in case time component is detected in the date string.
     Default: False.
     * `PARSERS`: list of date parsers to use, in order of preference. Default:
     :attr:`dateparser.settings.default_parsers`.
-    """ # noqa E501
+    """
 
     _default = True
     _pyfile_data = None

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -467,9 +467,10 @@ class Locale(object):
 
     def _set_splitters(self, settings=None):
         splitters = {
-            'wordchars': set(),  # The ones that split string only if they are not surrounded
-            # by letters from both sides
-            'capturing': set(),  # The ones that are not filtered out from tokens after split
+            # The ones that split string only if they are not surrounded by letters from both sides:
+            'wordchars': set(),
+            # The ones that are not filtered out from tokens after split:
+            'capturing': set(),
         }
         splitters['capturing'] |= set(ALWAYS_KEEP_TOKENS)
 

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -467,7 +467,8 @@ class Locale(object):
 
     def _set_splitters(self, settings=None):
         splitters = {
-            'wordchars': set(),  # The ones that split string only if they are not surrounded by letters from both sides
+            'wordchars': set(),  # The ones that split string only if they are not surrounded
+            # by letters from both sides
             'capturing': set(),  # The ones that are not filtered out from tokens after split
         }
         splitters['capturing'] |= set(ALWAYS_KEEP_TOKENS)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -323,7 +323,7 @@ class _parser(object):
                     params['day'] = get_last_day_of_month(params['year'], params['month'])
                     return datetime(**params)
                 elif not self._token_year and params['day'] == 29 and params['month'] == 2 and \
-                    not calendar.isleap(params['year']):
+                        not calendar.isleap(params['year']):
                     # fix the year when year is not present and it is 29 of February
                     params['year'] = self._get_correct_leap_year(self.settings.PREFER_DATES_FROM, params['year'])
                     return datetime(**params)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -322,7 +322,8 @@ class _parser(object):
                     # if day is not available put last day of the month
                     params['day'] = get_last_day_of_month(params['year'], params['month'])
                     return datetime(**params)
-                elif not self._token_year and params['day'] == 29 and params['month'] == 2 and not calendar.isleap(params['year']):
+                elif not self._token_year and params['day'] == 29 and params['month'] == 2 and \
+                    not calendar.isleap(params['year']):
                     # fix the year when year is not present and it is 29 of February
                     params['year'] = self._get_correct_leap_year(self.settings.PREFER_DATES_FROM, params['year'])
                     return datetime(**params)

--- a/dateparser/search/__init__.py
+++ b/dateparser/search/__init__.py
@@ -37,15 +37,17 @@ def search_dates(text, languages=None, settings=None, add_detected_language=Fals
         >>> search_dates('The first artificial Earth satellite was launched on 4 October 1957.')
         [('on 4 October 1957', datetime.datetime(1957, 10, 4, 0, 0))]
 
-        >>> search_dates('The first artificial Earth satellite was launched on 4 October 1957.', add_detected_language=True)
+        >>> search_dates('The first artificial Earth satellite was launched on 4 October 1957.',
+        >>>              add_detected_language=True)
         [('on 4 October 1957', datetime.datetime(1957, 10, 4, 0, 0), 'en')]
 
-        >>> search_dates("The client arrived to the office for the first time in March 3rd, 2004 and got serviced, after a couple of months, on May 6th 2004, the customer returned indicating a defect on the part")
+        >>> search_dates("The client arrived to the office for the first time in March 3rd, 2004 "
+        >>>              "and got serviced, after a couple of months, on May 6th 2004, the customer "
+        >>>              "returned indicating a defect on the part")
         [('in March 3rd, 2004 and', datetime.datetime(2004, 3, 3, 0, 0)),
          ('on May 6th 2004', datetime.datetime(2004, 5, 6, 0, 0))]
 
-
-        """ # noqa E501
+        """
     result = _search_with_detection.search_dates(
         text=text, languages=languages, settings=settings
     )

--- a/dateparser/search/__init__.py
+++ b/dateparser/search/__init__.py
@@ -45,7 +45,7 @@ def search_dates(text, languages=None, settings=None, add_detected_language=Fals
          ('on May 6th 2004', datetime.datetime(2004, 5, 6, 0, 0))]
 
 
-        """
+        """ # noqa E501
     result = _search_with_detection.search_dates(
         text=text, languages=languages, settings=settings
     )

--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -10,9 +10,11 @@ timezone_info_list = [
         'replace':
             [
                 (r'(?:UTC|GMT)\\(\+|\-)0(\d):00', r'(?:UTC|GMT)\\\1\2'),  # UTC+n, UTC-n, GMT+n, GMT-n
-                (r'(?:UTC|GMT)\\(\+|\-)0(\d):(\d{2})', r'(?:UTC|GMT)\\\1\2:\3'),  # UTC+n:mm, UTC-n:mm,GMT+n:mm, GMT-n:mm
+                (r'(?:UTC|GMT)\\(\+|\-)0(\d):(\d{2})', r'(?:UTC|GMT)\\\1\2:\3'),
+                # UTC+n:mm, UTC-n:mm, GMT+n:mm, GMT-n:mm
                 (r'(?:UTC|GMT)\\(\+|\-)(\d{2}):00', r'(?:UTC|GMT)\\\1\2'),  # UTC+nn, UTC-nn, GMT+nn, GMT-nn
-                (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})', r'(?:UTC|GMT)\1\2:?\3.*'),  # UTC+nnmm, , UTC-nnmm, GMT+nnmm, GMT-nnmm
+                (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})', r'(?:UTC|GMT)\1\2:?\3.*'),
+                # UTC+nnmm, UTC-nnmm, GMT+nnmm, GMT-nnmm
                 (r'UTC', r''),
                 (r':', r''),
                 (r':|UTC', r''),

--- a/dateparser/timezones.py
+++ b/dateparser/timezones.py
@@ -9,16 +9,16 @@ timezone_info_list = [
             [r'(.)%s$'],
         'replace':
             [
-                (r'(?:UTC|GMT)\\(\+|\-)0(\d):00', r'(?:UTC|GMT)\\\1\2'),  # UTC+n, UTC-n, GMT+n, GMT-n
+                # UTC+n, UTC-n, GMT+n, GMT-n:
+                (r'(?:UTC|GMT)\\(\+|\-)0(\d):00', r'(?:UTC|GMT)\\\1\2'),
+                # UTC+n:mm, UTC-n:mm, GMT+n:mm, GMT-n:mm:
                 (r'(?:UTC|GMT)\\(\+|\-)0(\d):(\d{2})', r'(?:UTC|GMT)\\\1\2:\3'),
-                # UTC+n:mm, UTC-n:mm, GMT+n:mm, GMT-n:mm
-                (r'(?:UTC|GMT)\\(\+|\-)(\d{2}):00', r'(?:UTC|GMT)\\\1\2'),  # UTC+nn, UTC-nn, GMT+nn, GMT-nn
+                # UTC+nn, UTC-nn, GMT+nn, GMT-nn:
+                (r'(?:UTC|GMT)\\(\+|\-)(\d{2}):00', r'(?:UTC|GMT)\\\1\2'),
+                # UTC+nnmm, UTC-nnmm, GMT+nnmm, GMT-nnmm:
                 (r'(?:UTC|GMT)(\\[+-])(\d{2}):(\d{2})', r'(?:UTC|GMT)\1\2:?\3.*'),
-                # UTC+nnmm, UTC-nnmm, GMT+nnmm, GMT-nnmm
-                (r'UTC', r''),
-                (r':', r''),
-                (r':|UTC', r''),
-                (r'UTC', r'GMT'),
+                # Others:
+                (r'UTC', r''), (r':', r''), (r':|UTC', r''), (r'UTC', r'GMT'),
             ],
         'timezones':
             [(r'UTC\-12:00', -43200),

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ addopts =
     # the hiriji calendar files to avoid errors when collecting tests
     --ignore=dateparser/calendars/hijri_parser.py
     --ignore=dateparser/calendars/hijri.py
+flake8-max-line-length = 119
 flake8-ignore =
     # This rule goes against the PEP 8 recommended style and it's incompatible
     # with W504
@@ -17,45 +18,26 @@ flake8-ignore =
 
     # Issues pending a review:
     # dateparser
-    dateparser/__init__.py E501
     dateparser/calendars/jalali_parser.py F402
-    dateparser/conf.py E501
-    dateparser/data/numeral_translation_data E501 W292
-    dateparser/date.py E501
-    dateparser/dateparser/search/__init__.py F401 E501
+    dateparser/data/numeral_translation_data W292
+    dateparser/dateparser/search/__init__.py F401
     dateparser/freshness_date_parser.py E722 W504
-    dateparser/parser.py E501 E722 F841 W504
-    dateparser/search/search.py E501
-    dateparser/timezones.py E501
+    dateparser/parser.py E722 F841 W504
     dateparser/data/languages_info.py W292
     dateparser/languages/__init__.py F401
-    dateparser/languages/dictionary.py E501 W504
-    dateparser/languages/locale.py E501
-    dateparser/languages/validation.py E501
-    dateparser/search/search.py
+    dateparser/languages/dictionary.py W504
     dateparser/utils/strptime.py E402
     # data
     data/__init__.py F401 W292
     # docs
     docs/conf.py E402
     # setup
-    setup.py E731 E501
+    setup.py E731
     # dateparser_scripts
     dateparser_scripts/get_cldr_data.py E722 W504
-    dateparser_scripts/get_cldr_numeral_data.py E501
-    dateparser_scripts/order_languages.py E722 E501
-    dateparser_scripts/write_complete_data.py E501
+    dateparser_scripts/order_languages.py E722
     # tests
-    tests/__init__.py F401 E501
-    tests/test_clean_api.py E501
-    tests/test_data.py W504 E501
-    tests/test_date.py E501
-    tests/test_date_parser.py E501
-    tests/test_freshness_date_parser.py E501
-    tests/test_languages.py E501
+    tests/__init__.py F401
+    tests/test_data.py W504
     tests/test_loading.py E741
-    tests/test_parser.py E501 W605 E741
-    tests/test_search.py E501
-    tests/test_settings.py E501
-    tests/test_utils.py E501
-    tests/test_utils_strptime.py E501
+    tests/test_parser.py W605 E741

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -388,7 +388,9 @@ class TestDateParser(BaseTestCase):
         param('Fri, 09 Sep 2005 13:51:39 -0700', 'GMT', datetime(2005, 9, 9, 20, 51, 39)),
         param('Fri, 09 Sep 2005 13:51:39 +0000', 'GMT', datetime(2005, 9, 9, 13, 51, 39)),
     ])
-    def test_dateparser_should_return_date_in_setting_timezone_if_timezone_info_present_both_in_datestring_and_given_in_settings(self, date_string, setting_timezone, expected):
+    def test_dateparser_should_return_date_in_setting_timezone_if_timezone_info_present_in_datestring_and_in_settings(
+        self, date_string, setting_timezone, expected
+    ):
         self.given_parser(settings={'TIMEZONE': setting_timezone})
         self.when_date_is_parsed(date_string)
         self.then_date_was_parsed_by_date_parser()

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -1496,7 +1496,11 @@ class TestFreshnessDateDataParser(BaseTestCase):
         param('Today', 'US/Mountain', 'UTC', date(2014, 9, 1), time(16, 30)),
     ])
     def test_freshness_date_with_timezone_conversion(self, date_string, timezone, to_timezone, date, time):
-        self.given_parser(settings={'TIMEZONE': timezone, 'TO_TIMEZONE': to_timezone, 'RELATIVE_BASE': datetime(2014, 9, 1, 10, 30)})
+        self.given_parser(settings={
+            'TIMEZONE': timezone,
+            'TO_TIMEZONE': to_timezone,
+            'RELATIVE_BASE': datetime(2014, 9, 1, 10, 30)
+        })
         self.given_date_string(date_string)
         self.when_date_is_parsed()
         self.then_date_is(date)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -301,7 +301,9 @@ class TestNoSpaceParser(BaseTestCase):
             expected_period='day',
         ),
     ])
-    def test_best_order_used_if_date_order_not_supplied_to_8_digit_numbers(self, date_string, expected_date, expected_period):
+    def test_best_order_used_if_date_order_not_supplied_to_8_digit_numbers(
+        self, date_string, expected_date, expected_period
+    ):
         self.given_parser()
         self.given_settings(settings={'DATE_ORDER': ''})
         self.when_date_is_parsed(date_string)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -273,7 +273,11 @@ class TestTranslateSearch(BaseTestCase):
         param('en', 'last updated Aug 06, 2018 05:05 PM CDT',
               [(
                   'Aug 06, 2018 05:05 PM CDT',
-                  datetime.datetime(2018, 8, 6, 17, 5, tzinfo=StaticTzInfo('CDT', datetime.timedelta(seconds=-18000))))],
+                  datetime.datetime(
+                      2018, 8, 6, 17, 5, tzinfo=StaticTzInfo(
+                          'CDT', datetime.timedelta(seconds=-18000)
+                      ))
+              )],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
         param('en', '25th march 2015 , i need this report today.',
               [('25th march 2015', datetime.datetime(2015, 3, 25))],
@@ -308,8 +312,8 @@ class TestTranslateSearch(BaseTestCase):
 
         # Hindi
         param('hi',
-              'जुलाई 1937 में, मार्को-पोलो ब्रिज हादसे का बहाना लेकर जापान ने चीन पर हमला कर दिया और चीनी साम्राज्य की राजधानी बीजिंग '
-              'पर कब्जा कर लिया,',
+              'जुलाई 1937 में, मार्को-पोलो ब्रिज हादसे का बहाना लेकर जापान ने चीन पर हमला कर दिया और चीनी साम्राज्य '
+              'की राजधानी बीजिंग पर कब्जा कर लिया,',
               [('जुलाई 1937 में', datetime.datetime(1937, 7, 1, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
@@ -397,7 +401,8 @@ class TestTranslateSearch(BaseTestCase):
 
         # Thai
         param('th',
-              'และเมื่อวันที่ 11 พฤษภาคม 1939 ญี่ปุ่นตัดสินใจขยายพรมแดนญี่ปุ่น-มองโกเลียขึ้นไปถึงแม่น้ำคัลคินกอลด้วยกำลัง',
+              'และเมื่อวันที่ 11 พฤษภาคม 1939 '
+              'ญี่ปุ่นตัดสินใจขยายพรมแดนญี่ปุ่น-มองโกเลียขึ้นไปถึงแม่น้ำคัลคินกอลด้วยกำลัง',
               [('11 พฤษภาคม 1939', datetime.datetime(1939, 5, 11, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
@@ -408,9 +413,9 @@ class TestTranslateSearch(BaseTestCase):
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
         # Ukrainian
-        param('uk', 'Інші дати, що розглядаються деякими авторами як дати початку війни: початок японської інтервенції '
-                    'в Маньчжурію 13 вересня 1931, початок другої японсько-китайської війни 7 липня 1937 року та '
-                    'початок угорсько-української війни 14 березня 1939 року.',
+        param('uk', 'Інші дати, що розглядаються деякими авторами як дати початку війни: початок японської '
+                    'інтервенції в Маньчжурію 13 вересня 1931, початок другої японсько-китайської війни 7 '
+                    'липня 1937 року та початок угорсько-української війни 14 березня 1939 року.',
               [('13 вересня 1931', datetime.datetime(1931, 9, 13, 0, 0)),
                ('7 липня 1937', datetime.datetime(1937, 7, 7, 0, 0)),
                ('14 березня 1939', datetime.datetime(1939, 3, 14, 0, 0))],
@@ -435,7 +440,9 @@ class TestTranslateSearch(BaseTestCase):
                ('February 1st', datetime.datetime(2017, 2, 1, 0, 0))]),
         param('en', '2014 was good! October was excellent!'
                     ' Friday, 21 was especially good!',
-              [('2014', datetime.datetime(2014, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)),
+              [('2014', datetime.datetime(
+                  2014, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)
+                ),
                ('October', datetime.datetime(2014, 10, datetime.datetime.utcnow().day, 0, 0)),
                ('Friday, 21', datetime.datetime(2014, 10, 21, 0, 0))]),
 
@@ -460,8 +467,8 @@ class TestTranslateSearch(BaseTestCase):
                ('2 hónappal ezelőtt', datetime.datetime(1962, 6, 11, 0, 0))]),
 
         # Vietnamese
-        param('vi', '1/1/1940. Vào tháng 8 năm 1940, với lực lượng lớn của Pháp tại Bắc Phi chính thức trung lập trong '
-                    'cuộc chiến, Ý mở một cuộc tấn công vào thuộc địa Somalia của Anh tại Đông Phi. '
+        param('vi', '1/1/1940. Vào tháng 8 năm 1940, với lực lượng lớn của Pháp tại Bắc Phi chính thức trung lập '
+                    'trong cuộc chiến, Ý mở một cuộc tấn công vào thuộc địa Somalia của Anh tại Đông Phi. '
                     'Đến tháng 9 quân Ý vào đến Ai Cập (cũng đang dưới sự kiểm soát của Anh). ',
               [('1/1/1940', datetime.datetime(1940, 1, 1, 0, 0)),
                ('tháng 8 năm 1940', datetime.datetime(1940, 8, 1, 0, 0)),
@@ -478,7 +485,9 @@ class TestTranslateSearch(BaseTestCase):
                ('July 13th', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2014, 7, 14, 0, 0))]),
         param('en', '2014. July 13th July 14th',
-              [('2014', datetime.datetime(2014, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)),
+              [('2014', datetime.datetime(
+                  2014, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)
+                ),
                ('July 13th', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2014, 7, 14, 0, 0))]),
         param('en', 'July 13th 2014 July 14th 2014',
@@ -491,16 +500,21 @@ class TestTranslateSearch(BaseTestCase):
               [('July 13th, 2014', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th, 2014', datetime.datetime(2014, 7, 14, 0, 0))]),
         param('en', '2014. July 12th, July 13th, July 14th',
-              [('2014', datetime.datetime(2014, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)),
+              [('2014', datetime.datetime(
+                  2014, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)
+                ),
                ('July 12th', datetime.datetime(2014, 7, 12, 0, 0)),
                ('July 13th', datetime.datetime(2014, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2014, 7, 14, 0, 0))]),
         # Swedish
         param('sv', '1938–1939 marscherade tyska soldater i Österrike samtidigt som '
                     'österrikiska soldater marscherade i Berlin.',
-              [('1938', datetime.datetime(1938, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)),
-               ('1939', datetime.datetime(1939,
-                                          datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0))]),
+              [('1938', datetime.datetime(
+                  1938, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)
+                ),
+               ('1939', datetime.datetime(
+                   1939, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day, 0, 0)
+                )]),
         # German
         param('de', 'Verteidiger der Stadt kapitulierten am 2. Mai 1945. Am 8. Mai 1945 (VE-Day) trat '
                     'bedingungslose Kapitulation der Wehrmacht in Kraft',
@@ -560,8 +574,8 @@ class TestTranslateSearch(BaseTestCase):
 
         # Hindi
         param('hi',
-              'जुलाई 1937 में, मार्को-पोलो ब्रिज हादसे का बहाना लेकर जापान ने चीन पर हमला कर दिया और चीनी साम्राज्य की राजधानी बीजिंग '
-              'पर कब्जा कर लिया,'),
+              'जुलाई 1937 में, मार्को-पोलो ब्रिज हादसे का बहाना लेकर जापान ने चीन पर हमला कर दिया और चीनी साम्राज्य '
+              'की राजधानी बीजिंग पर कब्जा कर लिया,'),
 
         # Hungarian
         param('hu', 'A háború Európában 1945. május 8-án Németország feltétel nélküli megadásával, '
@@ -612,16 +626,17 @@ class TestTranslateSearch(BaseTestCase):
 
         # Thai
         param('th',
-              'และเมื่อวันที่ 11 พฤษภาคม 1939 ญี่ปุ่นตัดสินใจขยายพรมแดนญี่ปุ่น-มองโกเลียขึ้นไปถึงแม่น้ำคัลคินกอลด้วยกำลัง'),
+              'และเมื่อวันที่ 11 พฤษภาคม 1939 '
+              'ญี่ปุ่นตัดสินใจขยายพรมแดนญี่ปุ่น-มองโกเลียขึ้นไปถึงแม่น้ำคัลคินกอลด้วยกำลัง'),
 
         # Turkish
         param('tr', 'Almanya’nın Polonya’yı işgal ettiği 1 Eylül 1939 savaşın başladığı '
                     'tarih olarak genel kabul görür.'),
 
         # Ukrainian
-        param('uk', 'Інші дати, що розглядаються деякими авторами як дати початку війни: початок японської інтервенції '
-                    'в Маньчжурію 13 вересня 1931, початок другої японсько-китайської війни 7 липня 1937 року та '
-                    'початок угорсько-української війни 14 березня 1939 року.'),
+        param('uk', 'Інші дати, що розглядаються деякими авторами як дати початку війни: початок японської '
+                    'інтервенції в Маньчжурію 13 вересня 1931, початок другої японсько-китайської війни 7 '
+                    'липня 1937 року та початок угорсько-української війни 14 березня 1939 року.'),
 
         # Vietnamese
         param('vi', 'Ý theo gương Đức, đã tiến hành xâm lược Ethiopia năm 1935 và sát '

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -101,21 +101,29 @@ class SettingsTest(BaseTestCase):
         super(SettingsTest, self).setUp()
         self.default_settings = settings
 
-    def test_apply_settings_should_return_default_settings_when_no_settings_are_supplied_to_the_decorated_function(self):
+    def test_apply_settings_should_return_default_settings_when_no_settings_are_supplied_to_the_decorated_function(
+        self
+    ):
         test_func = apply_settings(test_function)
         self.assertEqual(test_func(), self.default_settings)
 
-    def test_apply_settings_should_return_non_default_settings_when_settings_are_supplied_to_the_decorated_function(self):
+    def test_apply_settings_should_return_non_default_settings_when_settings_are_supplied_to_the_decorated_function(
+        self
+    ):
         test_func = apply_settings(test_function)
         self.assertNotEqual(test_func(settings={'PREFER_DATES_FROM': 'past'}), self.default_settings)
 
-    def test_apply_settings_should_not_create_new_settings_when_same_settings_are_supplied_to_the_decorated_function_more_than_once(self):
+    def test_apply_settings_shouldnt_create_new_settings_when_same_settings_are_supplied_to_the_decorated_function_more_than_once(  # noqa E501
+        self
+    ):
         test_func = apply_settings(test_function)
         settings_once = test_func(settings={'PREFER_DATES_FROM': 'past'})
         settings_twice = test_func(settings={'PREFER_DATES_FROM': 'past'})
         self.assertEqual(settings_once, settings_twice)
 
-    def test_apply_settings_should_return_default_settings_when_called_with_no_settings_after_once_called_with_settings_supplied_to_the_decorated_function(self):
+    def test_apply_settings_should_return_default_settings_when_called_with_no_settings_after_once_called_with_settings_supplied_to_the_decorated_function( # noqa E501
+        self
+    ):
         test_func = apply_settings(test_function)
         settings_once = test_func(settings={'PREFER_DATES_FROM': 'past'})
         settings_twice = test_func()

--- a/tests/test_utils_strptime.py
+++ b/tests/test_utils_strptime.py
@@ -72,12 +72,18 @@ class TestStrptime(BaseTestCase):
         param('12 Dec 10 10:30:55.10', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 100000)),
         param('12 Dec 10 10:30:55.100', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 100000)),
         param('12 Dec 10 10:30:55.1000', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 100000)),
-        param('12 Dec 10 10:30:55.100000', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 100000)),
+        param(
+            '12 Dec 10 10:30:55.100000', '%d %b %y %H:%M:%S.%f',
+            expected=datetime(2010, 12, 12, 10, 30, 55, 100000)
+        ),
         param('12 Dec 10 10:30:55.000001', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 1)),
         param('12 Dec 10 10:30:55.000011', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 11)),
         param('12 Dec 10 10:30:55.000111', '%d %b %y %H:%M:%S.%f', expected=datetime(2010, 12, 12, 10, 30, 55, 111)),
         param('12 Feb 2016 11:41:23', '%d %b %Y %I:%M:%S', expected=datetime(2016, 2, 12, 11, 41, 23)),
-        param('11 Dec 10 10:30:2011.999999', '%y %b %S %H:%M:%Y.%f', expected=datetime(2011, 12, 1, 10, 30, 10, 999999)),
+        param(
+            '11 Dec 10 10:30:2011.999999', '%y %b %S %H:%M:%Y.%f',
+            expected=datetime(2011, 12, 1, 10, 30, 10, 999999)
+        ),
     ])
     def test_microseconds_are_parsed_correctly(self, date_string, fmt, expected):
         self.when_date_string_is_parsed(date_string, fmt)


### PR DESCRIPTION
~~waiting for this to be merged: https://github.com/scrapinghub/dateparser/pull/731~~

----

I selected 119 as the max default line length because it's used by Scrapy and Django, and this is because it's the default line length supported by GitHub without needing to do horizontal scrolling.

I have some doubts when accepting exceptions so don't be afraid and comment if you see anything that could be improved.