### PR TITLE
fix: change tzlocal version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'pytz',
         # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
         'regex !=2019.02.19,!=2021.8.27',
-        'tzlocal',
+        'tzlocal >4',
     ],
     entry_points={
         'console_scripts': ['dateparser-download = dateparser_cli.cli:entrance'],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'pytz',
         # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
         'regex !=2019.02.19,!=2021.8.27',
-        'tzlocal >4',
+        'tzlocal <4',
     ],
     entry_points={
         'console_scripts': ['dateparser-download = dateparser_cli.cli:entrance'],

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ commands =
 [testenv:latest]
 deps =
     {[base]deps}
-    tzlocal>3.0b1,<4
 
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 [testenv:latest]
 deps =
     {[base]deps}
-    tzlocal==3.0b1
+    tzlocal>3.0b1,<4
 
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 [testenv:latest]
 deps =
     {[base]deps}
-    tzlocal>=3.0b1
+    tzlocal==3.0b1
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
tzlocal version 4.0 just dropped and it doesn't work on many devices. wouldn't it be nice to set the dependency to a specific version that works everywhere before the maintainers of `tzlocal` will figure it out?