### PR TITLE
fix: parse dates with a numeric offset and redundant tz abbreviation (#1227)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 =======
 
+1.4.2 (unreleased)
+------------------
+
+Fixes:
+
+- Parse RFC 2822 email dates that carry both a numeric UTC offset and a
+  redundant, equivalent timezone abbreviation in parentheses, such as
+  "Thu, 30 May 2024 10:13:10 -0500 (CDT)" (#1227)
+
 1.4.1 (2026-06-15)
 ------------------
 

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -31,19 +31,44 @@ class StaticTzInfo(tzinfo):
         return self.__name, self.__offset
 
 
+def _search_and_pop_tz(date_string):
+    """Find and remove the first timezone token from ``date_string``.
+
+    Returns a ``(new_string, name, info)`` tuple, or ``None`` if no timezone
+    token is present.
+    """
+    if not _search_regex_ignorecase.search(date_string):
+        return None
+    for name, info in _tz_offsets:
+        timezone_match = info["regex"].search(date_string)
+        if timezone_match:
+            start, stop = timezone_match.span()
+            return date_string[: start + 1] + date_string[stop:], name, info
+    return None
+
+
 def pop_tz_offset_from_string(date_string, as_offset=True):
-    if _search_regex_ignorecase.search(date_string):
-        for name, info in _tz_offsets:
-            timezone_re = info["regex"]
-            timezone_match = timezone_re.search(date_string)
-            if timezone_match:
-                start, stop = timezone_match.span()
-                date_string = date_string[: start + 1] + date_string[stop:]
-                return (
-                    date_string,
-                    StaticTzInfo(name, info["offset"]) if as_offset else name,
-                )
-    return date_string, None
+    match = _search_and_pop_tz(date_string)
+    if match is None:
+        return date_string, None
+
+    date_string, name, info = match
+    result = StaticTzInfo(name, info["offset"]) if as_offset else name
+
+    # A date string may carry both a numeric UTC offset and a redundant,
+    # equivalent timezone abbreviation, e.g. the RFC 2822 email form
+    # ``-0500 (CDT)`` (the parenthesised name is informational and the numeric
+    # offset is authoritative). Only one token is removed above; strip a second,
+    # equivalent one so the leftover does not break the rest of the parser.
+    # The remainder is right-stripped first because the numeric-offset regexes
+    # are anchored at the end of the string.
+    while True:
+        extra = _search_and_pop_tz(date_string.rstrip())
+        if extra is None or extra[2]["offset"] != info["offset"]:
+            break
+        date_string = extra[0]
+
+    return date_string, result
 
 
 def word_is_tz(word):

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -547,6 +547,20 @@ class TestDateParser(BaseTestCase):
                 "Fri Sep 23 2016 10:34:51 GMT+0800 (CST)",
                 datetime(2016, 9, 23, 2, 34, 51),
             ),
+            # RFC 2822 email dates carry a numeric offset plus a redundant,
+            # equivalent timezone abbreviation in parentheses (#1227).
+            param(
+                "Thu, 30 May 2024 10:13:10 -0500 (CDT)",
+                datetime(2024, 5, 30, 15, 13, 10),
+            ),
+            param(
+                "30 May 2024 10:13:10 -0500 CDT",
+                datetime(2024, 5, 30, 15, 13, 10),
+            ),
+            param(
+                "Mon, 15 Jan 2024 09:30:00 +0000 (UTC)",
+                datetime(2024, 1, 15, 9, 30, 0),
+            ),
         ]
     )
     def test_parsing_with_utc_offsets(self, date_string, expected):

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -86,6 +86,14 @@ class TestTZPopping(BaseTestCase):
                 "17th October, 2034 @ 01:08 am +0700", "17th October, 2034 @ 01:08 am "
             ),
             param("Sep 03 2014 4:32 pm +0630", "Sep 03 2014 4:32 pm "),
+            param(
+                "Thu 30 May 2024 10:13:10 -0500 CDT",
+                "Thu 30 May 2024 10:13:10 ",
+            ),
+            param(
+                "Thu 30 May 2024 10:13:10 CDT -0500",
+                "Thu 30 May 2024 10:13:10 ",
+            ),
         ]
     )
     def test_timezone_deleted_from_string(self, initial_string, result_string):


### PR DESCRIPTION
## Summary

