### PR TITLE
Fix: Handle Russian preposition "с" in date parsing and add tests

### DIFF
--- a/dateparser/search/__init__.py
+++ b/dateparser/search/__init__.py
@@ -65,7 +65,6 @@ def search_dates(
         settings=settings,
         detect_languages_function=detect_languages_function,
     )
-
     dates = result.get("Dates")
     if dates:
         if add_detected_language:

--- a/dateparser/search/__init__.py
+++ b/dateparser/search/__init__.py
@@ -57,12 +57,15 @@ def search_dates(
      ('on May 6th 2004', datetime.datetime(2004, 5, 6, 0, 0))]
 
     """
+    text = _search_with_detection.preprocess_text(text, languages)
+
     result = _search_with_detection.search_dates(
         text=text,
         languages=languages,
         settings=settings,
         detect_languages_function=detect_languages_function,
     )
+
     dates = result.get("Dates")
     if dates:
         if add_detected_language:

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -295,3 +295,10 @@ class DateSearchWithDetection:
                 language_shortname, text, settings=settings
             ),
         }
+
+    def preprocess_text(self, text, languages):
+        """Preprocess text to handle language-specific quirks."""
+        if languages and "ru" in languages:
+            # Replace "с" (from) before numbers with a placeholder
+            text = re.sub(r"\bс\s+(?=\d)", "[FROM] ", text)
+        return text

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1090,3 +1090,16 @@ class TestTranslateSearch(BaseTestCase):
             text=text, languages=languages, error_type=ValueError
         )
         self.check_error_message("Unknown language(s): 'unknown language code'")
+
+    def test_search_dates_with_prepositions():
+        """Test `search_dates` for parsing Russian date ranges with prepositions and language detection."""
+        result = search_dates(
+            "Сервис будет недоступен с 12 января по 30 апреля.",
+            add_detected_language=True,
+            languages=["ru"],
+        )
+        expected = [
+            (" 12 января", datetime.datetime(2025, 1, 12, 0, 0), "ru"),
+            ("30 апреля", datetime.datetime(2025, 4, 30, 0, 0), "ru"),
+        ]
+        assert result == expected

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1091,7 +1091,7 @@ class TestTranslateSearch(BaseTestCase):
         )
         self.check_error_message("Unknown language(s): 'unknown language code'")
 
-    def test_search_dates_with_prepositions():
+    def test_search_dates_with_prepositions(self):
         """Test `search_dates` for parsing Russian date ranges with prepositions and language detection."""
         result = search_dates(
             "Сервис будет недоступен с 12 января по 30 апреля.",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1099,7 +1099,7 @@ class TestTranslateSearch(BaseTestCase):
             languages=["ru"],
         )
         expected = [
-            (" 12 января", datetime.datetime(2025, 1, 12, 0, 0), "ru"),
+            ("12 января", datetime.datetime(2025, 1, 12, 0, 0), "ru"),
             ("30 апреля", datetime.datetime(2025, 4, 30, 0, 0), "ru"),
         ]
         assert result == expected


### PR DESCRIPTION
Close #918 