### PR TITLE
Adding alternative to "in" - Italian translation

### DIFF
--- a/dateparser/data/date_translation_data/it.py
+++ b/dateparser/data/date_translation_data/it.py
@@ -272,7 +272,8 @@ info = {
         "fa"
     ],
     "in": [
-        "in"
+        "in",
+        "tra"
     ],
     "simplifications": [
         {


### PR DESCRIPTION
Adding "tra" as an alternative (and more correct) way to say "in" (as "in one hour")