### PR TITLE
Fix PytzUsageWarning for Python versions >= 3.6

### DIFF
--- a/dateparser/date_parser.py
+++ b/dateparser/date_parser.py
@@ -1,3 +1,5 @@
+import sys
+
 from tzlocal import get_localzone
 
 from .timezone_parser import pop_tz_offset_from_string
@@ -31,7 +33,7 @@ class DateParser:
         else:
             if 'local' in _settings_tz:
                 stz = get_localzone()
-                if hasattr(stz, 'localize'):
+                if hasattr(stz, 'localize') and sys.version_info < (3, 6):
                     date_obj = stz.localize(date_obj)
                 else:
                     date_obj = date_obj.replace(tzinfo=stz)


### PR DESCRIPTION
This fix makes the `localize` method to be used only for Python versions that are lower than 3.6, so that the warning doesn't appear for versions 3.6+. This also allows compatibility with Python 3.5.

Referencing Issue #1013 and implemented suggestions by @[DavidMStraub](https://github.com/DavidMStraub) and @[bsekiewicz](https://github.com/bsekiewicz) 

- [ ] Codecov report pending
- [x] Test cases passed with `tox` and `tox -e py`
![image](https://user-images.githubusercontent.com/58870992/173045856-2fa897e3-0915-4672-ae79-52df05c7b349.png)
