### PR TITLE
pin regex version (<2022.3.15)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'python-dateutil',
         'pytz',
         # https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named
-        'regex !=2019.02.19,!=2021.8.27',
+        'regex !=2019.02.19,!=2021.8.27,<2022.3.15',
         'tzlocal',
     ],
     entry_points={


### PR DESCRIPTION
Caused by https://github.com/scrapinghub/dateparser/issues/1045.
To be superseded with a proper fix to unhandled regexes.