Fixes #1227. `dateparser.parse` returned `None` for RFC 2822 email dates that
carry both a numeric UTC offset and a redundant, equivalent timezone
abbreviation in parentheses:

```python
>>> import dateparser
>>> dateparser.parse("Thu 30 May 2024 10:13:10 -0500 (CDT)")  # before: None
datetime.datetime(2024, 5, 30, 10, 13, 10, tzinfo=<StaticTzInfo '-05:00'>)
```

Python's own `email.utils.parsedate_to_datetime` parses this string fine, so
dateparser silently failing on a very common email-header form is surprising.

## Root cause

`dateparser.utils.strip_braces` turns `(CDT)` into a bare `CDT` token, so the
string reaching the timezone step contains **two** timezone tokens:
`-0500` and `CDT`. `pop_tz_offset_from_string` removed only the **first** token
it matched (`CDT`), leaving the numeric `-0500` stranded in the string. The
absolute parser then choked on the leftover (`ValueError: Unable to parse:
0500`) and the whole parse returned `None`.

The equivalent GMT-prefixed form already worked:

```python
>>> dateparser.parse("Fri Sep 23 2016 10:34:51 GMT+0800 (CST)")
datetime.datetime(2016, 9, 23, 10, 34, 51, tzinfo=<StaticTzInfo '+08:00'>)
```

...but only by accident: the offset regex for the `GMT+0800` form is
`(?:UTC|GMT)\+08:?00.*$`, whose trailing `.*$` greedily swallows the
` CST` abbreviation, so both tokens are consumed by one match. A **bare**
numeric offset like `-0500` has no such spanning regex, so its redundant
abbreviation is orphaned.

## Fix

After removing the first timezone token, strip a second, adjacent token too
**when it denotes the same UTC offset** — the parenthesised abbreviation is
purely informational and the numeric offset is authoritative (this matches
`email.utils`). A *conflicting* second timezone is deliberately left in place,
so existing behavior is preserved for contradictory input. The remainder is
right-stripped before the follow-up search because the numeric-offset regexes
are anchored at the end of the string.

The change is behavior-preserving for every existing case: I verified the new
`pop_tz_offset_from_string` returns byte-identical `(string, offset)` results
to the old implementation across all 40 inputs in the existing
`test_extracting_valid_offset` suite plus assorted trailing-whitespace edge
cases.

### Before / after

| input | before | after |
|---|---|---|
| `Thu, 30 May 2024 10:13:10 -0500 (CDT)` | `None` | `2024-05-30 10:13:10-05:00` |
| `30 May 2024 10:13:10 -0500 CDT` | `None` | `2024-05-30 10:13:10-05:00` |
| `30 May 2024 10:13:10 CDT -0500` | `None` | `2024-05-30 10:13:10-05:00` |
| `Mon, 15 Jan 2024 09:30:00 +0000 (UTC)` | `None` | `2024-01-15 09:30:00+00:00` |
| `Fri Sep 23 2016 10:34:51 GMT+0800 (CST)` | `2016-09-23 10:34:51+08:00` | *unchanged* |
| `30 May 2024 10:13:10 -0500 CST` (conflicting) | `None` | `None` *(unchanged)* |

## Tests

Added regression coverage at two levels:

- `tests/test_timezone_parser.py::TestTZPopping::test_timezone_deleted_from_string`
  — both token orderings (`-0500 CDT` and `CDT -0500`) must leave the string
  clean.
- `tests/test_date_parser.py::TestDateParser::test_parsing_with_utc_offsets`
  — full-parse cases converted to UTC (the reported string plus a `+0000
  (UTC)` variant).

Each new case fails on `master` and passes with the fix (verified by stashing
only the source change):

```
# without the source fix:
5 failed, 14 passed
FAILED ...test_timezone_deleted_from_string_8_...0500_CDT
FAILED ...test_timezone_deleted_from_string_9_...CDT_0500
FAILED ...test_parsing_with_utc_offsets_6_...0500_CDT_
FAILED ...test_parsing_with_utc_offsets_7_...0500_CDT
FAILED ...test_parsing_with_utc_offsets_8_...0000_UTC_

# with the fix:
19 passed
```

Full suite green with the fix: `24205 passed, 1 skipped, 1 xfailed`
(baseline was `24200 passed` + 5 new cases). `ruff check` and `ruff format
--check` are clean on all changed files.
