### PR TITLE
Make order of previous locales deterministic

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -363,7 +363,7 @@ class DateDataParser:
         self.languages = languages
         self.locales = locales
         self.region = region
-        self.previous_locales = set()
+        self.previous_locales = collections.OrderedDict()
 
     def get_date_data(self, date_string, date_formats=None):
         """
@@ -423,7 +423,7 @@ class DateDataParser:
             if parsed_date:
                 parsed_date['locale'] = locale.shortname
                 if self.try_previous_locales:
-                    self.previous_locales.add(locale)
+                    self.previous_locales[locale] = None
                 return parsed_date
         else:
             return DateData(date_obj=None, period='day', locale=None)
@@ -457,7 +457,7 @@ class DateDataParser:
                 yield stripped_date_string
 
         if self.try_previous_locales:
-            for locale in self.previous_locales:
+            for locale in self.previous_locales.keys():
                 for s in date_strings():
                     if self._is_applicable_locale(locale, s):
                         yield locale

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -410,6 +410,14 @@ class TestDateDataParser(BaseTestCase):
         self.when_date_string_is_parsed('2020-05-01')
         self.then_detected_locale('es')
 
+    def test_try_previous_locales_order_deterministic(self):
+        self.given_parser(try_previous_locales=True)
+        self.when_date_string_is_parsed('Mañana')  # es
+        self.then_detected_locale('es')
+        self.when_date_string_is_parsed('Понедельник')  # ru
+        self.then_detected_locale('ru')
+        self.then_previous_locales_is(["es", "ru"])
+
     @parameterized.expand([
         param("2014-10-09T17:57:39+00:00"),
     ])
@@ -582,6 +590,10 @@ class TestDateDataParser(BaseTestCase):
 
     def then_returned_tuple_is(self, expected_tuple):
         self.assertEqual(expected_tuple, self.result)
+
+    def then_previous_locales_is(self, expected_list):
+        self.assertEqual(expected_list,
+                         [locale.shortname for locale in self.parser.previous_locales])
 
 
 class TestParserInitialization(BaseTestCase):


### PR DESCRIPTION
When using `set` for storing previously seen locales we eventually end up in the land of non-determinism when looping through them:
```
Python 3.8.5 (default, Jul 21 2020, 10:48:26)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> a = set()
>>> a.add("ru")
>>> a.add("es")
>>> a
{'es', 'ru'}
>>> a.add("en")
>>> a
{'es', 'en', 'ru'}
...
```

Since python 3.7 insertion order is [preserved](https://mail.python.org/pipermail/python-dev/2017-December/151283.html) in dictionaries, so we can take advantage of this. 

I'm not sure what the policy is as for support of python < 3.7, on travis we seem to be running even 3.5, then my test will fail there. However, when looking at [this](https://github.com/scrapinghub/dateparser/issues/549) discussion, I see there's an appetite for making this logic deterministic. Approach with `dict` should not be slowing parsing either:
```
>>> b = {}
>>> b.update({"es": "es"})  # first string parsed
>>> b
{'es': 'es'}
>>> b.update({"ru": "ru"})  # second string parsed
>>> b
{'es': 'es', 'ru': 'ru'}
>>> b.update({"es": "es"})  # third string parsed
>>> b
{'es': 'es', 'ru': 'ru'}
...
```