### PR TITLE
OSSFuzz Bug Fix 

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,35 @@
+name: CIFuzz
+on: [pull_request]
+permissions: {}
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'dateparser'
+        language: python
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'dateparser'
+        language: python
+        fuzz-seconds: 600
+        output-sarif: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: cifuzz-sarif/results.sarif
+        checkout_path: cifuzz-sarif

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -181,26 +181,34 @@ class Dictionary:
         ):
             cache.pop(list(cache.keys())[0])
 
-    def _split_by_known_words(self, string, keep_formatting):
-        if not string:
-            return string
-
+    def _split_by_known_words(self, string: str, keep_formatting: bool):
         regex = self._get_split_regex_cache()
-        match = regex.match(string)
-        if not match:
-            return (
-                self._split_by_numerals(string, keep_formatting)
-                if self._should_capture(string, keep_formatting)
-                else []
-            )
+        splitted = []
+        unknown = string
 
-        unparsed, known, unknown = match.groups()
-        splitted = [known] if self._should_capture(known, keep_formatting) else []
-        if unparsed and self._should_capture(unparsed, keep_formatting):
-            splitted = self._split_by_numerals(unparsed, keep_formatting) + splitted
-        if unknown:
-            splitted.extend(self._split_by_known_words(unknown, keep_formatting))
+        while unknown:
+            match = regex.match(string)
 
+            if not match:
+                curr_split = (
+                    self._split_by_numerals(string, keep_formatting)
+                    if self._should_capture(string, keep_formatting)
+                    else []
+                )
+                unknown = ""
+            else:
+                unparsed, known, unknown = match.groups()
+                curr_split = (
+                    [known] if self._should_capture(known, keep_formatting) else []
+                )
+                if unparsed and self._should_capture(unparsed, keep_formatting):
+                    curr_split = (
+                        self._split_by_numerals(unparsed, keep_formatting) + curr_split
+                    )
+                if unknown:
+                    string = unknown if string != unknown else ""
+
+            splitted.extend(curr_split)
         return splitted
 
     def _split_by_numerals(self, string, keep_formatting):

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -144,10 +144,10 @@ class _no_spaces_parser:
             "%m%d%y": (
                 self._preferred_formats
                 + sorted(
-                    self._all,
-                    key=lambda x: x.lower().startswith("%m%d%y"),
-                    reverse=True,
-                )
+                self._all,
+                key=lambda x: x.lower().startswith("%m%d%y"),
+                reverse=True,
+            )
             ),
             "%m%y%d": sorted(
                 self._all, key=lambda x: x.lower().startswith("%m%y%d"), reverse=True
@@ -566,10 +566,16 @@ class _parser:
             except pytz.UnknownTimeZoneError:
                 tz = None
 
+            dateobj_time = None
             if tz:
-                dateobj_time = (dateobj - tz.utcoffset(dateobj)).time()
-            else:
+                try:
+                    dateobj_time = (dateobj - tz.utcoffset(dateobj)).time()
+                except pytz.InvalidTimeError:
+                    pass
+
+            if not dateobj_time:
                 dateobj_time = dateobj.time()
+
             if "past" in self.settings.PREFER_DATES_FROM:
                 if self.now.time() < dateobj_time:
                     dateobj = dateobj + timedelta(days=-1)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -564,7 +564,7 @@ class _parser:
             try:
                 tz = tz or get_timezone_from_tz_string(self.settings.TIMEZONE)
                 tz_offset = tz.utcoffset(dateobj)
-            except pytz.UnknownTimeZoneError:
+            except (pytz.UnknownTimeZoneError, pytz.NonExistentTimeError):
                 tz_offset = timedelta(hours=0)
 
             dateobj_time = None

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -567,16 +567,6 @@ class _parser:
             except (pytz.UnknownTimeZoneError, pytz.NonExistentTimeError):
                 tz_offset = timedelta(hours=0)
 
-            dateobj_time = None
-            if tz:
-                try:
-                    dateobj_time = (dateobj - tz.utcoffset(dateobj)).time()
-                except pytz.InvalidTimeError:
-                    pass
-
-            if not dateobj_time:
-                dateobj_time = dateobj.time()
-
             if "past" in self.settings.PREFER_DATES_FROM:
                 if self.now < dateobj - tz_offset:
                     dateobj = dateobj + timedelta(days=-1)

--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -144,10 +144,10 @@ class _no_spaces_parser:
             "%m%d%y": (
                 self._preferred_formats
                 + sorted(
-                self._all,
-                key=lambda x: x.lower().startswith("%m%d%y"),
-                reverse=True,
-            )
+                    self._all,
+                    key=lambda x: x.lower().startswith("%m%d%y"),
+                    reverse=True,
+                )
             ),
             "%m%y%d": sorted(
                 self._all, key=lambda x: x.lower().startswith("%m%y%d"), reverse=True

--- a/tests/test_clean_api.py
+++ b/tests/test_clean_api.py
@@ -113,6 +113,55 @@ class TestParseFunction(BaseTestCase):
 
     @parameterized.expand(
         [
+            param(
+                date_string='0:4',
+                locales=["fr-PF"],
+                languages=["en"],
+                region='',
+                date_formats=['%a', '%a', '%a', '%a'],
+                expected_date=datetime(1969, 12, 31, 14, 4)
+            )
+        ]
+    )
+    def test_dates_parse_utc_offset_does_not_throw(
+        self, date_string, locales, languages, region, date_formats, expected_date
+    ):
+        """
+        Bug discovered by OSSFuzz that caused an exception in pytz to halt parsing
+        Regression test to ensure that this is not reintroduced
+        """
+        self.when_date_is_parsed_with_args_and_settings(
+            date_string,
+            languages=languages,
+            locales=locales,
+            region=region,
+            date_formats=date_formats,
+            settings={
+                'CACHE_SIZE_LIMIT': 1000,
+                'DATE_ORDER': 'YDM',
+                'DEFAULT_LANGUAGES': ['mzn', 'as', 'af', 'fur', 'sr-Cyrl', 'kw', 'ne', 'en', 'vi', 'teo', 'sr', 'cgg'],
+                'LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD': 0.18823535008398845,
+                'NORMALIZE': True,
+                'PARSERS': ['custom-formats', 'absolute-time'],
+                'PREFER_DATES_FROM': 'past',
+                'PREFER_DAY_OF_MONTH': 'first',
+                'PREFER_LOCALE_DATE_ORDER': True,
+                'PREFER_MONTH_OF_YEAR': 'current',
+                'RELATIVE_BASE': datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0),
+                'REQUIRE_PARTS': [],
+                'RETURN_AS_TIMEZONE_AWARE': False,
+                'RETURN_TIME_AS_PERIOD': False,
+                'SKIP_TOKENS': [],
+                'STRICT_PARSING': False,
+                'TIMEZONE': 'America/Hermosillo',
+                'TO_TIMEZONE': 'Asia/Almaty'
+            }
+        )
+        self.then_parsed_date_and_time_is(expected_date)
+        print(self.result)
+
+    @parameterized.expand(
+        [
             param(date_string="January 24, 2014", locales=["pt-AO"]),
         ]
     )
