### PR TITLE
Revert "Set "usedforsecurity' to False for md5 checksum."

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -46,7 +46,7 @@ class Settings:
             return 'default'
 
         keys = sorted(['%s-%s' % (key, str(settings[key])) for key in settings])
-        return hashlib.md5(''.join(keys).encode('utf-8'), usedforsecurity=False).hexdigest()
+        return hashlib.md5(''.join(keys).encode('utf-8')).hexdigest()
 
     @classmethod
     def _get_settings_from_pyfile(cls):


### PR DESCRIPTION
Reverts scrapinghub/dateparser#1143

it [seems](https://docs.python.org/3/library/hashlib.html#hash-algorithms) it is a 3.9 feature so I revert this PR