### PR TITLE
Fixing: flake8 E402 and windows setup.py not working

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import sys
 import os
 
+import dateparser
 
 # Get the project root dir, which is the parent dir of this
 cwd = os.getcwd()
@@ -22,8 +23,6 @@ project_root = os.path.dirname(cwd)
 # This lets us ensure that the source package is imported, and that its
 # version is used.
 sys.path.insert(0, project_root)
-
-import dateparser
 
 # -- General configuration ---------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 
 __version__ = re.search(r"__version__.*\s*=\s*[']([^']+)[']", open('dateparser/__init__.py').read()).group(1)
 
-introduction = re.sub(r':members:.+|..\sautomodule::.+|:class:|:func:|:ref:', '', open('docs/introduction.rst').read())
-history = re.sub(r':mod:|:class:|:func:', '', open('HISTORY.rst').read())
+introduction = re.sub(r':members:.+|..\sautomodule::.+|:class:|:func:|:ref:', '', open('docs/introduction.rst', encoding="utf8").read())
+history = re.sub(r':mod:|:class:|:func:', '', open('HISTORY.rst', encoding="utf8").read())
 
 test_requirements = open('tests/requirements.txt').read().splitlines()
 


### PR DESCRIPTION
This PR Fixes,

- Fixing E402 module-level import, not at top of file in dateparser/docs/conf.py
- Fixing UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1442: character maps to <undefined> in Windows

Note: This change makes it possible to run `pip install . `. But tox is not entirely fixed.

Please suggest.