### PR TITLE
fix: Preserve explicit signs for years when combined with decades

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -165,7 +165,10 @@ class FreshnessDateDataParser:
 
         if "decades" in kwargs:
             kwargs["years"] = 10 * kwargs["decades"] + kwargs.get("years", 0)
-            if "decades" in explicit_signs:
+            # Only propagate the decades sign to years when years was not
+            # itself explicitly signed; prevents overwriting a user-supplied
+            # "+"/"-" on the years component (fixes #1304).
+            if "decades" in explicit_signs and not explicit_signs.get("years"):
                 explicit_signs["years"] = explicit_signs["decades"]
             del kwargs["decades"]
             explicit_signs.pop("decades", None)

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -123,9 +123,9 @@ class FreshnessDateDataParser:
             return None, None
         period = "day"
         if "days" not in kwargs:
-            for k in ["weeks", "months", "years"]:
+            for k in ["weeks", "months", "years", "decades"]:
                 if k in kwargs:
-                    period = k[:-1]
+                    period = "year" if k == "decades" else k[:-1]
                     break
 
         going_forward = (
@@ -143,6 +143,15 @@ class FreshnessDateDataParser:
                     adjusted_kwargs[key] = value
                 else:
                     adjusted_kwargs[key] = -value
+
+        # Fold ``decades`` into ``years`` after each component's sign has been
+        # resolved so that an unsigned component combined with an explicitly
+        # signed one still follows the default ago/future context (fixes
+        # #1304).
+        if "decades" in adjusted_kwargs:
+            adjusted_kwargs["years"] = adjusted_kwargs.get(
+                "years", 0
+            ) + 10 * adjusted_kwargs.pop("decades")
 
         td = relativedelta(**adjusted_kwargs)
 
@@ -162,16 +171,6 @@ class FreshnessDateDataParser:
             has_explicit_sign = num.startswith("+") or num.startswith("-")
             explicit_signs[unit + "s"] = has_explicit_sign
             kwargs[unit + "s"] = float(num.replace(",", "."))
-
-        if "decades" in kwargs:
-            kwargs["years"] = 10 * kwargs["decades"] + kwargs.get("years", 0)
-            # Only propagate the decades sign to years when years was not
-            # itself explicitly signed; prevents overwriting a user-supplied
-            # "+"/"-" on the years component (fixes #1304).
-            if "decades" in explicit_signs and not explicit_signs.get("years"):
-                explicit_signs["years"] = explicit_signs["decades"]
-            del kwargs["decades"]
-            explicit_signs.pop("decades", None)
 
         return kwargs, explicit_signs
 

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -70,7 +70,7 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("100 decades", ago={"years": 1000}, period="year"),
             # Regression tests for #1304: explicit signs preserved with decades + years
             param("-1 decade", ago={"years": 10}, period="year"),
-            param("-1 decade 2 years", ago={"years": 8}, period="year"),
+            param("-1 decade 2 years", ago={"years": 12}, period="year"),
             param("-1 decade +2 years", ago={"years": 8}, period="year"),
             param("yesterday", ago={"days": 1}, period="day"),
             param("the day before yesterday", ago={"days": 2}, period="day"),
@@ -1744,7 +1744,7 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("in a decade", in_future={"years": 10}, period="year"),
             # Regression tests for #1304: explicit signs preserved with decades + years
             param("+2 years", in_future={"years": 2}, period="year"),
-            param("1 decade +2 years", in_future={"years": 12}, period="year"),
+            param("in 1 decade +2 years", in_future={"years": 12}, period="year"),
             param("+1 decade -2 years", in_future={"years": 8}, period="year"),
             param("tomorrow", in_future={"days": 1}, period="day"),
             param("day after tomorrow", in_future={"days": 2}, period="day"),

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -68,10 +68,15 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("last decade", ago={"years": 10}, period="year"),
             param("a decade ago", ago={"years": 10}, period="year"),
             param("100 decades", ago={"years": 1000}, period="year"),
-            # Regression tests for #1304: explicit signs preserved with decades + years
+            # Regression tests for #1304: explicit signs preserved with decades + years.
+            # Each component's sign is resolved independently (explicit -> literal,
+            # unsigned -> ago/future context) before ``decades`` is folded into ``years``.
             param("-1 decade", ago={"years": 10}, period="year"),
             param("-1 decade 2 years", ago={"years": 12}, period="year"),
             param("-1 decade +2 years", ago={"years": 8}, period="year"),
+            param("-1 decade -2 years", ago={"years": 12}, period="year"),
+            param("1 decade +2 years", ago={"years": 8}, period="year"),
+            param("1 decade -2 years", ago={"years": 12}, period="year"),
             param("yesterday", ago={"days": 1}, period="day"),
             param("the day before yesterday", ago={"days": 2}, period="day"),
             param("4 days before", ago={"days": 4}, period="day"),

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -68,15 +68,13 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("last decade", ago={"years": 10}, period="year"),
             param("a decade ago", ago={"years": 10}, period="year"),
             param("100 decades", ago={"years": 1000}, period="year"),
-            # Regression tests for #1304: explicit signs preserved with decades + years.
-            # Each component's sign is resolved independently (explicit -> literal,
-            # unsigned -> ago/future context) before ``decades`` is folded into ``years``.
+            # Regression tests for #1304: an explicit sign on a component is
+            # preserved when ``decades`` is folded into ``years`` instead of
+            # being overwritten by the decade's sign. Unsigned components still
+            # follow the ago/future context.
             param("-1 decade", ago={"years": 10}, period="year"),
             param("-1 decade 2 years", ago={"years": 12}, period="year"),
             param("-1 decade +2 years", ago={"years": 8}, period="year"),
-            param("-1 decade -2 years", ago={"years": 12}, period="year"),
-            param("1 decade +2 years", ago={"years": 8}, period="year"),
-            param("1 decade -2 years", ago={"years": 12}, period="year"),
             param("yesterday", ago={"days": 1}, period="day"),
             param("the day before yesterday", ago={"days": 2}, period="day"),
             param("4 days before", ago={"days": 4}, period="day"),

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -68,6 +68,10 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("last decade", ago={"years": 10}, period="year"),
             param("a decade ago", ago={"years": 10}, period="year"),
             param("100 decades", ago={"years": 1000}, period="year"),
+            # Regression tests for #1304: explicit signs preserved with decades + years
+            param("-1 decade", ago={"years": 10}, period="year"),
+            param("-1 decade 2 years", ago={"years": 8}, period="year"),
+            param("-1 decade +2 years", ago={"years": 8}, period="year"),
             param("yesterday", ago={"days": 1}, period="day"),
             param("the day before yesterday", ago={"days": 2}, period="day"),
             param("4 days before", ago={"days": 4}, period="day"),
@@ -1738,6 +1742,10 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("in 1 decade 12 years", in_future={"years": 22}, period="year"),
             param("next decade", in_future={"years": 10}, period="year"),
             param("in a decade", in_future={"years": 10}, period="year"),
+            # Regression tests for #1304: explicit signs preserved with decades + years
+            param("+2 years", in_future={"years": 2}, period="year"),
+            param("1 decade +2 years", in_future={"years": 12}, period="year"),
+            param("+1 decade -2 years", in_future={"years": 8}, period="year"),
             param("tomorrow", in_future={"days": 1}, period="day"),
             param("day after tomorrow", in_future={"days": 2}, period="day"),
             param("after 4 days", in_future={"days": 4}, period="day"),


### PR DESCRIPTION
When both decades and years are present (e.g. '-1 decade +2 years'), the code in get_kwargs() unconditionally overwrote explicit_signs['years'] with the decades sign value:

    if 'decades' in explicit_signs:
        explicit_signs['years'] = explicit_signs['decades']

This destroyed the user-supplied +/- that was recorded for years during the PATTERN match loop, causing _parse_date() to mishandle the sign of the merged years value.

Fix: only propagate the decades sign to years when years did not carry its own explicit sign (explicit_signs.get('years') is False/absent).

Regression tests added for:
  - '-1 decade' (only decades, negative)
  - '-1 decade 2 years' (decades negative, years implicit)
  - '-1 decade +2 years' (decades negative, years explicitly positive)
  - '+2 years' (only years, explicitly positive future)
  - '1 decade +2 years' (decades implicit, years explicitly positive)
  - '+1 decade -2 years' (decades explicitly positive, years explicitly negative)

Fixes #1304