### PR TITLE
removed parsing of single ambiguous words like year and month without…

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -40,6 +40,8 @@ RE_SANITIZE_ON = re.compile(r'^.*?on:\s+(.*)')
 RE_SANITIZE_APOSTROPHE = re.compile('|'.join(APOSTROPHE_LOOK_ALIKE_CHARS))
 
 RE_SEARCH_TIMESTAMP = re.compile(r'^(\d{10})(\d{3})?(\d{3})?(?![^.])')
+RE_AMBIGUOUS_SINGLE_WORDS = re.compile('|'.join(['year', 'month', 'week', 'day', 
+                                        'hour', 'minute', 'second', 'microsecond']))
 
 
 def sanitize_spaces(date_string):
@@ -47,7 +49,6 @@ def sanitize_spaces(date_string):
     date_string = RE_SPACES.sub(' ', date_string)
     date_string = RE_TRIM_SPACES.sub(r'\1', date_string)
     return date_string
-
 
 def date_range(begin, end, **kwargs):
     dateutil_error_prone_args = ['year', 'month', 'week', 'day', 'hour',
@@ -423,6 +424,8 @@ class DateDataParser:
             return res
 
         date_string = sanitize_date(date_string)
+        if re.match(RE_AMBIGUOUS_SINGLE_WORDS, date_string):
+            return DateData(date_obj=None, period='day', locale=None)
 
         for locale in self._get_applicable_locales(date_string):
             parsed_date = _DateLocaleParser.parse(

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -211,11 +211,12 @@ class Locale:
                     translated_chunk.append(dictionary[word])
                     original_chunk.append(original_tokens[i])
                 elif word.strip('()\"\'{}[],.،') in dictionary and word not in dashes:
-                    punct = word[len(word.strip('()\"\'{}[],.،')):]
-                    if punct and dictionary[word.strip('()\"\'{}[],.،')]:
-                        translated_chunk.append(dictionary[word.strip('()\"\'{}[],.،')] + punct)
+                    cleaned_word = word.strip('()\"\'{}[],.،')
+                    punct = word[len(cleaned_word):]
+                    if punct and dictionary[cleaned_word]:
+                        translated_chunk.append(dictionary[cleaned_word] + punct)
                     else:
-                        translated_chunk.append(dictionary[word.strip('()\"\'{}[],.،')])
+                        translated_chunk.append(dictionary[cleaned_word])
                     original_chunk.append(original_tokens[i])
                 elif self._token_with_digits_is_ok(word):
                     translated_chunk.append(word)

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -7,9 +7,9 @@ from dateparser.search.text_detection import FullTextLanguageDetector
 from dateparser.custom_language_detection.language_mapping import map_languages
 import regex as re
 
-
-RELATIVE_REG = re.compile("(ago|in|from now|tomorrow|today|yesterday)")
-
+RELATIVE_WORDS = ["ago", "in", "next", "from now", "tomorrow",
+                "today", "yesterday", "last", "previous"]
+RELATIVE_REG = re.compile("|".join(RELATIVE_WORDS))
 
 def date_is_relative(translation):
     return re.search(RELATIVE_REG, translation) is not None


### PR DESCRIPTION
While working on the issue [#1032](https://github.com/scrapinghub/dateparser/issues/1032), I noticed that the parser in date.py accepts single ambiguous words like "_year_" and "_month_" (widely uses in phrases like "_Happy New Year_", etc...) and I added a little check that returns None if the chunk analyzed by the parser is just that ambigous word, without any digit or prefix. So, the library works with chunks like "_1 year ago_" or "_next year_", but returns None with the phrase in the issue: "_The year of mention_".

First time contributor here, I'm just learning, I hope that this fix can be helpful!

