### PR TITLE
Fixed ClusterFuzz build error by adding dateparserr.data as a binary

### DIFF
--- a/fuzzing/build.sh
+++ b/fuzzing/build.sh
@@ -3,6 +3,6 @@ pip3 install .
 
 # Build fuzzers in $OUT
 for fuzzer in $(find fuzzing -name '*_fuzzer.py');do
-  compile_python_fuzzer "$fuzzer"
+  compile_python_fuzzer "$fuzzer" --add-binary="dateparser/data:dateparser/data"
 done
 zip -q $OUT/dateparser_fuzzer_seed_corpus.zip $SRC/corpus/*


### PR DESCRIPTION
Fixes the nightly build of the OSSFuzz continuous testing. 