### PR TITLE
Prevent ReDoS in Spanish sentence splitting regex

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -275,9 +275,7 @@ class Locale:
             split_reg = abbreviation_string + splitters_dict[self.info['sentence_splitter_group']]
             sentences = re.split(split_reg, string)
 
-        for i in sentences:
-            if not i:
-                sentences.remove(i)
+        sentences = filter(None, sentences)
         return sentences
 
     def _simplify_split_align(self, original, settings):

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -263,7 +263,7 @@ class Locale:
 
         splitters_dict = {1: r'[\.!?;…\r\n]+(?:\s|$)*',  # most European, Tagalog, Hebrew, Georgian,
                           # Indonesian, Vietnamese
-                          2: r'(?:[¡¿]+|[\.!?;…\r\n]+(?:\s|$))+',  # Spanish
+                          2: r'[\.!?;…\r\n]+(\s+[¡¿]*|$)|[¡¿]+',  # Spanish
                           3: r'[|!?;\r\n]+(?:\s|$)+',  # Hindi and Bangla
                           4: r'[。…‥\.!?？！;\r\n]+(?:\s|$)+',  # Japanese and Chinese
                           5: r'[\r\n]+',  # Thai

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -263,7 +263,7 @@ class Locale:
 
         splitters_dict = {1: r'[\.!?;…\r\n]+(?:\s|$)*',  # most European, Tagalog, Hebrew, Georgian,
                           # Indonesian, Vietnamese
-                          2: r'[\.!?;…\r\n]+(\s+[¡¿]*|$)|[¡¿]+',  # Spanish
+                          2: r'[\.!?;…\r\n]+(\s*[¡¿]*|$)|[¡¿]+',  # Spanish
                           3: r'[|!?;\r\n]+(?:\s|$)+',  # Hindi and Bangla
                           4: r'[。…‥\.!?？！;\r\n]+(?:\s|$)+',  # Japanese and Chinese
                           5: r'[\r\n]+',  # Thai

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -416,6 +416,10 @@ class TestTranslateSearch(BaseTestCase):
                ('de 1941', datetime.datetime(1941, 1, 1, 0, 0))],
               settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
 
+        param('es', '¡¡Ay!! En Madrid, a 17 de marzo de 1615. ¿Vos bueno?',
+              [('a 17 de marzo de 1615', datetime.datetime(1615, 3, 17, 0, 0))],
+              settings={'RELATIVE_BASE': datetime.datetime(2000, 1, 1)}),
+
         # Swedish
         param('sv', 'Efter kommunisternas seger 1922 drog de allierade och Japan bort sina trupper.',
               [('1922', datetime.datetime(1922, 1, 1, 0, 0))],
@@ -657,6 +661,7 @@ class TestTranslateSearch(BaseTestCase):
 
         # Spanish
         param('es', '11 junio 2010'),
+        param('es', '¡¡Ay!! En Madrid, a 17 de marzo de 1615. ¿Vos bueno?'),
 
         # Swedish
         param('sv', ' den 15 augusti 1945 då Kejsardömet'),


### PR DESCRIPTION
In Spanish, questions start with an upside down question mark:

> ¿Vos bueno?

This was already handled in the original regex, but the original regex was vulnerable for regular expression denial of service (ReDoS). In the new regex, we either search for normal end-of-sentence optionally followed by a ¿ or ¡, or a ¿ or ¡ on its own. A change is that the normal end-of-sentence (.!?;…) has to come before the ¡ or ¿, but I think this is acceptable.

This PR also adds some Spanish test cases. These hit the sentence splitting logic, but the exact result of the splitting is not tested.

Fixes #869