### PR TITLE
Parse Vietnamese dates with zero-padded months (#1297)

### DIFF
--- a/dateparser/data/date_translation_data/vi.py
+++ b/dateparser/data/date_translation_data/vi.py
@@ -4,47 +4,65 @@ info = {
     "january": [
         "thg 1",
         "tháng 1",
-        "Tháng một"
+        "Tháng một",
+        "tháng 01",
+        "thg 01"
     ],
     "february": [
         "thg 2",
         "tháng 2",
-        "Tháng hai"
+        "Tháng hai",
+        "tháng 02",
+        "thg 02"
     ],
     "march": [
         "thg 3",
         "tháng 3",
-        "Tháng ba"
+        "Tháng ba",
+        "tháng 03",
+        "thg 03"
     ],
     "april": [
         "thg 4",
         "tháng 4",
-        "Tháng tư"
+        "Tháng tư",
+        "tháng 04",
+        "thg 04"
     ],
     "may": [
         "thg 5",
         "tháng 5",
-        "Tháng năm"
+        "Tháng năm",
+        "tháng 05",
+        "thg 05"
     ],
     "june": [
         "thg 6",
         "tháng 6",
-        "Tháng sáu"
+        "Tháng sáu",
+        "tháng 06",
+        "thg 06"
     ],
     "july": [
         "thg 7",
         "tháng 7",
-        "Tháng bảy"
+        "Tháng bảy",
+        "tháng 07",
+        "thg 07"
     ],
     "august": [
         "thg 8",
         "tháng 8",
-        "Tháng tám"
+        "Tháng tám",
+        "tháng 08",
+        "thg 08"
     ],
     "september": [
         "thg 9",
         "tháng 9",
-        "Tháng chín"
+        "Tháng chín",
+        "tháng 09",
+        "thg 09"
     ],
     "october": [
         "thg 10",

--- a/dateparser_data/supplementary_language_data/date_translation_data/vi.yaml
+++ b/dateparser_data/supplementary_language_data/date_translation_data/vi.yaml
@@ -19,22 +19,40 @@ sunday:
 
 january:
     - Tháng một
+    - tháng 01
+    - thg 01
 february:
     - Tháng hai
+    - tháng 02
+    - thg 02
 march:
     - Tháng ba
+    - tháng 03
+    - thg 03
 april:
     - Tháng tư
+    - tháng 04
+    - thg 04
 may:
     - Tháng năm
+    - tháng 05
+    - thg 05
 june:
     - Tháng sáu
+    - tháng 06
+    - thg 06
 july:
     - Tháng bảy
+    - tháng 07
+    - thg 07
 august:
     - Tháng tám
+    - tháng 08
+    - thg 08
 september:
     - Tháng chín
+    - tháng 09
+    - thg 09
 october:
     - Tháng mười
 november:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -160,6 +160,9 @@ class TestBundledLanguages(BaseTestCase):
             param(
                 "vi", "9 Tháng 1 2015 lúc 15:08", "9 january 2015 15:08"
             ),  # Issue #1302: "lúc" removed, whitespace preserved
+            param(
+                "vi", "21 tháng 09 năm 2025", "21 september 2025"
+            ),  # Issue #1297: zero-padded month "09"
             # Thai
             param(
                 "th",


### PR DESCRIPTION
Fixes #1297.

Vietnamese dates with a zero-padded month such as `21 tháng 09 năm 2025` were not parsed as absolute dates. The `vi` locale data only listed the un-padded month forms (`tháng 9`), so `tháng 09` did not match a month name and fell through to the generic `tháng` -> *month* token, yielding a wrong relative date:

```python
import dateparser
dateparser.parse("21 tháng 09 năm 2025", languages=["vi"])
# -> datetime.datetime(2024, 9, 16, 8, 16, 26)  # garbage, drifts with "now"

dateparser.parse("21 tháng 9 năm 2025", languages=["vi"])  # un-padded works
# -> datetime.datetime(2025, 9, 21, 0, 0)
```

## Fix

Add zero-padded month aliases (`tháng 0N` and `thg 0N`) for months 1-9 in the supplementary language data and regenerate `vi.py`. Months 10-12 already carry their two-digit forms, so they are untouched.

```python
dateparser.parse("21 tháng 09 năm 2025", languages=["vi"])
# -> datetime.datetime(2025, 9, 21, 0, 0)
```

## Tests

Added a `test_translation` case (`tests/test_languages.py`): `param("vi", "21 tháng 09 năm 2025", "21 september 2025")`. It is RED on the unpadded-only data (translates to `21 month 09 2025`) and GREEN with the fix. The full `tests/test_languages.py` suite passes (1366 passed).

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