@@ -132,6 +181,15 @@ class TestParseFunction(BaseTestCase):
 
     def when_date_is_parsed_with_settings(self, date_string, settings=None):
         self.result = dateparser.parse(date_string, settings=settings)
+
+    def when_date_is_parsed_with_args_and_settings(self, date_string, languages=None, locales=None, region=None, date_formats=None, settings=None):
+        self.result = dateparser.parse(
+            date_string,
+            languages=languages,
+            locales=locales,
+            region=region,
+            date_formats=date_formats,
+            settings=settings)
 
     def then_parsed_date_is(self, expected_date):
         self.assertEqual(

--- a/tests/test_clean_api.py
+++ b/tests/test_clean_api.py
@@ -114,12 +114,12 @@ class TestParseFunction(BaseTestCase):
     @parameterized.expand(
         [
             param(
-                date_string='0:4',
+                date_string="0:4",
                 locales=["fr-PF"],
                 languages=["en"],
-                region='',
-                date_formats=['%a', '%a', '%a', '%a'],
-                expected_date=datetime(1969, 12, 31, 14, 4)
+                region="",
+                date_formats=["%a", "%a", "%a", "%a"],
+                expected_date=datetime(1969, 12, 31, 14, 4),
             )
         ]
     )
@@ -137,25 +137,40 @@ class TestParseFunction(BaseTestCase):
             region=region,
             date_formats=date_formats,
             settings={
-                'CACHE_SIZE_LIMIT': 1000,
-                'DATE_ORDER': 'YDM',
-                'DEFAULT_LANGUAGES': ['mzn', 'as', 'af', 'fur', 'sr-Cyrl', 'kw', 'ne', 'en', 'vi', 'teo', 'sr', 'cgg'],
-                'LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD': 0.18823535008398845,
-                'NORMALIZE': True,
-                'PARSERS': ['custom-formats', 'absolute-time'],
-                'PREFER_DATES_FROM': 'past',
-                'PREFER_DAY_OF_MONTH': 'first',
-                'PREFER_LOCALE_DATE_ORDER': True,
-                'PREFER_MONTH_OF_YEAR': 'current',
-                'RELATIVE_BASE': datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0),
-                'REQUIRE_PARTS': [],
-                'RETURN_AS_TIMEZONE_AWARE': False,
-                'RETURN_TIME_AS_PERIOD': False,
-                'SKIP_TOKENS': [],
-                'STRICT_PARSING': False,
-                'TIMEZONE': 'America/Hermosillo',
-                'TO_TIMEZONE': 'Asia/Almaty'
-            }
+                "CACHE_SIZE_LIMIT": 1000,
+                "DATE_ORDER": "YDM",
+                "DEFAULT_LANGUAGES": [
+                    "mzn",
+                    "as",
+                    "af",
+                    "fur",
+                    "sr-Cyrl",
+                    "kw",
+                    "ne",
+                    "en",
+                    "vi",
+                    "teo",
+                    "sr",
+                    "cgg",
+                ],
+                "LANGUAGE_DETECTION_CONFIDENCE_THRESHOLD": 0.18823535008398845,
+                "NORMALIZE": True,
+                "PARSERS": ["custom-formats", "absolute-time"],
+                "PREFER_DATES_FROM": "past",
+                "PREFER_DAY_OF_MONTH": "first",
+                "PREFER_LOCALE_DATE_ORDER": True,
+                "PREFER_MONTH_OF_YEAR": "current",
+                "RELATIVE_BASE": datetime(
+                    year=1970, month=1, day=1, hour=0, minute=0, second=0
+                ),
+                "REQUIRE_PARTS": [],
+                "RETURN_AS_TIMEZONE_AWARE": False,
+                "RETURN_TIME_AS_PERIOD": False,
+                "SKIP_TOKENS": [],
+                "STRICT_PARSING": False,
+                "TIMEZONE": "America/Hermosillo",
+                "TO_TIMEZONE": "Asia/Almaty",
+            },
         )
         self.then_parsed_date_and_time_is(expected_date)
 
