### PR TITLE
fix: %j (day of year) format directive overwrote parsed month/day

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -14,6 +14,7 @@ from dateparser.languages.loader import LocaleDataLoader
 from dateparser.parser import _parse_absolute, _parse_nospaces
 from dateparser.timezone_parser import pop_tz_offset_from_string
 from dateparser.utils import (
+    _get_missing_parts,
     apply_timezone_from_settings,
     get_timezone_from_tz_string,
     set_correct_day_from_settings,
@@ -187,8 +188,9 @@ def parse_with_formats(date_string, date_formats, settings):
         except ValueError:
             continue
         else:
-            missing_month = not any(m in date_format for m in ["%m", "%b", "%B"])
-            missing_day = "%d" not in date_format
+            _missing = _get_missing_parts(date_format)
+            missing_month = "month" in _missing
+            missing_day = "day" in _missing
             if missing_month and missing_day:
                 period = "year"
                 date_obj = set_correct_month_from_settings(date_obj, settings)

--- a/dateparser/utils/__init__.py
+++ b/dateparser/utils/__init__.py
@@ -57,7 +57,9 @@ def _get_missing_parts(fmt):
     """
     directive_mapping = {
         "day": ["%d", "%-d", "%j", "%-j"],
-        "month": ["%b", "%B", "%m", "%-m"],
+        # %j (day of year) encodes month implicitly: a successful strptime with %j always
+        # populates the month field, so %j should count as providing month information.
+        "month": ["%b", "%B", "%m", "%-m", "%j", "%-j"],
         "year": ["%y", "%-y", "%Y"],
     }
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -377,6 +377,34 @@ class TestParseWithFormatsFunction(BaseTestCase):
     @parameterized.expand(
         [
             param(
+                date_string="2023-100",
+                date_formats=["%Y-%j"],
+                expected_result=datetime(2023, 4, 10),
+            ),
+            param(
+                date_string="2024-060",
+                date_formats=["%Y-%j"],
+                expected_result=datetime(2024, 2, 29),
+            ),
+            param(
+                date_string="2023 060",
+                date_formats=["%Y %j"],
+                expected_result=datetime(2023, 3, 1),
+            ),
+        ]
+    )
+    def test_should_parse_day_of_year_format(
+        self, date_string, date_formats, expected_result
+    ):
+        """Format %%j (day of year) should correctly set both month and day."""
+        self.when_date_is_parsed_with_formats(date_string, date_formats)
+        self.then_date_was_parsed()
+        self.then_parsed_period_is("day")
+        self.then_parsed_date_is(expected_result)
+
+    @parameterized.expand(
+        [
+            param(
                 date_string="09.16",
                 date_formats=["%m.%d"],
                 expected_month=9,


### PR DESCRIPTION
## Bug

When a format string passed to `parse_with_formats` (via `dateparser.parse(..., date_formats=[...])` or `DateDataParser.get_date_data(..., date_formats=[...])`) contained `%j` (day of year), the correctly-parsed month and day were silently replaced with today's date:

```python
import dateparser

# Day 100 of 2023 is April 10
dateparser.parse("2023-100", date_formats=["%Y-%j"])
# Before fix: datetime(2023, 6, 25)  ← today, wrong
# After fix:  datetime(2023, 4, 10)  ← correct
```

This also affects `%-j` (no-padding variant).

## Root cause

`parse_with_formats` computed:

```python
missing_month = not any(m in date_format for m in ["%m", "%b", "%B"])
missing_day = "%d" not in date_format
```

Neither check recognises `%j`. A successful `strptime` call with `%j` always populates both the `month` and `day` fields in the returned `datetime` object, so the parsed values should be kept as-is.

The existing `_get_missing_parts` helper in `dateparser/utils/__init__.py` already listed `%j` and `%-j` under the `"day"` directive, but not under `"month"`. This was a secondary inconsistency: since `%j` encodes a day-of-year that uniquely determines the month, it implicitly provides month information.

## Fix

1. Add `%j` and `%-j` to the `"month"` directive list in `_get_missing_parts`.
2. Replace the ad-hoc `missing_month`/`missing_day` expressions in `parse_with_formats` with a single `_get_missing_parts` call, which is the authoritative and already-tested source for this logic.

All 22 703 existing tests continue to pass. Three new regression tests are included.

---

This pull request was prepared with the assistance of AI, under my direction and review.