### PR TITLE
remove FUZZY setting

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -293,7 +293,7 @@ class _parser:
                     self.time = lambda: time_parser(self._token_time)
                     continue
 
-            results = self._parse(type, token, settings.FUZZY, skip_component=skip_component)
+            results = self._parse(type, token, skip_component=skip_component)
             for res in results:
                 if len(token) == 4 and res[0] == 'year':
                     skip_component = 'year'
@@ -395,15 +395,6 @@ class _parser:
         self._set_relative_base()
 
         time = self.time() if self.time is not None else None
-
-        if self.settings.FUZZY:
-            attr_truth_values = []
-            for attr in ['day', 'month', 'year', 'time']:
-                attr_truth_values.append(getattr(self, attr, False))
-
-            if not any(attr_truth_values):
-                raise ValueError('Nothing date like found')
-
         params = self._get_datetime_obj_params()
 
         if time:
@@ -510,7 +501,7 @@ class _parser:
 
         return dateobj, period
 
-    def _parse(self, type, token, fuzzy, skip_component=None):
+    def _parse(self, type, token, skip_component=None):
 
         def set_and_return(token, type, component, dateobj, skip_date_order=False):
             if not skip_date_order:
@@ -541,10 +532,7 @@ class _parser:
                     except ValueError:
                         pass
             else:
-                if not fuzzy:
-                    raise ValueError('Unable to parse: %s' % token)
-                else:
-                    return []
+                raise ValueError('Unable to parse: %s' % token)
 
         def parse_alpha(token, skip_component=None):
             type = 1
@@ -567,10 +555,7 @@ class _parser:
                     except:
                         pass
             else:
-                if not fuzzy:
-                    raise ValueError('Unable to parse: %s' % token)
-                else:
-                    return []
+                raise ValueError('Unable to parse: %s' % token)
 
         handlers = {0: parse_number, 1: parse_alpha}
         return handlers[type](token, skip_component)

--- a/dateparser_data/settings.py
+++ b/dateparser_data/settings.py
@@ -16,7 +16,6 @@ settings = {
     'RELATIVE_BASE': False,
     'DATE_ORDER': 'MDY',
     'PREFER_LOCALE_DATE_ORDER': True,
-    'FUZZY': False,
     'STRICT_PARSING': False,
     'RETURN_TIME_AS_PERIOD': False,
     'PARSERS': default_parsers,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -435,17 +435,6 @@ class TestParser(BaseTestCase):
         self.given_settings(settings={'REQUIRE_PARTS': ['year']})
         self.then_error_is_raised_when_date_is_parsed(date_string)
 
-    @parameterized.expand([
-        param(date_string="Januar"),
-        param(date_string="56341819"),
-        param(date_string="56341819 Febr"),
-    ])
-    def test_error_is_raised_when_invalid_dates_given_when_fuzzy(self, date_string):
-        self.given_parser()
-        self.given_settings(settings={'FUZZY': True})
-        self.when_date_is_parsed(date_string)
-        self.then_error_was_raised(ValueError, ['Nothing date like found'])
-
     def given_parser(self):
         self.parser = _parser
 


### PR DESCRIPTION
As mentioned here: https://github.com/scrapinghub/dateparser/pull/722

I removed the `FUZZY` setting as:
* It has been never documented
* There isn't any known use case where a user needs to change it.
* There are 0 references in issues
