### PR TITLE
Support short UTC offset timezones

### DIFF
--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -73,6 +73,9 @@ def get_timezone_from_tz_string(tz_string):
     try:
         return timezone(tz_string)
     except UnknownTimeZoneError as e:
+        if re.fullmatch(r"[+-]\d{2}", tz_string):
+            tz_string = "UTC%s" % tz_string
+
         for name, info in _tz_offsets:
             if info["regex"].search(" %s" % tz_string):
                 return StaticTzInfo(name, info["offset"])

--- a/tests/test_short_utc_offsets.py
+++ b/tests/test_short_utc_offsets.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+import pytest
+
+from dateparser.utils import get_timezone_from_tz_string
+
+
+@pytest.mark.parametrize(
+    ("tz_string", "expected_offset"),
+    [
+        ("+08", timedelta(hours=8)),
+        ("-03", -timedelta(hours=3)),
+    ],
+)
+def test_two_digit_utc_offsets_without_minutes_are_supported(
+    tz_string, expected_offset
+):
+    tzinfo = get_timezone_from_tz_string(tz_string)
+
+    assert tzinfo.utcoffset(None) == expected_offset


### PR DESCRIPTION
## Summary

Support two-digit UTC offset timezone strings such as `+08` and `-03` when they are passed through timezone settings. These values are produced by Python's timezone APIs on some systems, but currently raise `UnknownTimeZoneError` while equivalent forms like `UTC+08`, `+0800`, and `+08:00` are accepted.

## Changes

- Normalize `+HH` / `-HH` timezone strings to the existing `UTC+HH` matching path.
- Add focused regression coverage for positive and negative short UTC offsets.

## Validation

- `python -m pytest tests/test_short_utc_offsets.py -q` -> `2 passed`
- Manual smoke check confirmed `dateparser.parse(..., settings={"TIMEZONE": "+08"})` and `"-03"` no longer raise.
