### PR TITLE
Resolve concurrency issues

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -16,8 +16,6 @@ PATTERN = re.compile(r'(\d+)\s*(%s)\b' % _UNITS, re.I | re.S | re.U)
 
 class FreshnessDateDataParser:
     """ Parses date string like "1 year, 2 months ago" and "3 hours, 50 minutes ago" """
-    def __init__(self):
-        self.now = None
 
     def _are_all_words_units(self, date_string):
         skip = [_UNITS,
@@ -59,42 +57,42 @@ class FreshnessDateDataParser:
             )
 
         if settings.RELATIVE_BASE:
-            self.now = settings.RELATIVE_BASE
+            now = settings.RELATIVE_BASE
 
             if 'local' not in _settings_tz:
-                self.now = localize_timezone(self.now, settings.TIMEZONE)
+                now = localize_timezone(now, settings.TIMEZONE)
 
             if ptz:
-                if self.now.tzinfo:
-                    self.now = self.now.astimezone(ptz)
+                if now.tzinfo:
+                    now = now.astimezone(ptz)
                 else:
                     if hasattr(ptz, 'localize'):
-                        self.now = ptz.localize(self.now)
+                        now = ptz.localize(now)
                     else:
-                        self.now = self.now.replace(tzinfo=ptz)
+                        now = now.replace(tzinfo=ptz)
 
-            if not self.now.tzinfo:
+            if not now.tzinfo:
                 if hasattr(self.get_local_tz(), 'localize'):
-                    self.now = self.get_local_tz().localize(self.now)
+                    now = self.get_local_tz().localize(now)
                 else:
-                    self.now = self.now.replace(tzinfo=self.get_local_tz())
+                    now = now.replace(tzinfo=self.get_local_tz())
 
         elif ptz:
             _now = datetime.now(ptz)
 
             if 'local' in _settings_tz:
-                self.now = _now
+                now = _now
             else:
-                self.now = apply_timezone(_now, settings.TIMEZONE)
+                now = apply_timezone(_now, settings.TIMEZONE)
 
         else:
             if 'local' not in _settings_tz:
                 utc_dt = datetime.utcnow()
-                self.now = apply_timezone(utc_dt, settings.TIMEZONE)
+                now = apply_timezone(utc_dt, settings.TIMEZONE)
             else:
-                self.now = datetime.now(self.get_local_tz())
+                now = datetime.now(self.get_local_tz())
 
-        date, period = self._parse_date(date_string, settings.PREFER_DATES_FROM)
+        date, period = self._parse_date(date_string, now, settings.PREFER_DATES_FROM)
 
         if date:
             old_date = date
@@ -112,10 +110,9 @@ class FreshnessDateDataParser:
             ):
                 date = date.replace(tzinfo=None)
 
-        self.now = None
         return date, period
 
-    def _parse_date(self, date_string, prefer_dates_from):
+    def _parse_date(self, date_string, now, prefer_dates_from):
         if not self._are_all_words_units(date_string):
             return None, None
 
@@ -135,9 +132,9 @@ class FreshnessDateDataParser:
             or re.search(r'\bfuture\b', prefer_dates_from)
             and not re.search(r'\bago\b', date_string)
         ):
-            date = self.now + td
+            date = now + td
         else:
-            date = self.now - td
+            date = now - td
         return date, period
 
     def get_kwargs(self, date_string):

--- a/dateparser/search/text_detection.py
+++ b/dateparser/search/text_detection.py
@@ -11,7 +11,7 @@ class FullTextLanguageDetector(BaseLanguageDetector):
         self.language_chars = []
 
     def get_unique_characters(self, settings):
-        settings = settings.replace(NORMALIZE=False)
+        settings = settings.replace(settings={'NORMALIZE': False})
 
         for language in self.languages:
             chars = language.get_wordchars_for_detection(settings=settings)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,57 @@