@@ -181,14 +196,23 @@ class TestParseFunction(BaseTestCase):
     def when_date_is_parsed_with_settings(self, date_string, settings=None):
         self.result = dateparser.parse(date_string, settings=settings)
 
-    def when_date_is_parsed_with_args_and_settings(self, date_string, languages=None, locales=None, region=None, date_formats=None, settings=None):
+    def when_date_is_parsed_with_args_and_settings(
+        self,
+        date_string,
+        languages=None,
+        locales=None,
+        region=None,
+        date_formats=None,
+        settings=None,
+    ):
         self.result = dateparser.parse(
             date_string,
             languages=languages,
             locales=locales,
             region=region,
             date_formats=date_formats,
-            settings=settings)
+            settings=settings,
+        )
 
     def then_parsed_date_is(self, expected_date):
         self.assertEqual(

--- a/tests/test_clean_api.py
+++ b/tests/test_clean_api.py
@@ -158,7 +158,6 @@ class TestParseFunction(BaseTestCase):
             }
         )
         self.then_parsed_date_and_time_is(expected_date)
-        print(self.result)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
This pull request fixes a crash encountered during OSSFuzz continuous fuzzing. Previously, an InvalidTimeError exception in pytz's UTC offset when processing 01-01-1970 0400 would cause parsing to exit prematurely. This fix catches the exception and resolves dateobj_time the secondary way. 

Additionally, to detect bugs prior to them being merged into the codebase, the CIFuzz.yml job that comes with OSSFuzz is proposed in this PR. With this, each PR will be fuzz-tested as part of the CI workflow. 

Thank you for your time and your review!