### PR TITLE
Set "usedforsecurity' to Flase for md5 checksum.

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -46,7 +46,7 @@ class Settings:
             return 'default'
 
         keys = sorted(['%s-%s' % (key, str(settings[key])) for key in settings])
-        return hashlib.md5(''.join(keys).encode('utf-8')).hexdigest()
+        return hashlib.md5(''.join(keys).encode('utf-8'), usedforsecurity=Flase).hexdigest()
 
     @classmethod
     def _get_settings_from_pyfile(cls):


### PR DESCRIPTION
There is no cryptographic use of md5 done. So setting usedforsecurity to False. Doing so will make this FIPS complaint.