### PR TITLE
fix leak of memory in cache - add settings.CACHE_SIZE_LIMIT

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -28,6 +28,7 @@ class Settings:
     * `PARSERS`
     * `DEFAULT_LANGUAGES`
     * `LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD`
+    * `CACHE_SIZE_LIMIT`
     """
 
     _default = True
@@ -225,6 +226,9 @@ def check_settings(settings):
         'LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD': {
             'type': float,
             'extra_check': _check_between_0_and_1
+        },
+        'CACHE_SIZE_LIMIT': {
+            'type': int,
         },
     }
 

--- a/dateparser_data/settings.py
+++ b/dateparser_data/settings.py
@@ -33,4 +33,5 @@ settings = {
     # Other settings
     'RETURN_TIME_AS_PERIOD': False,
     'PARSERS': default_parsers,
+    'CACHE_SIZE_LIMIT': 1000,
 }

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -210,3 +210,6 @@ Dateparser in the future. For example, to ignore relative times:
     >>> from dateparser_data.settings import default_parsers
     >>> parsers = [parser for parser in default_parsers if parser != 'relative-time']
     >>> parse('today', settings={'PARSERS': parsers})
+
+``CACHE_SIZE_LIMIT``: limits the size of caches, that store data for already processed dates.
+Default to ``1000``, but you can set ``0`` for turning off the limit.


### PR DESCRIPTION
**PROBLEM:** leak of memory.
```
import dateparser
from datetime import datetime

# ~1.5GB of leaked memory after function finish
def hard_leak():
    for i in range(3000):
        # every call == -0.55MB of leaked memory
        dateparser.parse('dasdasd', settings={'RELATIVE_BASE': datetime.utcnow()})


# ~27MB of leaked memory after function finish
def light_leak():
    for i in range(3000):
        # every call == -0.01MB of leaked memory
        dateparser.parse('12.01.2021', settings={'RELATIVE_BASE': datetime.utcnow()})
```

After each calling of `dateparser.parse` new item is added to cache dictionaries:
```
    _split_regex_cache = {}
    _sorted_words_cache = {}
    _split_relative_regex_cache = {}
    _sorted_relative_strings_cache = {}
    _match_relative_regex_cache = {}
```

After 3000 calls we will found 3000 items in each of dictionaries, and we have lost few memory. We are forced to stop using this module.

**SOLUTION:** add a limit (`CACHE_SIZE_LIMIT`) for max items in caches.