### PR TITLE
Fix `calendars` extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
       env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=py27
-    - python: pypy3
-      env: TOXENV=pypy3
     - python: pypy
       env: TOXENV=pypy
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=py27
+    - python: pypy3
+      env: TOXENV=pypy3
     - python: pypy
       env: TOXENV=pypy
     - python: 3.5

--- a/README.rst
+++ b/README.rst
@@ -234,14 +234,14 @@ Dependencies
 `dateparser` relies on following libraries in some ways:
 
   * dateutil_'s module ``relativedelta`` for its freshness parser.
-  * jdatetime_ to convert *Jalali* dates to *Gregorian*.
+  * convertdate_ to convert *Jalali* dates to *Gregorian*.
   * umalqurra_ to convert *Hijri* dates to *Gregorian*.
   * tzlocal_ to reliably get local timezone.
   * ruamel.yaml_ (optional) for operations on language files.
 
 .. _dateutil: https://pypi.python.org/pypi/python-dateutil
-.. _jdatetime: https://pypi.python.org/pypi/jdatetime
-.. _umalqurra: https://pypi.python.org/pypi/umalqurra/
+.. _convertdate: https://pypi.python.org/pypi/convertdate
+.. _umalqurra: https://pypi.python.org/pypi/umalqurra
 .. _tzlocal: https://pypi.python.org/pypi/tzlocal
 .. _ruamel.yaml: https://pypi.python.org/pypi/ruamel.yaml
 

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
         'regex !=2019.02.19',
         'tzlocal',
     ],
-    extra_requires={
-        'calendars': ['convertdate', 'umalqurra', 'jdatetime', 'ruamel.yaml'],
+    extras_require={
+        'calendars:python_version<="2.7"': ['umalqurra', 'convertdate'],
+        'calendars:python_version>"2.7"': ['convertdate']
     },
     license="BSD",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'pytz',
         # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
         'regex !=2019.02.19',
+        'regex==2019.01.24; implementation_name == "PyPy"',
         'tzlocal',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     extras_require={
         'calendars:python_version<="2.7"': ['umalqurra', 'convertdate'],
-        'calendars:python_version>"2.7"': ['convertdate']
+        'calendars:python_version>"2.7"': ['convertdate'],
     },
     license="BSD",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,9 @@ setup(
         'python-dateutil',
         'pytz',
         # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
-        'regex !=2019.02.19',
-        'regex==2019.01.24; implementation_name == "PyPy"',
+        'regex !=2019.02.19; platform.python_implementation != "PyPy"',
+        # temporary workaround for: https://github.com/scrapinghub/dateparser/issues/565
+        'regex==2019.01.24; platform.python_implementation == "PyPy"',
         'tzlocal',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,15 @@ envlist = flake8, py2, py3
 
 [testenv]
 deps =
-    -rrequirements.txt
     -rdateparser_scripts/requirements.txt
     -rtests/requirements.txt
+extras = calendars
 commands =
     pytest --cov=dateparser {posargs: tests}
 
 [testenv:flake8]
 basepython = python3
+extras = calendars
 deps =
     {[testenv]deps}
     pytest-flake8


### PR DESCRIPTION
I noticed that `pip install dateparser[calendars]` didn't work. After some time investigating, it seems that there was a typo in `extras_require`.

I also updated the `tox` file after this change and the docs (that were wrong). The `requirements.txt` file will be deleted in this PR: https://github.com/scrapinghub/dateparser/pull/739