### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,28 @@ matrix:
       env: TOXENV=latest
     - python: 3.9-dev
       env: TOXENV=latest
+    #powerjobs
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=flake8
+    - python: 3.5
+      arch: ppc64le
+      env: TOXENV=py
+    - python: 3.6
+      arch: ppc64le
+      env: TOXENV=py
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py PYPI_RELEASE_JOB=true
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=latest
+    - python: 3.9-dev
+      arch: ppc64le
+      env: TOXENV=latest    
 
 install: pip install -U wheel tox codecov
 


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
