### PR TITLE
[WIP] Reimplementing search_dates &  fixing search translation

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -176,6 +176,7 @@ class Locale:
 
     def translate_search(self, search_string, settings=None):
         dashes = ['-', '——', '—', '～']
+        word_joint_unsupported_laguage = ["zh", "ja"]
         sentences = self._sentence_split(search_string, settings=settings)
         dictionary = self._get_dictionary(settings=settings)
         translated = []
@@ -184,10 +185,31 @@ class Locale:
             original_tokens, simplified_tokens = self._simplify_split_align(sentence, settings=settings)
             translated_chunk = []
             original_chunk = []
+            simplified_tokens_length = len(simplified_tokens)
+            skip_next_token = False
             for i, word in enumerate(simplified_tokens):
+
+                next_word = simplified_tokens[i + 1] if (simplified_tokens_length - 1) > i else ""
+                current_and_next_joined = self._join_chunk([word, next_word], settings=settings)
+
+                if skip_next_token:
+                    skip_next_token = False
+                    continue
+
                 if word == '' or word == ' ':
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
+                elif (
+                    current_and_next_joined in dictionary
+                    and word not in dashes
+                    and self.shortname not in word_joint_unsupported_laguage
+                ):
+                    translated_chunk.append(dictionary[current_and_next_joined])
+                    original_chunk.append(
+                        self._join_chunk([original_tokens[i], original_tokens[i + 1]], settings=settings)
+                    )
+                    skip_next_token = True
+
                 elif word in dictionary and word not in dashes:
                     translated_chunk.append(dictionary[word])
                     original_chunk.append(original_tokens[i])
@@ -214,6 +236,7 @@ class Locale:
             if translated_chunk:
                 translated.append(translated_chunk)
                 original.append(original_chunk)
+
         for i in range(len(translated)):
             if "in" in translated[i]:
                 translated[i] = self._clear_future_words(translated[i])
@@ -266,6 +289,7 @@ class Locale:
         original_tokens = self._word_split(original, settings=settings)
         simplified_tokens = self._word_split(self._simplify(normalize_unicode(original), settings=settings),
                                              settings=settings)
+
         if len(original_tokens) == len(simplified_tokens):
             return original_tokens, simplified_tokens
 

--- a/dateparser/search_dates/__init__.py
+++ b/dateparser/search_dates/__init__.py
@@ -1,0 +1,24 @@
+from dateparser.search_dates.search import DateSearch
+from dateparser.conf import apply_settings
+
+
+_search_dates = DateSearch()
+
+
+@apply_settings
+def search_dates(text, languages=None, settings=None, add_detected_language=False):
+    result = _search_dates.search_dates(
+        text=text, languages=languages, settings=settings
+    )
+
+    dates = result.get('Dates')
+    return dates
+
+
+@apply_settings
+def search_first_date(text, languages=None, settings=None):
+    result = _search_dates.search_dates(
+        text=text, languages=languages, parse_first_date_only=True, settings=settings
+    )
+    dates = result.get('Dates')
+    return dates

--- a/dateparser/search_dates/detection.py
+++ b/dateparser/search_dates/detection.py
@@ -1,0 +1,70 @@
+from functools import wraps
+
+
+def _restore_languages_on_generator_exit(method):
+    @wraps(method)
+    def wrapped(self, *args, **kwargs):
+        stored_languages = self.languages[:]
+        for language in method(self, *args, **kwargs):
+            yield language
+        else:
+            self.languages[:] = stored_languages
+
+    return wrapped
+
+
+class BaseLanguageDetector:
+    def __init__(self, languages):
+        self.languages = languages[:]
+
+    @_restore_languages_on_generator_exit
+    def iterate_applicable_languages(self, date_string, settings=None, modify=False):
+        languages = self.languages if modify else self.languages[:]
+        yield from self._filter_languages(date_string, languages, settings)
+
+    @staticmethod
+    def _filter_languages(date_string, languages, settings=None):
+        while languages:
+            language = languages[0]
+            if language.is_applicable(date_string, strip_timezone=False, settings=settings):
+                yield language
+            elif language.is_applicable(date_string, strip_timezone=True, settings=settings):
+                yield language
+
+            languages.pop(0)
+
+
+class AutoDetectLanguage(BaseLanguageDetector):
+    def __init__(self, languages, allow_redetection=False):
+        super().__init__(languages=languages[:])
+        self.language_pool = languages[:]
+        self.allow_redetection = allow_redetection
+
+    @_restore_languages_on_generator_exit
+    def iterate_applicable_languages(self, date_string, modify=False, settings=None):
+        languages = self.languages if modify else self.languages[:]
+        initial_languages = languages[:]
+        yield from self._filter_languages(date_string, languages, settings=settings)
+
+        if not self.allow_redetection:
+            return
+
+        # Try languages that was not tried before with this date_string
+        languages = [language
+                     for language in self.language_pool
+                     if language not in initial_languages]
+        if modify:
+            self.languages = languages
+
+        yield from self._filter_languages(date_string, languages, settings=settings)
+
+
+class ExactLanguages(BaseLanguageDetector):
+    def __init__(self, languages):
+        if languages is None:
+            raise ValueError("language cannot be None for ExactLanguages")
+        super().__init__(languages=languages)
+
+    @_restore_languages_on_generator_exit
+    def iterate_applicable_languages(self, date_string, modify=False, settings=None):
+        yield from super().iterate_applicable_languages(date_string, modify=False, settings=settings)

