### PR TITLE
Check for derived types for configuration

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -243,7 +243,7 @@ def check_settings(settings):
         setting_props = settings_values[setting_name]
 
         # check type:
-        if not setting_type == setting_props["type"]:
+        if not isinstance(setting_type, setting_props["type"]):
             raise SettingValidationError(
                 '"{}" must be "{}", not "{}".'.format(
                     setting_name, setting_props["type"].__name__, setting_type.__name__

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -243,7 +243,7 @@ def check_settings(settings):
         setting_props = settings_values[setting_name]
 
         # check type:
-        if not isinstance(setting_type, setting_props["type"]):
+        if not isinstance(setting_value, setting_props["type"]):
             raise SettingValidationError(
                 '"{}" must be "{}", not "{}".'.format(
                     setting_name, setting_props["type"].__name__, setting_type.__name__


### PR DESCRIPTION
Currently if we want to use a derived type for one of the configuration fields, we can't do that. This aims to permit it.

We were using a class that overrides datetime for our tests, and needed this change.