### PR TITLE
remove convert_to_local_tz

### DIFF
--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -49,10 +49,6 @@ def word_is_tz(word):
     return bool(_search_regex.match(word))
 
 
-def convert_to_local_tz(datetime_obj, datetime_tz_offset):
-    return datetime_obj - datetime_tz_offset + local_tz_offset
-
-
 def build_tz_offsets(search_regex_parts):
 
     def get_offset(tz_obj, regex, repl='', replw=''):


### PR DESCRIPTION
This function is not used, is not documented, it's not tested and there isn't any reference anywhere (https://github.com/scrapinghub/dateparser/search?q=convert_to_local_tz).

However removing it directly could be considered as a breaking change.