### PR TITLE
don't try previous locales by default

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -298,16 +298,16 @@ class DateDataParser:
     locale_loader = None
 
     @apply_settings
-    def __init__(self, languages=None, locales=None, region=None, try_previous_locales=True,
+    def __init__(self, languages=None, locales=None, region=None, try_previous_locales=False,
                  use_given_order=False, settings=None):
 
-        if not isinstance(languages, (list, tuple, Set)) and languages is not None:
+        if languages is not None and not isinstance(languages, (list, tuple, Set)):
             raise TypeError("languages argument must be a list (%r given)" % type(languages))
 
-        if not isinstance(locales, (list, tuple, Set)) and locales is not None:
+        if locales is not None and not isinstance(locales, (list, tuple, Set)):
             raise TypeError("locales argument must be a list (%r given)" % type(locales))
 
-        if not isinstance(region, str) and region is not None:
+        if region is not None and not isinstance(region, str):
             raise TypeError("region argument must be str or unicode (%r given)" % type(region))
 
         if not isinstance(try_previous_locales, bool):

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -395,6 +395,20 @@ class TestDateDataParser(BaseTestCase):
         self.when_date_string_is_parsed(date_string)
         self.then_detected_locale(locale)
 
+    def test_try_previous_locales_false(self):
+        self.given_parser(try_previous_locales=False)
+        self.when_date_string_is_parsed('Mañana')  # es
+        self.then_detected_locale('es')
+        self.when_date_string_is_parsed('2020-05-01')
+        self.then_detected_locale('en')
+
+    def test_try_previous_locales_true(self):
+        self.given_parser(try_previous_locales=True)
+        self.when_date_string_is_parsed('Mañana')  # es
+        self.then_detected_locale('es')
+        self.when_date_string_is_parsed('2020-05-01')
+        self.then_detected_locale('es')
+
     @parameterized.expand([
         param("2014-10-09T17:57:39+00:00"),
     ])


### PR DESCRIPTION
fixes: https://github.com/scrapinghub/dateparser/issues/549, https://github.com/scrapinghub/dateparser/issues/776

Trying previous locales by default improves the performance when trying to parse the less common languages. However, it makes the `dateparser.parser()` nondeterministic, and it produces some side effects that are not easy to detect and track (check referenced issues to see examples).


We have two options:

1. Change the default value in `DateDataParser` for `try_previous_locales` from `True` to `False`.
2. Add `try_previous_locales=False` in the DateDataParser objects created in the `dateparser/__init__.py`.

(Note that it doesn't make sense to move this feature to a new setting because `dateparser.parser()` won't be able to track the used languages as it doesn't have a real internal state and if we pass different parameters we will lose them.)


The second approach has the advantage that it remains `True` by default when using `DateDataParser` directly, but I think it's better to make both APIs (`dateparser.parse()` and `DateDataParser.get_date_data()`) to behave in the same way by default, so I decided to use the first approach.

I added this new issue: https://github.com/scrapinghub/dateparser/issues/780 to create a section in the documentation regarding the performance tweaks.