### PR TITLE
fix redundant expression

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -372,7 +372,7 @@ class DateDataParser:
             {'date_obj': datetime.datetime(2000, 3, 23, 14, 21), 'period': 'day'}
 
         """
-        if not(isinstance(date_string, str) or isinstance(date_string, str)):
+        if not isinstance(date_string, str):
             raise TypeError('Input type must be str')
 
         res = parse_with_formats(date_string, date_formats or [], self._settings)


### PR DESCRIPTION
It seems that it was introduced when removing the six package: https://github.com/scrapinghub/dateparser/pull/754/files#diff-497df515e3e0f7db80cd0a8d7c301444R377