### PR TITLE
apply str.strip() in sanitize_date

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -106,9 +106,8 @@ def sanitize_date(date_string):
     date_string = RE_SANITIZE_PERIOD.sub('', date_string)
     date_string = RE_SANITIZE_ON.sub(r'\1', date_string)
     date_string = RE_TRIM_COLONS.sub(r'\1', date_string)
-
     date_string = RE_SANITIZE_APOSTROPHE.sub("'", date_string)
-
+    date_string = date_string.strip()
     return date_string
 
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -657,8 +657,10 @@ class TestParserInitialization(BaseTestCase):
 
 class TestSanitizeDate(BaseTestCase):
     def test_remove_year_in_russian(self):
-        self.assertEqual(date.sanitize_date('2005г.'), '2005 ')
-        self.assertEqual(date.sanitize_date('2005 г.'), '2005 ')
+        self.assertEqual(date.sanitize_date('2005г.'), '2005')
+        self.assertEqual(date.sanitize_date('2005г. 20:37'), '2005 20:37')
+        self.assertEqual(date.sanitize_date('2005 г.'), '2005')
+        self.assertEqual(date.sanitize_date('2005 г. 15:24'), '2005 15:24')
         self.assertEqual(date.sanitize_date('Авг.'), 'Авг')
 
     def test_sanitize_date_colons(self):

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -385,6 +385,7 @@ class TestDateParser(BaseTestCase):
         param('1999-12-31 19:00:00 +0500', '+05:00', datetime(1999, 12, 31, 19, 0)),
         param('Fri, 09 Sep 2005 13:51:39 -0700', '-07:00', datetime(2005, 9, 9, 13, 51, 39)),
         param('Fri, 09 Sep 2005 13:51:39 +0000', '+00:00', datetime(2005, 9, 9, 13, 51, 39)),
+        param('Mon, 25 Jun 2018 10:37:47 +0530 ', '+05:30', datetime(2018, 6, 25, 10, 37, 47)),  # Trailing space
     ])
     def test_dateparser_should_return_tzaware_date_when_tz_info_present_in_date_string(
             self, date_string, timezone_str, expected):


### PR DESCRIPTION
The trailing spaces can cause unexpected issues. For example:

```python3
>>> dateparser.parse('Mon, 25 Jun 2018 10:37:47 +0530 ')
```

returns `None`.

(Or this: https://github.com/scrapinghub/dateparser/issues/691).

For that reason, I added an `str.strip()` to the `sanitize_date()` function.