+import concurrent.futures
+import random
+from datetime import datetime
+
+import dateparser
+from tests import BaseTestCase
+
+RELATIVE = {'RELATIVE_BASE': datetime(2014, 9, 15, 10, 30)}
+
+TEST_DATA = [
+    {'ds': 'Tue May 07, 2018 10:55 PM', 'expected': datetime(2018, 5, 7, 22, 55), 'loc': 'en'},
+    {'ds': '2018-10-07T22:55:01', 'expected': datetime(2018, 10, 7, 22, 55, 1), 'loc': 'en'},
+    {'ds': '2018-Oct-11', 'expected': datetime(2018, 10, 11, 0, 0), 'loc': 'en'},
+    {'ds': '12.04.2018', 'expected': datetime(2018, 12, 4, 0, 0), 'loc': 'en'},
+    {'ds': '12-10-2018 20:13', 'expected': datetime(2018, 12, 10, 20, 13), 'loc': 'en'},
+    {'ds': '03.04.2019', 'expected': datetime(2019, 4, 3, 0, 0), 'loc': 'en-150'},
+    {'ds': 'on Tue October 7, 2019 04:55 PM', 'expected': datetime(2019, 10, 7, 16, 55), 'loc': 'en-150'},
+    {'ds': '2019Oct8', 'expected': datetime(2019, 10, 8, 0, 0), 'loc': 'en-150'},
+    {'ds': '07.03.2020 - 11:13', 'expected': datetime(2020, 3, 7, 11, 13), 'loc': 'ru'},
+    {'ds': '9 Авг. 2020 17:11:01', 'expected': datetime(2020, 8, 9, 17, 11, 1), 'loc': 'ru'},
+    {'ds': '07.01.2020', 'expected': datetime(2020, 1, 7, 0, 0), 'loc': 'ru'},
+    {'ds': 'yesterday 11:00', 'expected': datetime(2014, 9, 14, 11), 'loc': 'en', 'extra': RELATIVE},
+    {'ds': '13 days ago', 'expected': datetime(2014, 9, 2, 10, 30), 'loc': 'en', 'extra': RELATIVE},
+           ] * 180
+
+random.shuffle(TEST_DATA)
+
+
+class TestConcurrency(BaseTestCase):
+
+    def test_concurrency(self):
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+
+            results = list(executor.map(self.concurrency_test, TEST_DATA))
+            results_with_error = [(r['ds'], r['error']) for r in results if r['error']]
+            self.assertEqual([], results_with_error,
+                             f'{len(results_with_error)} Threads failed with errors:\n{set(results_with_error)}')
+
+            wrong_results = [str(r) for r in results if (r['expected'] != r['date'])]
+            w_r_output = '\n'.join(wrong_results)
+            self.assertEqual([], wrong_results,
+                             f'{len(wrong_results)} Threads returned wrong date time:\n{w_r_output}')
+
+    @staticmethod
+    def concurrency_test(data_for_test):
+        try:
+            date_string = data_for_test['ds']
+            date = dateparser.parse(date_string, locales=[data_for_test['loc']],
+                                    settings=data_for_test.get('extra'))
+            if date:
+                data_for_test['date'] = date
+                data_for_test['error'] = None
+        except Exception as error:
+            data_for_test['error'] = str(error)
+            data_for_test['date'] = None
+        finally:
+            return data_for_test

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -21,7 +21,7 @@ TEST_DATA = [
     {'ds': '07.01.2020', 'expected': datetime(2020, 1, 7, 0, 0), 'loc': 'ru'},
     {'ds': 'yesterday 11:00', 'expected': datetime(2014, 9, 14, 11), 'loc': 'en', 'extra': RELATIVE},
     {'ds': '13 days ago', 'expected': datetime(2014, 9, 2, 10, 30), 'loc': 'en', 'extra': RELATIVE},
-           ] * 180
+] * 180
 
 random.shuffle(TEST_DATA)
 

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -1666,7 +1666,6 @@ class TestFreshnessDateDataParser(BaseTestCase):
                                     collecting_get_date_data(freshness_date_parser.get_date_data)))
 
         self.freshness_parser = Mock(wraps=freshness_date_parser)
