### PR TITLE
Detect hours with period/dot as separator

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -16,6 +16,7 @@ NSP_COMPATIBLE = re.compile(r'\D+')
 MERIDIAN = re.compile(r'am|pm')
 MICROSECOND = re.compile(r'\d{1,6}')
 EIGHT_DIGIT = re.compile(r'^\d{8}$')
+HOUR_MINUTE_REGEX = re.compile(r'^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$')
 
 
 def no_space_parser_eligibile(datestring):
@@ -209,7 +210,7 @@ class _parser(object):
     def __init__(self, tokens, settings):
         self.settings = settings
         self.tokens = list(tokens)
-        self.filtered_tokens = [t for t in self.tokens if t[1] <= 1]
+        self.filtered_tokens = [(*t, i) for i, t in enumerate(self.tokens) if t[1] <= 1]
 
         self.unset_tokens = []
 
@@ -232,46 +233,65 @@ class _parser(object):
 
         skip_index = []
         skip_component = None
-        for index, token_type in enumerate(self.filtered_tokens):
+        for index, token_type_original_index in enumerate(self.filtered_tokens):
 
             if index in skip_index:
                 continue
 
-            token, type = token_type
+            token, type, original_index = token_type_original_index
 
             if token in settings.SKIP_TOKENS_PARSER:
                 continue
 
             if self.time is None:
+                meridian_index = index + 1
+
+                try:
+                    # try case where hours and minutes are separated by a period. Example: 13.20.
+                    _is_before_period = self.tokens[original_index + 1][0] == '.'
+                    _is_after_period = original_index != 0 and self.tokens[original_index - 1][0] == '.'
+
+                    if _is_before_period and not _is_after_period:
+                        index_next_token = index + 1
+                        next_token = self.filtered_tokens[index_next_token][0]
+                        index_in_tokens_for_next_token = self.filtered_tokens[index_next_token][2]
+
+                        next_token_is_last = index_next_token == len(self.filtered_tokens) - 1
+                        if next_token_is_last or self.tokens[index_in_tokens_for_next_token + 1][0] != '.':
+                            new_token = token + ':' + next_token
+                            if re.match(HOUR_MINUTE_REGEX, new_token):
+                                token = new_token
+                                skip_index.append(index + 1)
+                                meridian_index += 1
+                except Exception:
+                    pass
+
                 try:
                     microsecond = MICROSECOND.search(self.filtered_tokens[index + 1][0]).group()
                     _is_after_time_token = token.index(":")
-                    _is_after_period = self.tokens[
-                        self.tokens.index((token, 0)) + 1][0].index('.')
+                    _is_after_period = self.tokens[self.tokens.index((token, 0)) + 1][0].index('.')
                 except:
                     microsecond = None
 
                 if microsecond:
-                    mindex = index + 2
-                else:
-                    mindex = index + 1
+                    meridian_index += 1
 
                 try:
-                    meridian = MERIDIAN.search(self.filtered_tokens[mindex][0]).group()
+                    meridian = MERIDIAN.search(self.filtered_tokens[meridian_index][0]).group()
                 except:
                     meridian = None
 
                 if any([':' in token, meridian, microsecond]):
                     if meridian and not microsecond:
                         self._token_time = '%s %s' % (token, meridian)
-                        skip_index.append(mindex)
+                        skip_index.append(meridian_index)
                     elif microsecond and not meridian:
                         self._token_time = '%s.%s' % (token, microsecond)
                         skip_index.append(index + 1)
                     elif meridian and microsecond:
                         self._token_time = '%s.%s %s' % (token, microsecond, meridian)
                         skip_index.append(index + 1)
-                        skip_index.append(mindex)
+                        skip_index.append(meridian_index)
                     else:
                         self._token_time = token
                     self.time = lambda: time_parser(self._token_time)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -210,7 +210,7 @@ class _parser(object):
     def __init__(self, tokens, settings):
         self.settings = settings
         self.tokens = list(tokens)
-        self.filtered_tokens = [(*t, i) for i, t in enumerate(self.tokens) if t[1] <= 1]
+        self.filtered_tokens = [(t[0], t[1], i) for i, t in enumerate(self.tokens) if t[1] <= 1]
 
         self.unset_tokens = []
 

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -47,6 +47,8 @@ class TestDateParser(BaseTestCase):
         param('19 February 2013 year 09:10', datetime(2013, 2, 19, 9, 10)),
         param('21 January 2012 13:11:23.678', datetime(2012, 1, 21, 13, 11, 23, 678000)),
         param('1/1/16 9:02:43.1', datetime(2016, 1, 1, 9, 2, 43, 100000)),
+        param('29.02.2020 13.12', datetime(2020, 2, 29, 13, 12)),
+        param('Wednesday, 22nd June, 2016, 12.16 pm.', datetime(2016, 6, 22, 12, 16)),
         # French dates
         param('11 Mai 2014', datetime(2014, 5, 11)),
         param('dimanche, 11 Mai 2014', datetime(2014, 5, 11)),
@@ -108,6 +110,7 @@ class TestDateParser(BaseTestCase):
         param('18.10.14 um 22:56 Uhr', datetime(2014, 10, 18, 22, 56)),
         param('12-Mär-2014', datetime(2014, 3, 12)),
         param('Mit 13:14', datetime(2012, 11, 7, 13, 14)),
+        param('23. März 18.37 Uhr', datetime(2012, 3, 23, 18, 37)),
         # Czech dates
         param('pon 16. čer 2014 10:07:43', datetime(2014, 6, 16, 10, 7, 43)),
         param('13 Srpen, 2014', datetime(2014, 8, 13)),
@@ -178,7 +181,9 @@ class TestDateParser(BaseTestCase):
         param('12 जनवरी  1997 11:08 अपराह्न', datetime(1997, 1, 12, 23, 8)),
         # Georgian dates
         param('2011 წლის 17 მარტი, ოთხშაბათი', datetime(2011, 3, 17, 0, 0)),
-        param('2015 წ. 12 ივნ, 15:34', datetime(2015, 6, 12, 15, 34))
+        param('2015 წ. 12 ივნ, 15:34', datetime(2015, 6, 12, 15, 34)),
+        # Finish dates
+        param('5.7.2018 5.45 ip.', datetime(2018, 7, 5, 17, 45))
     ])
     def test_dates_parsing(self, date_string, expected):
         self.given_parser(settings={'NORMALIZE': False,

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -182,7 +182,7 @@ class TestDateParser(BaseTestCase):
         # Georgian dates
         param('2011 წლის 17 მარტი, ოთხშაბათი', datetime(2011, 3, 17, 0, 0)),
         param('2015 წ. 12 ივნ, 15:34', datetime(2015, 6, 12, 15, 34)),
-        # Finish dates
+        # Finnish dates
         param('5.7.2018 5.45 ip.', datetime(2018, 7, 5, 17, 45))
     ])
     def test_dates_parsing(self, date_string, expected):


### PR DESCRIPTION
fixes: https://github.com/scrapinghub/dateparser/issues/643
fixes: https://github.com/scrapinghub/dateparser/issues/422

I worked on a solution for this issue and I got this. This is fully working and I added different cases to the tests coming from the issues. However, I think that this part of the code should be heavily refactored, as it's really hard to read, understand, and follow.

Solving this is not as trivial as it seems, because we use dots to separate the tokens, so it's hard to know when it's a valid HH.MM.