### PR TITLE
Add 'no_correction' option for PREFER_DAY_OF_MONTH and PREFER_MONTH_OF_YEAR

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -192,8 +192,8 @@ def check_settings(settings):
             # It defaults to 'default', but it's not allowed to use it directly
             "type": bool
         },
-        "PREFER_MONTH_OF_YEAR": {"values": ("current", "first", "last"), "type": str},
-        "PREFER_DAY_OF_MONTH": {"values": ("current", "first", "last"), "type": str},
+        "PREFER_MONTH_OF_YEAR": {"values": ("current", "first", "last", "no_correction"), "type": str},
+        "PREFER_DAY_OF_MONTH": {"values": ("current", "first", "last", "no_correction"), "type": str},
         "PREFER_DATES_FROM": {
             "values": ("current_period", "past", "future"),
             "type": str,

--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -180,6 +180,8 @@ def set_correct_day_from_settings(date_obj, settings, current_day=None):
     }
 
     try:
+        if settings.PREFER_DAY_OF_MONTH == 'no_correction':
+            return date_obj
         return date_obj.replace(day=options[settings.PREFER_DAY_OF_MONTH])
     except ValueError:
         return date_obj.replace(day=options["last"])
@@ -190,6 +192,8 @@ def set_correct_month_from_settings(date_obj, settings, current_month=None):
     options = {"first": 1, "last": 12, "current": current_month or datetime.now().month}
 
     try:
+        if settings.PREFER_MONTH_OF_YEAR == 'no_correction':
+            return date_obj
         return date_obj.replace(month=options[settings.PREFER_MONTH_OF_YEAR])
     except ValueError:
         return date_obj.replace(month=options["last"])


### PR DESCRIPTION
In cases where only the day of the week is input, for example, 'Monday', without the day and month, the `set_correct_day_from_settings` and `set_correct_month_from_settings` functions produce an incorrect date.

I added a 4th option for the `PREFER_DAY_OF_MONTH` and `PREFER_MONTH_OF_YEAR` settings - `no_correction`.

It is intended for use in cases where day and month correction is not required.

Use example:
```
from dateparser import parse
from datetime import datetime

print(
    parse(
        "Mon 01:11",
        settings={"PREFER_DATES_FROM": "past", "RELATIVE_BASE": datetime(2025, 4, 3)},
    )
)
# Expected '2025-03-31 01:11:00'. Got '2025-12-31 01:11:00'
print(
    parse(
        "Mon 01:11",
        settings={
            "PREFER_DATES_FROM": "past",
            "PREFER_DAY_OF_MONTH": "no_correction",
            "PREFER_MONTH_OF_YEAR": "no_correction",
            "RELATIVE_BASE": datetime(2025, 4, 3),
        },
    )
)
# '2025-03-31 01:11:00'
```