### PR TITLE
fix custom-formats with timezone

### DIFF
--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -3,7 +3,7 @@
 import unittest
 from collections import OrderedDict
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from unittest.mock import Mock, patch
 from parameterized import parameterized, param
@@ -12,6 +12,7 @@ import dateparser
 from dateparser.date import DateData
 from dateparser import date
 from dateparser.conf import settings
+from dateparser.timezone_parser import StaticTzInfo
 
 from tests import BaseTestCase
 
@@ -253,6 +254,22 @@ class TestParseWithFormatsFunction(BaseTestCase):
         param(date_string='25-03-14', date_formats=['%d-%m-%y'], expected_result=datetime(2014, 3, 25)),
     ])
     def test_should_parse_date(self, date_string, date_formats, expected_result):
+        self.when_date_is_parsed_with_formats(date_string, date_formats)
+        self.then_date_was_parsed()
+        self.then_parsed_period_is('day')
+        self.then_parsed_date_is(expected_result)
+
+    @parameterized.expand([
+        param(date_string='Fri Jan 26 16:32:21 +0000 2018', date_formats=['%a %b %d %H:%M:%S %z %Y'],
+              expected_result=datetime(2018, 1, 26, 16, 32, 21)),
+        param(date_string='15/04/1904 14:05 +0004', date_formats=['%d/%m/%Y %H:%M %z'],
+              expected_result=datetime(1904, 4, 15, 14, 5, tzinfo=timezone(timedelta(0, 240)))),
+        param(date_string='20-05-1994 23:00 GMT', date_formats=['%d-%m-%Y %H:%M %Z'],
+              expected_result=datetime(
+                  1994, 5, 20, 23, 0, tzinfo=StaticTzInfo('GMT', timedelta(seconds=0))
+              )),
+    ])
+    def test_should_parse_localized_dates(self, date_string, date_formats, expected_result):
         self.when_date_is_parsed_with_formats(date_string, date_formats)
         self.then_date_was_parsed()
         self.then_parsed_period_is('day')

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -264,10 +264,11 @@ class TestParseWithFormatsFunction(BaseTestCase):
               expected_result=datetime(2018, 1, 26, 16, 32, 21)),
         param(date_string='15/04/1904 14:05 +0004', date_formats=['%d/%m/%Y %H:%M %z'],
               expected_result=datetime(1904, 4, 15, 14, 5, tzinfo=timezone(timedelta(0, 240)))),
-        param(date_string='20-05-1994 23:00 GMT', date_formats=['%d-%m-%Y %H:%M %Z'],
-              expected_result=datetime(
-                  1994, 5, 20, 23, 0, tzinfo=StaticTzInfo('GMT', timedelta(seconds=0))
-              )),
+        param(
+            date_string='20-05-1994 23:00 GMT', date_formats=['%d-%m-%Y %H:%M %Z'], expected_result=datetime(
+                1994, 5, 20, 23, 0, tzinfo=StaticTzInfo('GMT', timedelta(seconds=0))
+            )
+        ),
     ])
     def test_should_parse_localized_dates(self, date_string, date_formats, expected_result):
         self.when_date_is_parsed_with_formats(date_string, date_formats)


### PR DESCRIPTION
Fix `ValueError` when parsing a date string that already contains timezone info with the `custom-formats` parser.

fixes: https://github.com/scrapinghub/dateparser/issues/376, closes: https://github.com/scrapinghub/dateparser/issues/375