### PR TITLE
fix: don't invent a day under STRICT_PARSING

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -368,12 +368,21 @@ class _parser:
         params = {}
         for attr in known:
             params.update({attr: getattr(self, attr)})
+        # A leftover numeric token can back-fill a missing component, but under
+        # STRICT_PARSING/REQUIRE_PARTS one token must not stand in for several of
+        # them, otherwise an incomplete date such as "MM/YYYY" invents the parts
+        # it lacks instead of being rejected.
+        enforce_parts = self.settings.STRICT_PARSING or self.settings.REQUIRE_PARTS
+        available_tokens = [
+            token for token, token_type, _ in self.unset_tokens if token_type == 0
+        ]
         for attr in unknown:
-            for token, type, _ in self.unset_tokens:
-                if type == 0:
-                    params.update({attr: int(token)})
-                    setattr(self, "_token_%s" % attr, token)
-                    setattr(self, attr, int(token))
+            if not available_tokens:
+                break
+            token = available_tokens.pop(0) if enforce_parts else available_tokens[-1]
+            params.update({attr: int(token)})
+            setattr(self, "_token_%s" % attr, token)
+            setattr(self, attr, int(token))
 
     def _get_period(self):
         if self.settings.RETURN_TIME_AS_PERIOD:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -293,6 +293,27 @@ def test_no_spaces_strict_parsing(date_string, expected_result):
     assert parser.get_date_data(date_string)["date_obj"] is None
 
 
+@pytest.mark.parametrize("languages", [["zh"], ["en"], None])
+def test_strict_parsing_rejects_month_and_year_without_day(languages):
+    # Regression test for #850: a YMD locale (zh) left a spare token that
+    # back-filled the missing day, so STRICT_PARSING wrongly accepted "10/2017".
+    assert (
+        parse("10/2017", languages=languages, settings={"STRICT_PARSING": True}) is None
+    )
+
+
+def test_require_parts_rejects_month_and_year_without_day():
+    # Same #850 reuse path, reached through REQUIRE_PARTS.
+    assert (
+        parse(
+            "10/2017",
+            languages=["zh"],
+            settings={"REQUIRE_PARTS": ["day", "month", "year"]},
+        )
+        is None
+    )
+
+
 def detect_languages(text, confidence_threshold):
     if confidence_threshold > 0.5:
         return ["en"]


### PR DESCRIPTION
`parse("10/2017", settings={"STRICT_PARSING": True})` gives `2017-10-10` instead of `None`. Only for YMD locales like `zh` (`en` is already fine).

What happens: "10/2017" leaves one spare token ("10") and the back-fill reuses it for both the missing month and day, so the date looks complete and the strict check never fires.

Fix: under `STRICT_PARSING`/`REQUIRE_PARTS`, use each leftover token only once. Day stays unset, so it's rejected.

Kept it scoped to the strict path so non-strict output doesn't change (`zh` still gives `2017-10-10`). Wider fix would stop the reuse everywhere and match `en` at `2017-10-02`, but that shifts default behavior, so your call. Happy to widen it.

Tests at the `parse()` level, fail on master, pass here.

Fixes #850
