### PR TITLE
Updated Czech localization

### DIFF
--- a/dateparser/data/date_translation_data/cs.py
+++ b/dateparser/data/date_translation_data/cs.py
@@ -4,45 +4,54 @@ info = {
     "january": [
         "led",
         "leden",
-        "ledna"
+        "ledna",
+        "lednu"
     ],
     "february": [
         "úno",
         "únor",
         "února",
-        "únr"
+        "únr",
+        "únoru"
     ],
     "march": [
         "bře",
         "březen",
-        "března"
+        "března",
+        "březnu"
     ],
     "april": [
         "dub",
         "duben",
-        "dubna"
+        "dubna",
+        "dubnu"
     ],
     "may": [
         "kvě",
         "květen",
-        "května"
+        "května",
+        "květnu"
     ],
     "june": [
         "červen",
         "června",
         "čvn",
-        "Čer"
+        "Čer",
+        "červnu"
     ],
     "july": [
         "července",
         "červenec",
         "čvc",
-        "Črc"
+        "Črc",
+        "červenci",
+        "črv"
     ],
     "august": [
         "srp",
         "srpen",
-        "srpna"
+        "srpna",
+        "srpnu"
     ],
     "september": [
         "zář",
@@ -51,7 +60,8 @@ info = {
     "october": [
         "říj",
         "říjen",
-        "října"
+        "října",
+        "říjnu"
     ],
     "november": [
         "lis",
@@ -61,7 +71,8 @@ info = {
     "december": [
         "pro",
         "prosince",
-        "prosinec"
+        "prosinec",
+        "prosinci"
     ],
     "monday": [
         "po",
@@ -511,6 +522,15 @@ info = {
         },
         {
             "(?<=(za|před)\\s)den(em)\\b": "1 den"
+        },
+        {
+            "(?<=za\\s)týden\\b": "1 týden"
+        },
+        {
+            "(?<=za\\s)měsíc\\b": "1 měsíc"
+        },
+        {
+            "(?<=za\\s)rok\\b": "1 rok"
         },
         {
             "čtvrt\\s*hodin(y|u)": "15 minut"

--- a/dateparser_data/supplementary_language_data/date_translation_data/cs.yaml
+++ b/dateparser_data/supplementary_language_data/date_translation_data/cs.yaml
@@ -24,12 +24,30 @@ sunday:
     - Ned
     - Neděli
 
+january:
+    - lednu
 february:
     - únr
+    - únoru
+march:
+    - březnu
+april:
+    - dubnu
+may:
+    - květnu
 june:
     - Čer
+    - červnu
 july:
     - Črc
+    - červenci
+    - črv
+august:
+    - srpnu
+october:
+    - říjnu
+december:
+    - prosinci
 year:
     - roků
     - roky
@@ -176,6 +194,10 @@ simplifications:
     - '(?<=(za|před)\s)měsíc(em)\b': '1 měsíc'
     - '(?<=(za|před)\s)rok(em)\b': '1 rok'
     - '(?<=(za|před)\s)den(em)\b': '1 den'
+    # Accusative forms used with "za" (e.g. "za týden" = "in a week")
+    - '(?<=za\s)týden\b': '1 týden'
+    - '(?<=za\s)měsíc\b': '1 měsíc'
+    - '(?<=za\s)rok\b': '1 rok'
 
     # Fractions of hours (For relative time)
     - 'čtvrt\s*hodin(y|u)': 15 minut

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1205,6 +1205,12 @@ class TestBundledLanguages(BaseTestCase):
             param("cs", "čtvrt na tři", "2:15"),
             param("cs", "zítra o půlnoci", "in 1 day 0:00"),
             param("cs", "v sedum třicet odpoledne", " 7 30 pm"),
+            param("cs", "za měsíc", "in 1 month"),
+            param("cs", "za týden", "in 1 week"),
+            param("cs", "za rok", "in 1 year"),
+            param("cs", "v lednu", " january"),
+            param("cs", "v červenci 2020", " july 2020"),
+            param("cs", "v únoru", " february"),
             # Chinese
             param("zh", "昨天", "1 day ago"),
             param("zh", "前天", "2 day ago"),


### PR DESCRIPTION
In some cases, there's some inconsistencies with Czech grammar. For example, in English:

`In a month` will output a correct datetime object - 1 month from now. But in Czech `za měsíc` won't print anything, but `příští měsíc` will. Both are correct Czech sentences.

 The same proposed changes applies to `za týden` (in a week), `za hodinu` (in a hour), `příští rok` (next year).

Added new words:
In two days - `pozítří`
Two days ago - `předevčírem`
Last year - `loni` or `vloni`

And finally, added some new declensions of initial words. 