### PR TITLE
fix(regex-version): removed version 2021.8.27 that breaks dateparser with SegFault

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'python-dateutil',
         'pytz',
         # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
-        'regex !=2019.02.19',
+        'regex !=2019.02.19,!=2021.8.27',
         'tzlocal',
     ],
     extras_require={


### PR DESCRIPTION
fix(regex-version): removed version 2021.8.27 that breaks dateparser with SegFault

Related to  #972

Tests result:
![image](https://user-images.githubusercontent.com/67998510/131174617-7558c5c0-2a42-4c9c-b7e5-5fdfe0ff3f25.png)

-----

Fixes: #972. 
Fixes: #973 