### PR TITLE
postpone timezone regex evaluation until first use - shaves off time from package import

### DIFF
--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -9,7 +9,7 @@ import regex as re
 from pytz import UTC, UnknownTimeZoneError, timezone
 from tzlocal import get_localzone
 
-from dateparser.timezone_parser import StaticTzInfo, _tz_offsets
+from dateparser.timezone_parser import StaticTzInfo, TzRegexCache
 
 
 def strip_braces(date_string):
@@ -73,7 +73,7 @@ def get_timezone_from_tz_string(tz_string):
     try:
         return timezone(tz_string)
     except UnknownTimeZoneError as e:
-        for name, info in _tz_offsets:
+        for name, info in TzRegexCache.tz_offsets():
             if info["regex"].search(" %s" % tz_string):
                 return StaticTzInfo(name, info["offset"])
         else:
@@ -104,7 +104,7 @@ def apply_tzdatabase_timezone(date_time, pytz_string):
 
 
 def apply_dateparser_timezone(utc_datetime, offset_or_timezone_abb):
-    for name, info in _tz_offsets:
+    for name, info in TzRegexCache.tz_offsets():
         if info["regex"].search(" %s" % offset_or_timezone_abb):
             tz = StaticTzInfo(name, info["offset"])
             return utc_datetime.astimezone(tz)


### PR DESCRIPTION
This MR is related to issue #533 which is caused mainly by a time intensive parsing of regular expressions for timezone matching. This MR introduces a global object `TzRegexCache` and moves preparation of the regexps into it. The regexps are no longer parsed on startup, but during first use instead. On my machine it shaves off about 200 ms from the import time of `dateparser` thus reducing it to less than 20 % of the original import time.