### PR TITLE
support two-digit year in non-gregorian calendars

### DIFF
--- a/dateparser/calendars/__init__.py
+++ b/dateparser/calendars/__init__.py
@@ -76,6 +76,9 @@ class non_gregorian_parser(_parser):
 
         return result
 
+    def handle_two_digit_year(self, year):
+        raise ValueError
+
     def _get_datetime_obj(self, **params):
         day = params["day"]
         year = params["year"]
@@ -129,6 +132,8 @@ class non_gregorian_parser(_parser):
             day = int(token)
         elif directive == "%Y" and token_len == 4 and is_digit:
             year = int(token)
+        elif directive == "%Y" and token_len == 2 and is_digit:
+            year = self.handle_two_digit_year(int(token))
         else:
             raise ValueError
         return self.non_gregorian_date_cls(year, month, day)

--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -54,3 +54,9 @@ class hijri_parser(non_gregorian_parser):
             for arabic in arabics:
                 result = result.replace(arabic, latin)
         return result
+    
+    def handle_two_digit_year(self, year):
+        if year >= 90:
+            return year + 1300
+        else:
+            return year + 1400

--- a/dateparser/calendars/jalali_parser.py
+++ b/dateparser/calendars/jalali_parser.py
@@ -1,5 +1,6 @@
 import re
 from collections import OrderedDict
+from datetime import datetime
 from functools import reduce
 
 from convertdate import persian
@@ -176,3 +177,9 @@ class jalali_parser(non_gregorian_parser):
         ):
             result = result.replace(persian_number, str(number))
         return result
+
+    def handle_two_digit_year(self, year):
+        if year > 60:
+            return year + 1300
+        else:
+            return year + 1400

--- a/tests/test_hijri.py
+++ b/tests/test_hijri.py
@@ -51,6 +51,8 @@ class TestHijriParser(BaseTestCase):
                 dt_string="04-03-1433 هـ, 10:08 مساءً",
                 dt_obj=datetime(2012, 1, 27, 22, 8),
             ),
+            param(dt_string="30-02-33", dt_obj=datetime(2012, 1, 24)),
+            param(dt_string="10-03-90", dt_obj=datetime(1970, 5, 16)),
         ]
     )
     def test_datetime_parsing(

--- a/tests/test_jalali.py
+++ b/tests/test_jalali.py
@@ -240,6 +240,14 @@ class TestJalaliCalendar(BaseTestCase):
                 date_string="پنجشنبه 26 شهریور 1394 ساعت ساعت 11 و 01 دقیقه",
                 dt=datetime(2015, 9, 17, 11, 1),
             ),
+            param(
+                date_string="پنجشنبه 26 شهریور 94 ساعت ساعت 11 و 01 دقیقه",
+                dt=datetime(2015, 9, 17, 11, 1),
+            ),
+            param(
+                date_string="چهارشنبه 22 شهریور 02 ساعت ساعت 11 و 01 دقیقه",
+                dt=datetime(2023, 9, 13, 11, 1),
+            ),
         ]
     )
     def test_get_date(self, date_string, dt):


### PR DESCRIPTION
We had an issue with parsing two digit year in non-gregorian calendars. This PR will fix that issue and provide a fix for both jalali and hijri calendars.