### PR TITLE
Use month with 31 days to avoid test failures

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -461,15 +461,15 @@ class TestTranslateSearch(BaseTestCase):
                ('October', datetime.datetime(2014, 10, datetime.datetime.utcnow().day, 0, 0)),
                ('Friday, 21', datetime.datetime(2014, 10, 21, 0, 0))]),
         param('en', """May 2020
-                    June 2020
+                    July 2020
                     2023
                     January UTC
                     June 5 am utc
                     June 23th 5 pm EST
                     May 31, 8am UTC""",
               [('May 2020', datetime.datetime(2020, 5, datetime.datetime.utcnow().day, 0, 0)),
-               ('June 2020', datetime.datetime(2020, 6, datetime.datetime.utcnow().day, 0, 0)),
-               ('2023', datetime.datetime(2023, 6, datetime.datetime.utcnow().day, 0, 0)),
+               ('July 2020', datetime.datetime(2020, 7, datetime.datetime.utcnow().day, 0, 0)),
+               ('2023', datetime.datetime(2023, 7, datetime.datetime.utcnow().day, 0, 0)),
                ('January UTC', datetime.datetime(2023, 1, datetime.datetime.utcnow().day, 0, 0, tzinfo=pytz.utc)),
                ('June 5 am utc', datetime.datetime(2023, 6, 5, 0, 0, tzinfo=pytz.utc)),
                ('June 23th 5 pm EST', datetime.datetime(2023, 6, 23, 17, 0, tzinfo=pytz.timezone("EST"))),


### PR DESCRIPTION
The test fails on the 31st of any month since the set month in the test doesn't have the 31st date. We fix this by using the month with 31 days.

Fixes #1053 