### PR TITLE
encoding set to utf-8 causing UnicodeDecode errors in windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ __version__ = re.search(r"__version__.*\s*=\s*[']([^']+)[']",
                         open('dateparser/__init__.py').read()).group(1)
 
 introduction = re.sub(r':members:.+|..\sautomodule::.+|:class:|:func:|:ref:',
-                      '', open('docs/introduction.rst').read())
-history = re.sub(r':mod:|:class:|:func:', '', open('HISTORY.rst').read())
+                      '', open('docs/introduction.rst', encoding='utf-8').read())
+history = re.sub(r':mod:|:class:|:func:', '', open('HISTORY.rst', encoding='utf-8').read())
 
 test_requirements = open('tests/requirements.txt').read().splitlines()
 


### PR DESCRIPTION
Closes #978 
Encoding set to utf-8 wherever not present while opening a file causing the error in windows : "UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position line_number: character maps to something undefined"