### PR TITLE
Add `en-US` locale

### DIFF
--- a/dateparser/data/languages_info.py
+++ b/dateparser/data/languages_info.py
@@ -496,6 +496,7 @@ language_locale_dict = {
         "en-TZ",
         "en-UG",
         "en-UM",
+        "en-US",
         "en-VC",
         "en-VG",
         "en-VI",


### PR DESCRIPTION
The code for English (United States) 'en-US'. The prefix, 'en', is a language code following the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes). The suffix, 'US', is a country code following the [ISO 3166-1 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) standard.
E.g. Discord uses that locale name for language `English, US`