### PR TITLE
Add alternate translation for November in Croatian

### DIFF
--- a/dateparser_data/cldr_language_data/date_translation_data/hr.json
+++ b/dateparser_data/cldr_language_data/date_translation_data/hr.json
@@ -54,6 +54,7 @@
     "november": [
         "stu",
         "studeni",
+        "studenog",
         "studenoga"
     ],
     "december": [


### PR DESCRIPTION
The word "studenog" is a more colloquial and natural sounding version of "studenoga". Both are considered correct in the language.