-        self.add_patch(patch.object(self.freshness_parser, 'now', self.now))
 
         dt_mock = Mock(wraps=dateparser.freshness_date_parser.datetime)
         dt_mock.utcnow = Mock(return_value=self.now)

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -1546,7 +1546,7 @@ class TestFreshnessDateDataParser(BaseTestCase):
         self.then_time_is(time)
 
     def test_freshness_date_with_to_timezone_setting(self):
-        _settings = settings.replace(**{
+        _settings = settings.replace(settings={
             'TIMEZONE': 'local',
             'TO_TIMEZONE': 'UTC',
             'RELATIVE_BASE': datetime(2014, 9, 1, 10, 30)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -76,7 +76,7 @@ class TimeZoneSettingsTest(BaseTestCase):
         if 'TIMEZONE' not in confs:
             confs.update({'TIMEZONE': 'local'})
 
-        self.confs = settings.replace(**confs)
+        self.confs = settings.replace(settings=confs)
 
     def when_date_is_parsed(self):
         self.result = parse(self.given_ds, settings=(self.confs or {}))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,7 +84,9 @@ class TestUtils(BaseTestCase):
         param(datetime(2015, 12, 12, 10, 12), timezone='-0500', expected=datetime(2015, 12, 12, 5, 12)),
     ])
     def test_apply_timezone_from_settings_function(self, date, timezone, expected):
-        result = apply_timezone_from_settings(date, settings.replace(**{'TO_TIMEZONE': timezone, 'TIMEZONE': 'UTC'}))
+        result = apply_timezone_from_settings(date,
+                                              settings.replace(settings={'TO_TIMEZONE': timezone, 'TIMEZONE': 'UTC'})
+                                              )
         self.assertEqual(expected, result)
 
     @parameterized.expand([
@@ -101,7 +103,7 @@ class TestUtils(BaseTestCase):
         param(datetime(2015, 12, 12, 10, 12),),
     ])
     def test_apply_timezone_from_settings_function_should_return_tz(self, date):
-        result = apply_timezone_from_settings(date, settings.replace(**{'RETURN_AS_TIMEZONE_AWARE': True}))
+        result = apply_timezone_from_settings(date, settings.replace(settings={'RETURN_AS_TIMEZONE_AWARE': True}))
         self.assertTrue(bool(result.tzinfo))
 
     def test_registry_when_get_keys_not_implemented(self):


### PR DESCRIPTION
I’ve found two main concurrent issues with dateparser:
### I) TypeError: unsupported operand type(s) for -: 'NoneType' and 'relativedelta' #441 #813
**_Reason:_** Variable **freshness_date_parser** is a shared instance and its **self.now** was set to **None** by some threads while still being used by others.
**_Solution:_** Make a local variable now instead of self.now.  There’s already an PR #814 with this solution, but unfortunately it stuck, so I had to add it to my code in order to pass tests.

### II) Threads mixed up date orders
**_Reason:_** Settings instances are shared between locales and while one thread in
**_DateLocaleParser._try_parser()** was parsing a date with _date order_ picked for specific locale, other threads with the same **Settings** instances and different locales used shared **_settings.DATE_ORDER** before previous thread set default _settings.DATE_ORDER back,  which is wrong for their locales and thus returned wrong dates.
**_Solution:_**  Create separate **Settings** instances not only for different incoming settings, but for all other _kwargs_ e.g. different locales, languages, etc. 

**_other notes:_**
I noticed that the **replace()** method changed the original settings dict as it's a mutable object, so I’ve modified it to work with a _copy()_ of it. As settings can be passed to _kwargs_ as a **None**- added a check for this case.
