### PR TITLE
Migrate from hijri-converter to hijridate

### DIFF
--- a/dateparser/calendars/hijri_parser.py
+++ b/dateparser/calendars/hijri_parser.py
@@ -1,4 +1,4 @@
-from hijri_converter import convert
+from hijridate import Gregorian, Hijri
 
 from dateparser.calendars import non_gregorian_parser
 
@@ -6,19 +6,17 @@ from dateparser.calendars import non_gregorian_parser
 class hijri:
     @classmethod
     def to_gregorian(cls, year=None, month=None, day=None):
-        g = convert.Hijri(
-            year=year, month=month, day=day, validate=False
-        ).to_gregorian()
+        g = Hijri(year=year, month=month, day=day, validate=False).to_gregorian()
         return g.datetuple()
 
     @classmethod
     def from_gregorian(cls, year=None, month=None, day=None):
-        h = convert.Gregorian(year, month, day).to_hijri()
+        h = Gregorian(year, month, day).to_hijri()
         return h.datetuple()
 
     @classmethod
     def month_length(cls, year, month):
-        h = convert.Hijri(year=year, month=month, day=1)
+        h = Hijri(year=year, month=month, day=1)
         return h.month_length()
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -223,13 +223,13 @@ Dependencies
 
   * dateutil_'s module ``relativedelta`` for its freshness parser.
   * convertdate_ to convert *Jalali* dates to *Gregorian*.
-  * hijri-converter_ to convert *Hijri* dates to *Gregorian*.
+  * hijridate_ to convert *Hijri* dates to *Gregorian*.
   * tzlocal_ to reliably get local timezone.
   * ruamel.yaml_ (optional) for operations on language files.
 
 .. _dateutil: https://pypi.python.org/pypi/python-dateutil
 .. _convertdate: https://pypi.python.org/pypi/convertdate
-.. _hijri-converter: https://pypi.python.org/pypi/hijri-converter
+.. _hijridate: https://pypi.python.org/pypi/hijridate
 .. _tzlocal: https://pypi.python.org/pypi/tzlocal
 .. _ruamel.yaml: https://pypi.python.org/pypi/ruamel.yaml
 
@@ -261,4 +261,4 @@ To be able to use them you need to install the `calendar` extra by typing:
     >>> HijriCalendar('17-01-1437 هـ 08:30 مساءً').get_date()
     DateData(date_obj=datetime.datetime(2015, 10, 30, 20, 30), period='day', locale=None)
 
-.. note:: `HijriCalendar` only works with Python ≥ 3.6.
+.. note:: `HijriCalendar` only works with Python ≥ 3.7.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "console_scripts": ["dateparser-download = dateparser_cli.cli:entrance"],
     },
     extras_require={
-        "calendars": ["hijri-converter", "convertdate"],
+        "calendars": ["hijridate", "convertdate"],
         "fasttext": ["fasttext"],
         "langdetect": ["langdetect"],
     },


### PR DESCRIPTION
hijri-converter has been renamed to hijridate since 2.3.0.
Closes: #1197 