### PR TITLE
Fix _validate_pertain_list reading from wrong dict key

### DIFF
--- a/dateparser/languages/validation.py
+++ b/dateparser/languages/validation.py
@@ -172,7 +172,7 @@ class LanguageValidator:
 
         result = True
 
-        pertain_tokens_list = info["skip"]
+        pertain_tokens_list = info["pertain"]
         if isinstance(pertain_tokens_list, list):
             for token in pertain_tokens_list:
                 if not isinstance(token, str) or not token:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2743,13 +2743,13 @@ class TestLanguageValidatorWhenInvalid(BaseTestCase):
         [
             param(
                 "en",
-                {"pertain": "it is a string", "skip": [""]},
-                log_msg="Invalid 'pertain' token '' for 'en' language: expected not empty string",
+                {"pertain": "it is a string"},
+                log_msg="Invalid 'pertain' list for 'en' language: expected list type but have got str",
             ),
             param(
                 "en",
-                {"pertain": [""], "skip": "it is a string"},
-                log_msg="Invalid 'pertain' list for 'en' language: expected list type but have got str",
+                {"pertain": [""]},
+                log_msg="Invalid 'pertain' token '' for 'en' language: expected not empty string",
             ),
         ]
     )


### PR DESCRIPTION
The `_validate_pertain_list` method was reading `info["skip"]` instead of `info["pertain"]`, meaning the actual `pertain` locale data was never validated, and the `skip` list was effectively validated twice.

**Fix:**
- Change `info["skip"]` to `info["pertain"]` in `_validate_pertain_list`

**Tests:**
- Updated the test parameters to pass the invalid data via the `pertain` key (not `skip`) so the tests actually exercise the correct validation path

This was a straightforward copy-paste error in the validation method.