### PR TITLE
Fixing Issue  #894

### DIFF
--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -88,8 +88,6 @@ class _ExactLanguageSearch:
 
     def parse_item(self, parser, item, translated_item, parsed, need_relative_base):
         relative_base = None
-        item = item.replace('ngày', '')
-        item = item.replace('am', '')
         parsed_item = parser.get_date_data(item)
         is_relative = date_is_relative(translated_item)
 


### PR DESCRIPTION
It seems removing this line resolves issue #894

Please check and merge the pull request

Before 

`[('March 3, 2021, 12:47 am', datetime.datetime(2021, 3, 3, 12, 47))]
`
After

`[('March 3, 2021, 00:47', datetime.datetime(2021, 3, 3, 0, 47))]
`