### PR TITLE
Fix search_dates language fallback

### DIFF
--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -320,7 +320,9 @@ class DateSearchWithDetection:
             detect_languages_function=detect_languages_function,
         )
 
-        candidate_languages = self._get_candidate_languages(language_shortname, languages)
+        candidate_languages = self._get_candidate_languages(
+            language_shortname, languages
+        )
         if not candidate_languages:
             return {"Language": None, "Dates": None}
 

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -218,6 +218,21 @@ class DateSearchWithDetection:
         self.available_language_map = self.loader.get_locale_map()
         self.search = _ExactLanguageSearch(self.loader)
 
+    def _get_candidate_languages(self, detected_language, languages):
+        candidates = []
+        if detected_language:
+            candidates.append(detected_language)
+
+        if isinstance(languages, (list, tuple, Set)) and len(languages) > 1:
+            candidates.extend(languages)
+
+        seen = set()
+        return [
+            language
+            for language in candidates
+            if not (language in seen or seen.add(language))
+        ]
+
     @apply_settings
     def detect_language(
         self, text, languages, settings=None, detect_languages_function=None
@@ -304,13 +319,21 @@ class DateSearchWithDetection:
             settings=settings,
             detect_languages_function=detect_languages_function,
         )
-        if not language_shortname:
+
+        candidate_languages = self._get_candidate_languages(language_shortname, languages)
+        if not candidate_languages:
             return {"Language": None, "Dates": None}
+
+        for candidate_language in candidate_languages:
+            dates = self.search.search_parse(
+                candidate_language, text, settings=settings
+            )
+            if dates:
+                return {"Language": candidate_language, "Dates": dates}
+
         return {
             "Language": language_shortname,
-            "Dates": self.search.search_parse(
-                language_shortname, text, settings=settings
-            ),
+            "Dates": [],
         }
 
     def preprocess_text(self, text, languages):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1020,6 +1020,14 @@ class TestTranslateSearch(BaseTestCase):
                 settings={"STRICT_PARSING": True},
                 expected=None,
             ),
+            param(
+                text="Date de facture 23 juillet 2020 Condition Redevable livraison FR",
+                languages=["en", "fr", "es", "pt", "de", "it", "ar"],
+                settings={"STRICT_PARSING": True},
+                expected=[
+                    ("23 juillet 2020", datetime.datetime(2020, 7, 23, 0, 0))
+                ],
+            ),
             param(text="a Americ", languages=None, settings=None, expected=None),
             # Date with comma and apostrophe
             param(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1024,9 +1024,7 @@ class TestTranslateSearch(BaseTestCase):
                 text="Date de facture 23 juillet 2020 Condition Redevable livraison FR",
                 languages=["en", "fr", "es", "pt", "de", "it", "ar"],
                 settings={"STRICT_PARSING": True},
-                expected=[
-                    ("23 juillet 2020", datetime.datetime(2020, 7, 23, 0, 0))
-                ],
+                expected=[("23 juillet 2020", datetime.datetime(2020, 7, 23, 0, 0))],
             ),
             param(text="a Americ", languages=None, settings=None, expected=None),
             # Date with comma and apostrophe


### PR DESCRIPTION
## Summary

Fix `search_dates()` so it can fall back to other explicitly provided languages when the initially selected language does not find any dates.

Fixes #1326.

---

## Problem

When `search_dates()` is called with multiple languages and `STRICT_PARSING=True`, the language selection step may choose a language that cannot parse the date expression. In that case, the current implementation stops after the first selected language and returns no dates, even if another explicitly provided language can parse the same text.

For example, this French date is parsed correctly with `languages=["fr"]`, but was previously dropped when several languages were provided:

```python
"Date de facture 23 juillet 2020 Condition Redevable livraison FR"
```

---

## Changes

- Keep the existing detected/selected language as the first parsing attempt.
- When multiple languages are explicitly provided, try the remaining candidate languages if the first one returns no dates.
- Return the first language that successfully finds dates.
- Add a regression test for the French `STRICT_PARSING=True` case from #1326.

This is not specific to French or to the `FR` suffix. It handles the broader case where the first selected language fails but another user-provided language can parse the date.

---

## Tests

```bash
python -m pytest -p no:cacheprovider tests/test_search.py tests/test_clean_api.py -q
```

Result:

```text
262 passed
```