### PR TITLE
1.4.1 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 =======
 
-1.4.1 (unreleased)
+1.4.1 (2026-06-15)
 ------------------
 
 Breaking changes:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,53 @@
 History
 =======
 
+1.4.1 (unreleased)
+------------------
+
+Breaking changes:
+
+- Remove fastText language detection support: the ``fasttext`` extra is
+  dropped and ``detect_languages()`` now raises ``ImportError``. Migrate to
+  the ``langdetect`` extra, which also unblocks ``numpy`` 2.x compatibility
+  (#1315)
+
+Security fixes:
+
+- Make digit quantifiers possessive in the relative-date regexes to prevent
+  quadratic backtracking (ReDoS) on long digit runs (#1335)
+
+New features:
+
+- Add the ``USE_GIVEN_LANGUAGE_ORDER`` setting to try ``languages`` and
+  ``locales`` in the order given rather than by frequency (#789)
+
+Fixes:
+
+- Preserve explicit signs on individual components when parsing relative
+  dates that combine decades with years, such as "-1 decade +2 years" (#1330)
+- Fall back to other provided languages in ``search_dates`` when the
+  detected language yields no dates (#1331)
+- Parse relative date expressions with spaces between the sign and number,
+  such as "now - 2 hours" and "now + 1 day" (#1327)
+- Use the parser-relative ``now`` for the current month when filling in
+  incomplete dates so the month and day stay consistent (#1332)
+- Fix Norwegian Bokmål (``nb``) parsing of relative date expressions such
+  as "3 måneder siden" and "om 2 måneder" (#1334)
+- Parse abbreviated English month expressions such as "1mon ago" and
+  "3mons ago" (#1329)
+- Preserve surrounding whitespace when removing skip tokens during
+  translation to avoid spurious double spaces (#1324)
+
+Improvements:
+
+- Move project metadata and build configuration to ``pyproject.toml`` (#1311)
+- Add alternative Korean date expressions for today, yesterday, tomorrow,
+  and "N months ago/later" (#1289)
+- Expand Czech date translations with additional inflections, word numbers,
+  decade and century expressions, and clock phrases like "čtvrt na tři"
+  (#1325)
+- Replace internal ``OrderedDict`` usage with the built-in ``dict`` (#1328)
+
 1.4.0 (2026-03-26)
 ------------------
 

--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from .conf import apply_settings
 from .date import DateDataParser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "dateparser"
-version = "1.4.0"
+version = "1.4.1"
 description = "Date parsing library designed to parse dates from HTML pages"
 authors = [
     { name = "Scrapinghub", email = "opensource@zyte.com" },


### PR DESCRIPTION
Release notes and version bump for **dateparser 1.4.1**, following the same two-step approach used for 1.4.0 (#1319 + the subsequent bump commit):

1. **`1.4.1 release notes`** — add the `1.4.1` section to `HISTORY.rst`, summarizing every PR merged since `v1.4.0`.
2. **`Bump version: 1.4.0 → 1.4.1`** — produced by `bump-my-version bump patch`, updating `pyproject.toml`, `dateparser/__init__.py`, and stamping the `HISTORY.rst` release date. `SECURITY.md` is unchanged because it tracks only `major.minor` (still `1.4.x`).

### Changelog

**Breaking changes:**
- Remove fastText language detection support; the `fasttext` extra is dropped and `detect_languages()` now raises `ImportError`. Migrate to the `langdetect` extra, which also unblocks `numpy` 2.x compatibility (#1315)

**Security fixes:**
- Make digit quantifiers possessive in the relative-date regexes to prevent quadratic backtracking (ReDoS) on long digit runs (#1335)

**New features:**
- Add the `USE_GIVEN_LANGUAGE_ORDER` setting to try `languages` and `locales` in the order given rather than by frequency (#789)

**Fixes:**
- Preserve explicit signs on individual components when parsing relative dates that combine decades with years (#1330)
- Fall back to other provided languages in `search_dates` when the detected language yields no dates (#1331)
- Parse relative date expressions with spaces between the sign and number, e.g. `now - 2 hours` (#1327)
- Use the parser-relative `now` for the current month when filling in incomplete dates (#1332)
- Fix Norwegian Bokmål (`nb`) parsing of relative date expressions (#1334)
- Parse abbreviated English month expressions such as `1mon ago` (#1329)
- Preserve surrounding whitespace when removing skip tokens during translation (#1324)

**Improvements:**
- Move project metadata and build configuration to `pyproject.toml` (#1311)
- Add alternative Korean date expressions (#1289)
- Expand Czech date translations (#1325)
- Replace internal `OrderedDict` usage with the built-in `dict` (#1328)

### After merge

The `v1.4.1` git tag is intentionally **not** included in this branch (a tag on a pre-merge branch would point at the wrong commit). After merging, tag the merge commit on `master`:

```
git tag v1.4.1 && git push origin v1.4.1
```

Internal-only changes (#1333 data-generation script cleanup, #1320 Read the Docs CI bump) were deliberately omitted from the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
