### PR TITLE
Reject negative cache size limits

### DIFF
--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -175,6 +175,11 @@ def _check_between_0_and_1(setting_name, setting_value):
         )
 
 
+def _check_non_negative(setting_name, setting_value):
+    if setting_value < 0:
+        raise SettingValidationError("{} cannot be negative".format(setting_name))
+
+
 def check_settings(settings):
     """
     Check if provided settings are valid, if not it raises `SettingValidationError`.
@@ -235,6 +240,7 @@ def check_settings(settings):
         },
         "CACHE_SIZE_LIMIT": {
             "type": int,
+            "extra_check": _check_non_negative,
         },
         "RETURN_TIME_SPAN": {"type": bool},
         "DEFAULT_START_OF_WEEK": {

--- a/tests/test_cache_size_limit.py
+++ b/tests/test_cache_size_limit.py
@@ -1,0 +1,12 @@
+import pytest
+
+from dateparser import DateDataParser
+from dateparser.conf import SettingValidationError
+
+
+def test_cache_size_limit_rejects_negative_values():
+    with pytest.raises(
+        SettingValidationError,
+        match="CACHE_SIZE_LIMIT cannot be negative",
+    ):
+        DateDataParser(settings={"CACHE_SIZE_LIMIT": -1})


### PR DESCRIPTION
## Summary

Reject negative `CACHE_SIZE_LIMIT` values during settings validation. The setting is used as a cache-size limit, but negative integers are currently accepted and make the cache eviction condition true immediately after entries are added.

## Changes

- Add a non-negative validation check for `CACHE_SIZE_LIMIT`.
- Add a focused regression test for negative values.
- Keep the existing behavior for `0` and positive limits unchanged.

## Validation

- `python -m pytest tests/test_cache_size_limit.py -q` -> `1 passed`
- Manual smoke check confirmed `CACHE_SIZE_LIMIT` values `0` and `1` are still accepted.
