### PR TITLE
Replace datetime.utcnow

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 
 import regex as re
 from dateutil.relativedelta import relativedelta
@@ -86,7 +86,7 @@ class FreshnessDateDataParser:
 
         else:
             if "local" not in _settings_tz:
-                utc_dt = datetime.utcnow()
+                utc_dt = datetime.now(tz=timezone.utc)
                 now = apply_timezone(utc_dt, settings.TIMEZONE)
             else:
                 now = datetime.now(self.get_local_tz())

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -1,6 +1,6 @@
 import calendar
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 
 import pytz
@@ -437,7 +437,7 @@ class _parser:
     def _set_relative_base(self):
         self.now = self.settings.RELATIVE_BASE
         if not self.now:
-            self.now = datetime.utcnow()
+            self.now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
     def _get_datetime_obj_params(self):
         if not self.now:

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 
 import regex as re
 
@@ -80,7 +80,7 @@ def build_tz_offsets(search_regex_parts):
 
 
 def get_local_tz_offset():
-    offset = datetime.now() - datetime.utcnow()
+    offset = datetime.now() - datetime.now(tz=timezone.utc).replace(tzinfo=None)
     offset = timedelta(days=offset.days, seconds=round(offset.seconds, -1))
     return offset
 

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -40,9 +40,7 @@ class TestFreshnessDateDataParser(BaseTestCase):
 
     def now_with_timezone(self, tz):
         now = self.now
-        return datetime(
-            now.year, now.month, now.day, now.hour, now.minute, tzinfo=tz
-        )
+        return datetime(now.year, now.month, now.day, now.hour, now.minute, tzinfo=tz)
 
     @parameterized.expand(
         [

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -38,10 +38,10 @@ class TestFreshnessDateDataParser(BaseTestCase):
 
         settings.TIMEZONE = "utc"
 
-    def now_with_timezone(self, tzinfo):
+    def now_with_timezone(self, tz):
         now = self.now
         return datetime(
-            now.year, now.month, now.day, now.hour, now.minute, tzinfo=tzinfo
+            now.year, now.month, now.day, now.hour, now.minute, tzinfo=tz
         )
 
     @parameterized.expand(
@@ -2621,7 +2621,6 @@ class TestFreshnessDateDataParser(BaseTestCase):
         self.freshness_parser = Mock(wraps=freshness_date_parser)
 
         dt_mock = Mock(wraps=dateparser.freshness_date_parser.datetime)
-        dt_mock.utcnow = Mock(return_value=self.now)
         dt_mock.now = Mock(side_effect=self.now_with_timezone)
         self.add_patch(patch("dateparser.freshness_date_parser.datetime", new=dt_mock))
         self.add_patch(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -597,19 +597,19 @@ class TestTranslateSearch(BaseTestCase):
                     (
                         "May 2020",
                         datetime.datetime(
-                            2020, 5, datetime.datetime.utcnow().day, 0, 0
+                            2020, 5, datetime.datetime.now(tz=datetime.timezone.utc).day, 0, 0
                         ),
                     ),
                     (
                         "July 2020",
                         datetime.datetime(
-                            2020, 7, datetime.datetime.utcnow().day, 0, 0
+                            2020, 7, datetime.datetime.now(tz=datetime.timezone.utc).day, 0, 0
                         ),
                     ),
                     (
                         "2023",
                         datetime.datetime(
-                            2023, 7, datetime.datetime.utcnow().day, 0, 0
+                            2023, 7, datetime.datetime.now(tz=datetime.timezone.utc).day, 0, 0
                         ),
                     ),
                     (
@@ -617,7 +617,7 @@ class TestTranslateSearch(BaseTestCase):
                         datetime.datetime(
                             2023,
                             1,
-                            datetime.datetime.utcnow().day,
+                            datetime.datetime.now(tz=datetime.timezone.utc).day,
                             0,
                             0,
                             tzinfo=pytz.utc,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -597,19 +597,31 @@ class TestTranslateSearch(BaseTestCase):
                     (
                         "May 2020",
                         datetime.datetime(
-                            2020, 5, datetime.datetime.now(tz=datetime.timezone.utc).day, 0, 0
+                            2020,
+                            5,
+                            datetime.datetime.now(tz=datetime.timezone.utc).day,
+                            0,
+                            0,
                         ),
                     ),
                     (
                         "July 2020",
                         datetime.datetime(
-                            2020, 7, datetime.datetime.now(tz=datetime.timezone.utc).day, 0, 0
+                            2020,
+                            7,
+                            datetime.datetime.now(tz=datetime.timezone.utc).day,
+                            0,
+                            0,
                         ),
                     ),
                     (
                         "2023",
                         datetime.datetime(
-                            2023, 7, datetime.datetime.now(tz=datetime.timezone.utc).day, 0, 0
+                            2023,
+                            7,
+                            datetime.datetime.now(tz=datetime.timezone.utc).day,
+                            0,
+                            0,
                         ),
                     ),
                     (

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -153,7 +153,9 @@ class TestLocalTZOffset(BaseTestCase):
         datetime_cls = dateparser.timezone_parser.datetime
         if not isinstance(datetime_cls, Mock):
             datetime_cls = Mock(wraps=datetime)
-        utc_dt_obj = datetime.strptime(utc_dt_string, "%Y-%m-%d %H:%M").astimezone(dt.timezone.utc)
+        utc_dt_obj = datetime.strptime(utc_dt_string, "%Y-%m-%d %H:%M").astimezone(
+            dt.timezone.utc
+        )
         local_dt_obj = datetime.strptime(local_dt_string, "%Y-%m-%d %H:%M")
 
         def _dt_now(tz=None):


### PR DESCRIPTION
Starting with Python 3.12 `datetime.utcnow` will be deprecated.
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow