### PR TITLE
fix: allow 'N {interval} from now' (#502)

### DIFF
--- a/dateparser/data/date_translation_data/en.py
+++ b/dateparser/data/date_translation_data/en.py
@@ -747,6 +747,7 @@ info = {
         "and",
         "at",
         "by",
+        "from",
         "just",
         "m",
         "nd",

--- a/dateparser_data/supplementary_language_data/date_translation_data/en.yaml
+++ b/dateparser_data/supplementary_language_data/date_translation_data/en.yaml
@@ -1,4 +1,4 @@
-skip: ["about", "ad", "and", "at", "by", "just", "m", "nd", "of", "on", "rd", "st", "th", "the"]
+skip: ["about", "ad", "and", "at", "by", "from", "just", "m", "nd", "of", "on", "rd", "st", "th", "the"]
 pertain: ["of"]
 
 sentence_splitter_group : 1

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -122,6 +122,11 @@ class TestFreshnessDateDataParser(BaseTestCase):
                 period="day",
             ),
             param("just now", ago={"seconds": 0}, period="day"),
+            param('11 hours from now', in_future={'hours': 11}, period='hour'),
+            param('10 days from now', in_future={'days': 10}, period='day'),
+            param('9 weeks from now', in_future={'weeks': 9}, period='week'),
+            param('8 months from now', in_future={'months': 8}, period='month'),
+            param('7 years from now', in_future={'years': 7}, period='year'),
             # Fix for #291, work till one to twelve only
             param("nine hours ago", ago={"hours": 9}, period="day"),
             param("three week ago", ago={"weeks": 3}, period="week"),


### PR DESCRIPTION
This is a copy of PR https://github.com/scrapinghub/dateparser/pull/642 which fixes https://github.com/scrapinghub/dateparser/issues/502. I'm not sure why it was closed, or if this is the right way to re-submit it. Afaict it's a general fix that works in all cases.

Before:
```
$ python -c "from dateparser import parse; from datetime import datetime ; print(parse('in 2 days', settings={'RELATIVE_BASE': datetime.now()}))"
2025-05-19 00:34:29.964320

$ python -c "from dateparser import parse; from datetime import datetime ; print(parse('2 days fron now', settings={'RELATIVE_BASE': datetime.now()}))"
None
```
After:
```
$ python -c "from dateparser import parse; from datetime import datetime ; print(parse('in 2 days', settings={'RELATIVE_BASE': datetime.now()}))"
2025-05-19 00:34:29.964320

$ python -c "from dateparser import parse; from datetime import datetime ; print(parse('2 days fron now', settings={'RELATIVE_BASE': datetime.now()}))"
2025-05-19 00:34:29.964320
```