### PR TITLE
fix link to settings section in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ You can control multiple behaviors by using the ``settings`` parameter:
     datetime.datetime(1992, 1, 2, 0, 0)
 
 To see more examples on how to use the ``settings``, check the `settings
-section <https://dateparser.readthedocs.io/en/latest/usage.html#settings>`__
+section <https://dateparser.readthedocs.io/en/latest/settings.html>`__
 in the docs.
 
 False positives


### PR DESCRIPTION
Hi,

I observed that in README, current URL for settings section of the docs leads to usage section, so this PR fixes the URL to properly redirect the readers to correct settings section of dateparser docs.

P.S. thank you for creating dateparser! ❤️ 