### PR TITLE
Remove self.now from freshness_date_parser in favor of a local variable (#813)

### DIFF
--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -1642,7 +1642,9 @@ class TestFreshnessDateDataParser(BaseTestCase):
                                     collecting_get_date_data(freshness_date_parser.get_date_data)))
 
         self.freshness_parser = Mock(wraps=freshness_date_parser)
-        self.add_patch(patch.object(self.freshness_parser, 'now', self.now))
+
+        # freshness_parser no longer has a local class member 'now'
+        # self.add_patch(patch.object(self.freshness_parser, 'now', self.now))
 
         dt_mock = Mock(wraps=dateparser.freshness_date_parser.datetime)
         dt_mock.utcnow = Mock(return_value=self.now)


### PR DESCRIPTION
In web server environment, since freshness_date_parser is a shared instance, it looks like self.now was set to None by some threads while still being used by others.

This change removes self.none from FreshnessDateDataParser and instead introduces a local variable insude FreshnessDateDataParser.parse().

I could've also just removed the statement at the end of pase() setting self.now to None, but I feel that this way is cleaner.

Thanks!

Fixes #813