### PR TITLE
Allow md5hash to function in fips environments

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -49,7 +49,7 @@ class Settings:
             return "default"
 
         keys = sorted(["%s-%s" % (key, str(settings[key])) for key in settings])
-        return hashlib.md5("".join(keys).encode("utf-8")).hexdigest()
+        return hashlib.new("md5", "".join(keys).encode("utf-8"), usedforsecurity=True).hexdigest()
 
     @classmethod
     def _get_settings_from_pyfile(cls):


### PR DESCRIPTION
Many secure environments disable the `hashlib.md5` function because it is insecure, this causes the line below to fail making dateparser unusable in these environments:

https://github.com/scrapinghub/dateparser/blob/02bd2e5dd4477b4f6db98c5e98149458eb3cc821/dateparser/conf.py#L52

This is remedied by replacing that line with `return hashlib.new("md5", "".join(keys).encode("utf-8"), usedforsecurity=True).hexdigest()` which appropriately bypasses the fips security check because dateparser is not using the md5 hash for security applications.