### PR TITLE
Document region usage and stabilize current-month parsing

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -598,16 +598,11 @@ class _parser:
         return dateobj
 
     def _correct_for_month(self, dateobj):
-        relative_base = getattr(self.settings, "RELATIVE_BASE", None)
-        relative_base_month = (
-            relative_base.month if hasattr(relative_base, "month") else relative_base
-        )
-
         if getattr(self, "_token_month", None):
             return dateobj
 
         dateobj = set_correct_month_from_settings(
-            dateobj, self.settings, relative_base_month
+            dateobj, self.settings, current_month=self.now.month
         )
         return dateobj
 

--- a/docs/supported_locales.rst
+++ b/docs/supported_locales.rst
@@ -3,6 +3,12 @@
 Supported languages and locales
 ===============================
 
+The ``region`` argument accepts the region subtag from one of the locale
+codes listed below. For example, ``languages=['en'], region='IN'`` uses the
+``en-IN`` locale, while ``languages=['fr'], region='CA'`` uses ``fr-CA``.
+If you already know the full locale code, pass it directly through
+``locales=['en-IN']`` instead.
+
 ============    ================================================================
   Language            Locales
 ============    ================================================================

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -1346,6 +1346,23 @@ class TestDateParser(BaseTestCase):
         self.then_date_was_parsed_by_date_parser()
         self.then_date_obj_exactly_is(expected)
 
+    def test_dates_with_no_day_or_month_use_same_current_date_for_month_and_day(self):
+        class ParserDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 5, 31, 12, 0, tzinfo=tz)
+
+        class UtilsDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 6, 1, 12, 0, tzinfo=tz)
+
+        with (
+            patch("dateparser.parser.datetime", ParserDateTime),
+            patch("dateparser.utils.datetime", UtilsDateTime),
+        ):
+            self.assertEqual(parse("2014"), datetime(2014, 5, 31))
+
     @parameterized.expand(
         [
             param(


### PR DESCRIPTION
## Summary

- Document how the `region` argument maps to locale subtags listed on the supported locales page, with `en-IN` and `fr-CA` examples.
- Reuse the parser's current month when applying `PREFER_MONTH_OF_YEAR="current"` to incomplete dates, so current month and current day come from the same relative base.
- Add a regression test for the month-boundary case where UTC is still May 31 but the local CI timezone is already June 1.

Fixes #465.

## Test

- `python -m sphinx -b html docs docs\_build\html -q`
- `python -m pytest tests/test_search.py -q`
- `python -m pytest tests/test_date_parser.py -k "dates_with_no_day_or_month" -q`
- `python -m ruff check dateparser/parser.py tests/test_date_parser.py`
- `python -m ruff format --check dateparser/parser.py tests/test_date_parser.py`
