### PR TITLE
remove some python2 specific code

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -1,5 +1,5 @@
 import collections
-from collections import Set
+from collections.abc import Set
 from datetime import datetime, timedelta
 
 import regex as re

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -1,4 +1,5 @@
 import collections
+from collections import Set
 from datetime import datetime, timedelta
 
 import regex as re
@@ -153,7 +154,7 @@ class _DateLocaleParser(object):
 
     def __init__(self, locale, date_string, date_formats, settings=None):
         self._settings = settings
-        if not (date_formats is None or isinstance(date_formats, (list, tuple, set))):
+        if not (date_formats is None or isinstance(date_formats, (list, tuple, Set))):
             raise TypeError("Date formats should be list, tuple or set of strings")
 
         self.locale = locale
@@ -300,10 +301,10 @@ class DateDataParser(object):
     def __init__(self, languages=None, locales=None, region=None, try_previous_locales=True,
                  use_given_order=False, settings=None):
 
-        if not isinstance(languages, (list, tuple, set)) and languages is not None:
+        if not isinstance(languages, (list, tuple, Set)) and languages is not None:
             raise TypeError("languages argument must be a list (%r given)" % type(languages))
 
-        if not isinstance(locales, (list, tuple, set)) and locales is not None:
+        if not isinstance(locales, (list, tuple, Set)) and locales is not None:
             raise TypeError("locales argument must be a list (%r given)" % type(locales))
 
         if not isinstance(region, str) and region is not None:
@@ -373,9 +374,6 @@ class DateDataParser(object):
         """
         if not(isinstance(date_string, str) or isinstance(date_string, str)):
             raise TypeError('Input type must be str or unicode')
-
-        if isinstance(date_string, bytes):
-            date_string = date_string.decode('utf-8')
 
         res = parse_with_formats(date_string, date_formats or [], self._settings)
         if res['date_obj']:

--- a/dateparser/languages/loader.py
+++ b/dateparser/languages/loader.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 
 from ..data import language_order, language_locale_dict
 from .locale import Locale
-from ..utils import convert_to_unicode
 
 LOCALE_SPLIT_PATTERN = re.compile(r'-(?=[A-Z0-9]+$)')
 
@@ -175,7 +174,6 @@ class LocaleDataLoader(object):
                 else:
                     language_info = getattr(
                         import_module('dateparser.data.date_translation_data.' + lang), 'info')
-                    language_info = convert_to_unicode(language_info)
                     locale = Locale(shortname, language_info=deepcopy(language_info))
                     self._loaded_languages[lang] = language_info
                     self._loaded_locales[shortname] = locale

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -149,8 +149,6 @@ class Locale(object):
         for i, token in enumerate(date_string_tokens):
             if token.isdecimal():
                 date_string_tokens[i] = str(int(token)).zfill(len(token))
-                if isinstance(date_string_tokens[i], bytes):
-                    date_string_tokens[i] = date_string_tokens[i].decode('utf-8')
         return ''.join(date_string_tokens)
 
     def _get_relative_translations(self, settings=None):

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -1,4 +1,4 @@
-from collections import Set
+from collections.abc import Set
 
 from dateparser.languages.loader import LocaleDataLoader
 from dateparser.conf import apply_settings, Settings

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -1,15 +1,11 @@
+from collections import Set
+
 from dateparser.languages.loader import LocaleDataLoader
 from dateparser.conf import apply_settings, Settings
 from dateparser.date import DateDataParser
 from dateparser.search.text_detection import FullTextLanguageDetector
 import regex as re
 
-try:
-    # Python 3
-    from collections.abc import Set
-except ImportError:
-    # Python 2.7
-    from collections import Set
 
 RELATIVE_REG = re.compile("(ago|in|from now|tomorrow|today|yesterday)")
 

--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -17,9 +17,6 @@ def strip_braces(date_string):
 
 
 def normalize_unicode(string, form='NFKD'):
-    if isinstance(string, bytes):
-        string = string.decode('utf-8')
-
     return ''.join(
         (c for c in unicodedata.normalize(form, string)
          if unicodedata.category(c) != 'Mn'))
@@ -41,25 +38,6 @@ def combine_dicts(primary_dict, supplementary_dict):
     for key in remaining_keys:
         combined_dict[key] = supplementary_dict[key]
     return combined_dict
-
-
-def convert_to_unicode(info):
-    unicode_info = OrderedDict()
-    for key, value in info.items():
-        if isinstance(key, bytes):
-            key = key.decode('utf-8')
-        if isinstance(value, list):
-            for i, v in enumerate(value):
-                if isinstance(v, dict):
-                    value[i] = convert_to_unicode(v)
-                elif isinstance(v, bytes):
-                    value[i] = v.decode('utf-8')
-        elif isinstance(value, dict):
-            value = convert_to_unicode(value)
-        elif isinstance(value, bytes):
-            value = value.decode('utf-8')
-        unicode_info[key] = value
-    return unicode_info
 
 
 def find_date_separator(format):

--- a/dateparser/utils/strptime.py
+++ b/dateparser/utils/strptime.py
@@ -1,8 +1,5 @@
 import sys
-if sys.version_info[0:2] < (3, 3):
-    import imp
-else:
-    import importlib.util
+import importlib.util
 import regex as re
 
 from datetime import datetime
@@ -25,24 +22,15 @@ def patch_strptime():
     For example, if system's locale is set to fr_FR. Parser won't recognize
     any date since all languages are translated to english dates.
     """
-    if sys.version_info[0:2] < (3, 3):
-        _strptime = imp.load_module(
-            'strptime_patched', *imp.find_module('_strptime')
-        )
+    _strptime_spec = importlib.util.find_spec('_strptime')
 
-        _calendar = imp.load_module(
-            'calendar_patched', *imp.find_module('_strptime')
-        )
-    else:
-        _strptime_spec = importlib.util.find_spec('_strptime')
+    _strptime = importlib.util.module_from_spec(_strptime_spec)
+    _strptime_spec.loader.exec_module(_strptime)
+    sys.modules['strptime_patched'] = _strptime
 
-        _strptime = importlib.util.module_from_spec(_strptime_spec)
-        _strptime_spec.loader.exec_module(_strptime)
-        sys.modules['strptime_patched'] = _strptime
-
-        _calendar = importlib.util.module_from_spec(_strptime_spec)
-        _strptime_spec.loader.exec_module(_calendar)
-        sys.modules['calendar_patched'] = _calendar
+    _calendar = importlib.util.module_from_spec(_strptime_spec)
+    _strptime_spec.loader.exec_module(_calendar)
+    sys.modules['calendar_patched'] = _calendar
 
     _strptime._getlang = lambda: ('en_US', 'UTF-8')
     _strptime.calendar = _calendar


### PR DESCRIPTION
I fixed some cases with Python 2 specific code that were detected when removing Python 2 from the pipelines (https://github.com/scrapinghub/dateparser/pull/744) (https://codecov.io/gh/scrapinghub/dateparser/pull/744/changes)