### PR TITLE
RETURN_TIME_AS_PERIOD for relative times with hours/minutes/seconds

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -92,7 +92,7 @@ class FreshnessDateDataParser:
             else:
                 now = datetime.now(self.get_local_tz())
 
-        date, period = self._parse_date(date_string, now, settings.PREFER_DATES_FROM)
+        date, period = self._parse_date(date_string, now, settings)
 
         if date:
             old_date = date
@@ -112,7 +112,7 @@ class FreshnessDateDataParser:
 
         return date, period
 
-    def _parse_date(self, date_string, now, prefer_dates_from):
+    def _parse_date(self, date_string, now, settings):
         if not self._are_all_words_units(date_string):
             return None, None
 
@@ -120,7 +120,12 @@ class FreshnessDateDataParser:
         if not kwargs:
             return None, None
         period = 'day'
-        if 'days' not in kwargs:
+        if settings.RETURN_TIME_AS_PERIOD:
+            for k in ['seconds', 'minutes', 'hours']:
+                if k in kwargs:
+                    period = 'time'
+                    break
+        if period != 'time' and 'days' not in kwargs:
             for k in ['weeks', 'months', 'years']:
                 if k in kwargs:
                     period = k[:-1]
@@ -129,7 +134,7 @@ class FreshnessDateDataParser:
 
         if (
             re.search(r'\bin\b', date_string)
-            or re.search(r'\bfuture\b', prefer_dates_from)
+            or re.search(r'\bfuture\b', settings.PREFER_DATES_FROM)
             and not re.search(r'\bago\b', date_string)
         ):
             date = now + td

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -45,6 +45,12 @@ class TestFreshnessDateDataParser(BaseTestCase):
         # English dates
         param("yesterday", ago={'days': 1}, period='day'),
         param("yesterday at 11:30", ago={'hours': 23}, period='time'),
+        param("2 days ago", ago={'days': 2}, period='day'),
+        param("48 hours ago", ago={'hours': 48}, period='time'),
+        param("today", ago={'days': 0}, period='day'),
+        param("now", ago={'seconds': 0}, period='time'),
+        param("4 weeks 2 hours ago", ago={'weeks': 4, 'hours': 2}, period='time'),
+        param("3 days 2 hours ago", ago={'days': 3, 'hours': 2}, period='time'),
     ])
     def test_relative_past_dates_with_time_as_period(self, date_string, ago, period):
         self.given_parser(settings={'NORMALIZE': False, 'RETURN_TIME_AS_PERIOD': True})


### PR DESCRIPTION
Currently, a relative time with granularity less than a day will still result in a period of `day`, even when `RETURN_TIME_AS_PERIOD` is set:

```python
In [1]: parser = dateparser.date.DateDataParser(settings={'RETURN_TIME_AS_PERIOD': True})

In [2]: parser.get_date_data('in 2 hours')
Out[2]: DateData(date_obj=datetime.datetime(2022, 3, 12, 19, 47, 25, 221085), period='day', locale='en')
```

This PR changes that behaviour, so that a period of `time` is is returned in this case.

The PR doesn't change the behaviour when `RETURN_TIME_AS_PERIOD` is false. This means that `in 2 months and 2 hours` results in period `month`, even though the actual granularity is much finer. I find this counter-intuitive, however there are tests for this, so I kept that behaviour.
