### PR TITLE
Fix skipping day when parsing times if UTC and TIMEZONE day are different

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -563,18 +563,15 @@ class _parser:
             # Convert dateobj to utc time to compare with self.now
             try:
                 tz = tz or get_timezone_from_tz_string(self.settings.TIMEZONE)
+                tz_offset = tz.utcoffset(dateobj)
             except pytz.UnknownTimeZoneError:
-                tz = None
+                tz_offset = timedelta(hours=0)
 
-            if tz:
-                dateobj_time = (dateobj - tz.utcoffset(dateobj)).time()
-            else:
-                dateobj_time = dateobj.time()
             if "past" in self.settings.PREFER_DATES_FROM:
-                if self.now.time() < dateobj_time:
+                if self.now < dateobj - tz_offset:
                     dateobj = dateobj + timedelta(days=-1)
             if "future" in self.settings.PREFER_DATES_FROM:
-                if self.now.time() > dateobj_time:
+                if self.now > dateobj - tz_offset:
                     dateobj = dateobj + timedelta(days=1)
 
         # Reset dateobj to the original value, thus removing any offset awareness that may

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -1213,6 +1213,16 @@ class TestDateParser(BaseTestCase):
                 {"PREFER_DATES_FROM": "future"},
             ),
             param(
+                "10pm EDT",
+                datetime(2021, 10, 20, 2, 0),
+                {"PREFER_DATES_FROM": "future"},
+            ),
+            param(
+                "8am AEDT",
+                datetime(2021, 10, 18, 21, 0),
+                {"PREFER_DATES_FROM": "past"},
+            ),
+            param(
                 "11pm AEDT",
                 datetime(2021, 10, 19, 12, 0),
                 {"PREFER_DATES_FROM": "past"},
@@ -1221,6 +1231,16 @@ class TestDateParser(BaseTestCase):
                 "4pm",
                 datetime(2021, 10, 19, 20, 0),
                 {"PREFER_DATES_FROM": "future", "TIMEZONE": "EDT"},
+            ),
+            param(
+                "10pm",
+                datetime(2021, 10, 20, 2, 0),
+                {"PREFER_DATES_FROM": "future", "TIMEZONE": "EDT"},
+            ),
+            param(
+                "8am",
+                datetime(2021, 10, 18, 21, 0),
+                {"PREFER_DATES_FROM": "past", "TIMEZONE": "AEDT"},
             ),
             param(
                 "11pm",


### PR DESCRIPTION
This should fix #1169 

If only a time is provided such as "8pm", the previous logic determines if the time is in the "future" or "past" by comparing the base time of day and the parsed time.
This works if the timezone is UTC, but to make this respect the TIMEZONE setting, #1002 subtracts the timezone's offset from the parsed time. If this causes the day to roll over, then comparing times will incorrectly report the parsed date as being in the past. For example. `datetime(2023, 2, 3, 4).time() == datetime.time(4, 0)` is reported as earlier tham ` datetime(2023, 2, 2, 18).time() == datetime.time(18, 0)`, and erroneously adding day. To correct this, we could compare dates rather than times.

```
from datetime import datetime
import dateparser
import pytz

now = datetime(2023, 2, 2, 10).astimezone(pytz.timezone("America/Los_Angeles"))
print(now)      # 2023-02-02 10:00:00-08:00
now_utc = now.astimezone(pytz.timezone("UTC")).replace(tzinfo=None)
print(now_utc)  # 2023-02-02 18:00:00

settings = {
    'PREFER_DATES_FROM': 'future',
    'RETURN_AS_TIMEZONE_AWARE': True,
    'RELATIVE_BASE': now_utc,
    'TIMEZONE': 'America/Los_Angeles',
    "TO_TIMEZONE": "etc/utc",
}
time = dateparser.parse('2pm', settings=settings)
print(time) # 2023-02-02 22:00:00+00:00 - correct

time = dateparser.parse('8pm', settings=settings)
print(time) # 2023-02-04 04:00:00+00:00 - incorrect

# datetime(2023, 2, 3, 4).time() = datetime.time(4, 0)
# datetime(2023, 2, 2, 18).time() = datetime.time(18, 0)
# datetime.time(4, 0) < datetime.time(18, 0) which causes date to be added even though the date is in the future

```