### PR TITLE
Improvements in locale:translate_search fixes

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -176,7 +176,7 @@ class Locale:
 
     def translate_search(self, search_string, settings=None):
         dashes = ['-', '——', '—', '～']
-        word_joint_unsupported_laguage = ["zh", "ja"]
+        word_joint_unsupported_languages = ["zh", "ja"]
         sentences = self._sentence_split(search_string, settings=settings)
         dictionary = self._get_dictionary(settings=settings)
         translated = []
@@ -185,10 +185,10 @@ class Locale:
             original_tokens, simplified_tokens = self._simplify_split_align(sentence, settings=settings)
             translated_chunk = []
             original_chunk = []
-            simplified_tokens_length = len(simplified_tokens)
+            last_token_index = len(simplified_tokens) - 1
             skip_next_token = False
             for i, word in enumerate(simplified_tokens):
-                next_word = simplified_tokens[i + 1] if (simplified_tokens_length - 1) > i else ""
+                next_word = simplified_tokens[i + 1] if i < (simplified_tokens_length - 1) else ""
                 current_and_next_joined = self._join_chunk([word, next_word], settings=settings)
                 if skip_next_token:
                     skip_next_token = False
@@ -200,7 +200,7 @@ class Locale:
                 elif (
                     current_and_next_joined in dictionary
                     and word not in dashes
-                    and self.shortname not in word_joint_unsupported_laguage
+                    and self.shortname not in word_joint_unsupported_languages
                 ):
                     translated_chunk.append(dictionary[current_and_next_joined])
                     original_chunk.append(

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -188,7 +188,7 @@ class Locale:
             last_token_index = len(simplified_tokens) - 1
             skip_next_token = False
             for i, word in enumerate(simplified_tokens):
-                next_word = simplified_tokens[i + 1] if i < (simplified_tokens_length - 1) else ""
+                next_word = simplified_tokens[i + 1] if i < last_token_index else ""
                 current_and_next_joined = self._join_chunk([word, next_word], settings=settings)
                 if skip_next_token:
                     skip_next_token = False

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -176,6 +176,7 @@ class Locale:
 
     def translate_search(self, search_string, settings=None):
         dashes = ['-', '——', '—', '～']
+        word_joint_unsupported_laguage = ["zh", "ja"]
         sentences = self._sentence_split(search_string, settings=settings)
         dictionary = self._get_dictionary(settings=settings)
         translated = []
@@ -184,10 +185,28 @@ class Locale:
             original_tokens, simplified_tokens = self._simplify_split_align(sentence, settings=settings)
             translated_chunk = []
             original_chunk = []
+            simplified_tokens_length = len(simplified_tokens)
+            skip_next_token = False
             for i, word in enumerate(simplified_tokens):
+                next_word = simplified_tokens[i + 1] if (simplified_tokens_length - 1) > i else ""
+                current_and_next_joined = self._join_chunk([word, next_word], settings=settings)
+                if skip_next_token:
+                    skip_next_token = False
+                    continue
+
                 if word == '' or word == ' ':
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
+                elif (
+                    current_and_next_joined in dictionary
+                    and word not in dashes
+                    and self.shortname not in word_joint_unsupported_laguage
+                ):
+                    translated_chunk.append(dictionary[current_and_next_joined])
+                    original_chunk.append(
+                        self._join_chunk([original_tokens[i], original_tokens[i + 1]], settings=settings)
+                    )
+                    skip_next_token = True
                 elif word in dictionary and word not in dashes:
                     translated_chunk.append(dictionary[word])
                     original_chunk.append(original_tokens[i])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -276,6 +276,11 @@ class TestTranslateSearch(BaseTestCase):
         param('en', 'in a minute',
               [('in a minute', datetime.datetime(2000, 1, 1, 0, 1))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
+
+        param('en', 'last decade',
+              [('last decade', datetime.datetime(1990, 1, 1, 0, 0))],
+              settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
+
         param('en', 'July 13th.\r\n July 14th',
               [('July 13th', datetime.datetime(2000, 7, 13, 0, 0)),
                ('July 14th', datetime.datetime(2000, 7, 14, 0, 0))],


### PR DESCRIPTION
This PR fixes #930

Adds support for `last decade`, `next decade`, etc in `search_dates`

PL suggest if any change is required.

Thanks