--- a/dateparser/search_dates/languages.py
+++ b/dateparser/search_dates/languages.py
@@ -1,0 +1,39 @@
+from collections.abc import Set
+
+from dateparser.search.text_detection import FullTextLanguageDetector
+from dateparser.languages.loader import LocaleDataLoader
+
+
+class DetectLanguage:
+    def __init__(self) -> None:
+        self.loader = LocaleDataLoader()
+        self.available_language_map = self.loader.get_locale_map()
+        self.language = None
+
+    def get_current_language(self, language_shortname):
+        if self.language is None or self.language.shortname != language_shortname:
+            self.language = self.loader.get_locale(language_shortname)
+
+    def translate_objects(self, text, language_shortname, settings):
+        self.get_current_language(language_shortname)
+        result = self.language.translate_search(text, settings=settings)
+        return result
+
+    def detect_language(self, text, languages):
+        if isinstance(languages, (list, tuple, Set)):
+
+            if all([language in self.available_language_map for language in languages]):
+                languages = [self.available_language_map[language] for language in languages]
+            else:
+                unsupported_languages = set(languages) - set(self.available_language_map.keys())
+                raise ValueError(
+                    "Unknown language(s): %s" % ', '.join(map(repr, unsupported_languages)))
+        elif languages is not None:
+            raise TypeError("languages argument must be a list (%r given)" % type(languages))
+
+        if languages:
+            self.language_detector = FullTextLanguageDetector(languages=languages)
+        else:
+            self.language_detector = FullTextLanguageDetector(list(self.available_language_map.values()))
+
+        return self.language_detector._best_language(text)

--- a/dateparser/search_dates/search.py
+++ b/dateparser/search_dates/search.py
@@ -1,0 +1,130 @@
+import re
+from typing import List, Dict
+
+from dateparser.conf import apply_settings
+from dateparser.date import DateDataParser
+from dateparser.search_dates.languages import DetectLanguage
+
+
+_detect_languages = DetectLanguage()
+
+_date_separator = re.compile(r"[ ,|\(\)@]")  # never part of the date
+_drop_words = {"on", "at", "of", "a"}  # cause annoying false positives
+_bad_date_re = re.compile(
+    # whole dates we black-list (can still be parts of valid dates)
+    "^("
+    + "|".join(
+        [
+            r"\d{1,3}",  # less than 4 digits
+            r"#\d+",  # this is a sequence number
+            # some common false positives below
+            r"[-/.]+",  # bare separators parsed as current date
+            r"\w\.?",  # one letter (with optional dot)
+            "an",
+        ]
+    )
+    + ")$"
+)
+
+
+def _split_objects(text) -> List[str]:
+    splited_text = [
+        p for p in _date_separator.split(text) if p and p not in _drop_words
+    ]
+    return splited_text
+
+
+def _create_joined_parse(text, max_join, reverse_list=True) -> List[str]:
+    split_objects = _split_objects(text)
+    joint_objects = []
+
+    for i in range(len(split_objects)):
+        for j in reversed(range(min(max_join, len(split_objects) - i))):
+            x = " ".join(split_objects[i:i + j + 1])
+            if _bad_date_re.match(x):
+                continue
+
+            joint_objects.append(x)
+
+    joint_objects = sorted(joint_objects, key=len)
+
+    if reverse_list:
+        joint_objects.reverse()
+
+    return joint_objects
+
+
+class DateSearch:
+    def __init__(
+        self,
+        max_join=7,
+        make_joints_parse=True,
+        minimum_date_str_length=4,
+        default_language="en",
+    ):
+        self.max_join = max_join
+        self.make_joints_parse = make_joints_parse
+        self.minimum_date_str_length = minimum_date_str_length
+        self.default_language = default_language
+
+    @apply_settings
+    def search_parse(
+        self, text, language_shortname, parse_first_date_only, settings
+    ) -> List[tuple]:
+
+        returnable_objects = []
+
+        parser = DateDataParser(languages=[language_shortname], settings=settings)
+        original, translated = _detect_languages.translate_objects(
+            text, language_shortname, settings
+        )
+
+        for index, translated_object in enumerate(translated):
+            parsed_date_object = None
+
+            if parse_first_date_only and returnable_objects:
+                return [returnable_objects[0]]
+
+            if not len(translated_object) >= self.minimum_date_str_length:
+                continue
+
+            if self.make_joints_parse:
+                joint_based_search_dates = _create_joined_parse(
+                    translated_object, self.max_join
+                )
+
+                for date_object_candidate in joint_based_search_dates:
+                    parsed_date_object = parser.get_date_data(date_object_candidate)
+                    if parsed_date_object.date_obj:
+                        break
+            else:
+                parsed_date_object = parser.get_date_data(translated_object)
+
+            if parsed_date_object.date_obj:
+                returnable_objects.append(
+                    (original[index], parsed_date_object.date_obj)
+                )
+
+        return returnable_objects
+
+    @apply_settings
+    def search_dates(
+        self, text, languages=None, parse_first_date_only=False, settings=None
+    ) -> Dict:
+
+        language_shortname = (
+            _detect_languages.detect_language(text=text, languages=languages)
+            or self.default_language
+        )
+
+        if not language_shortname:
+            return {"Language": None, "Dates": None}
+        return {
+            "Language": language_shortname,
+            "Dates": self.search_parse(
+                text=text,
+                language_shortname=language_shortname,
+                parse_first_date_only=parse_first_date_only,
+                settings=settings,
+            ),
+        }

