### PR TITLE
Fix weekday search

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -512,6 +512,10 @@ class _parser:
 
             dateobj = dateobj + delta
 
+            # set the token_month here so that it is not subsequently
+            # altered by _correct_for_month
+            self._token_month = dateobj.month
+
         # NOTE: If this assert fires, self.now needs to be made offset-aware in a similar
         # way that dateobj is temporarily made offset-aware.
         assert not (self.now.tzinfo is None and dateobj.tzinfo is not None), (

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -630,6 +630,25 @@ class TestDateParser(BaseTestCase):
 
     @parameterized.expand(
         [
+            param("Monday", datetime(2015, 3, 2)),
+        ]
+    )
+    def test_preferably_future_dates_relative_last_week_of_month(
+        self, date_string, expected
+    ):
+        self.given_local_tz_offset(0)
+        self.given_parser(
+            settings={
+                "PREFER_DATES_FROM": "future",
+                "RELATIVE_BASE": datetime(2015, 2, 24, 15, 30),
+            }
+        )
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.then_date_obj_exactly_is(expected)
+
+    @parameterized.expand(
+        [
             param("10 December", datetime(2015, 12, 10)),
             param("March", datetime(2015, 3, 15)),
             param("Friday", datetime(2015, 2, 13)),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -410,7 +410,7 @@ class TestTranslateSearch(BaseTestCase):
                 "Die UdSSR blieb gemäß dem Neutralitätspakt "
                 "vom 13. April 1941 gegenüber Japan vorerst neutral.",
                 [
-                    ("Die", datetime.datetime(1999, 1, 28, 0, 0)),
+                    ("Die", datetime.datetime(1999, 12, 28, 0, 0)),
                     ("13. April 1941", datetime.datetime(1941, 4, 13, 0, 0)),
                 ],
                 settings={"RELATIVE_BASE": datetime.datetime(2000, 1, 1)},


### PR DESCRIPTION
Fixes cases when searching only for a weekday where the parser had found the correct date but then erroneously "corrected" the month later.

Fixes #1266
Fixes #1249
Fixes #1243
Fixes #1202