--- a/dateparser/search_dates/text_detection.py
+++ b/dateparser/search_dates/text_detection.py
@@ -1,0 +1,66 @@
+from dateparser.search.detection import BaseLanguageDetector
+from dateparser.conf import apply_settings
+from dateparser.utils import normalize_unicode
+
+
+class FullTextLanguageDetector(BaseLanguageDetector):
+    def __init__(self, languages):
+        super(BaseLanguageDetector, self).__init__()
+        self.languages = languages[:]
+        self.language_unique_chars = []
+        self.language_chars = []
+
+    def get_unique_characters(self, settings):
+        settings = settings.replace(NORMALIZE=False)
+
+        for language in self.languages:
+            chars = language.get_wordchars_for_detection(settings=settings)
+            self.language_chars.append(chars)
+
+        for char_set in self.language_chars:
+            unique_chars = char_set
+            for other_char_set in self.language_chars:
+                if other_char_set != char_set:
+                    unique_chars = unique_chars - other_char_set
+            self.language_unique_chars.append(unique_chars)
+
+    def character_check(self, date_string, settings):
+        date_string_set = set(date_string.lower())
+        symbol_set = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+                      " ", "/", "-", ")", "(", ".", ":", "\\", ",", "'"}
+        if date_string_set & symbol_set == date_string_set:
+            self.languages = [self.languages[0]]
+            return
+        self.get_unique_characters(settings=settings)
+        for i in range(len(self.languages)):
+            for char in self.language_unique_chars[i]:
+                if char.lower() in date_string.lower():
+                    self.languages = [self.languages[i]]
+                    return
+        indices_to_pop = []
+        for i in range(len(self.languages)):
+            if len(date_string_set & self.language_chars[i]) == 0:
+                indices_to_pop.append(i)
+        self.languages = [i for j, i in enumerate(self.languages)
+                          if j not in indices_to_pop]
+
+    @apply_settings
+    def _best_language(self, date_string, settings=None):
+        self.character_check(date_string, settings)
+        date_string = normalize_unicode(date_string.lower())
+        if len(self.languages) == 1:
+            return self.languages[0].shortname
+        applicable_languages = []
+        for language in self.languages:
+            num_words = language.count_applicability(
+                date_string, strip_timezone=False, settings=settings)
+            if num_words[0] > 0 or num_words[1] > 0:
+                applicable_languages.append((language.shortname, num_words))
+            else:
+                num_words = language.count_applicability(
+                    date_string, strip_timezone=True, settings=settings)
+                if num_words[0] > 0 or num_words[1] > 0:
+                    applicable_languages.append((language.shortname, num_words))
+        if not applicable_languages:
+            return None
+        return max(applicable_languages, key=lambda p: (p[1][0], p[1][1]))[0]

--- a/test.py
+++ b/test.py
@@ -1,0 +1,11 @@
+from dateparser.search_dates import search_dates, search_first_date
+from dateparser.search import search_dates as sd
+from dateparser import parse
+
+
+text = "Сервис будет недоступен с 12 января по 30 апреля"
+
+out = search_first_date(text)
+print(out)
+
+


### PR DESCRIPTION
# Reimplementing and simplifying `search_dates` & fixing search translation

A reimplemented and simplified `search_dates` which more directly uses `dateparser.parse`,  improves accuracy and  fixes many bugs


New Feature:
- `search_first_date` -  searches and returns the first date from the given text.

Direct fixes on search translation:

This fix allows search date to translate 2 letter words and does not removes them from the search like - `next decade` and `last monday`.

Reference #930 


NOTE: This PR is derived from the previous implementation of search_dates and #931.

### TODO for 
- [ ] Gather feedback on the API and it's functions.
- [ ] Write docs.
- [ ] Write tests.
- [ ] Chack search translation joints.

