### PR TITLE
Add 'w' as an English abbreviation for 'week' (#1257)

### DIFF
--- a/dateparser/data/date_translation_data/en.py
+++ b/dateparser/data/date_translation_data/en.py
@@ -105,6 +105,7 @@ info = {
     "week": [
         "week",
         "wk",
+        "w",
         "weeks"
     ],
     "day": [

--- a/dateparser_data/supplementary_language_data/date_translation_data/en.yaml
+++ b/dateparser_data/supplementary_language_data/date_translation_data/en.yaml
@@ -37,6 +37,7 @@ year:
 month:
     - months
 week:
+    - w
     - weeks
 day:
     - d

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -135,6 +135,9 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("six days ago", ago={"days": 6}, period="day"),
             param("five years ago", ago={"years": 5}, period="year"),
             param("2y ago", ago={"years": 2}, period="year"),
+            # Single-letter week abbreviation (#1257)
+            param("1w ago", ago={"weeks": 1}, period="week"),
+            param("2w ago", ago={"weeks": 2}, period="week"),
             # Fractional units
             param("2.5 hours", ago={"hours": 2.5}, period="day"),
             param("10.75 minutes", ago={"minutes": 10.75}, period="day"),


### PR DESCRIPTION
Fixes #1257.

## Problem

`"1w ago"` returns `None`, even though the full word and every other single-letter unit abbreviation work:

```python
>>> dateparser.parse("1w ago")     # None
>>> dateparser.parse("1week ago")  # works
>>> dateparser.parse("1d ago")     # works (day)
>>> dateparser.parse("1h ago")     # works (hour)
>>> dateparser.parse("1m ago")     # works (minute)
>>> dateparser.parse("1s ago")     # works (second)
>>> dateparser.parse("1y ago")     # works (year)
```

Every relative-time unit had a single-letter abbreviation **except week**: in the English translation data, `day` has `d`, `hour` has `h`, `minute` has `m`, `second` has `s`, `year` has `y`, but `week` only had `week`/`wk`/`weeks`.

## Fix

Add `w` to the English `week` translation data in `dateparser_data/supplementary_language_data/date_translation_data/en.yaml` and regenerate `dateparser/data/date_translation_data/en.py` with `dateparser_scripts/write_complete_data.py`.

`month` intentionally keeps no single-letter form (since `m` already means minute), but `w` is unambiguous, so this fills a genuine gap rather than introducing a conflict.

```python
>>> dateparser.parse("1w ago")   # 7 days ago
>>> dateparser.parse("2w ago")   # 14 days ago
>>> dateparser.parse("in 2w")    # 14 days in the future
```

## Testing

- Added `"1w ago"` / `"2w ago"` cases to `tests/test_freshness_date_parser.py` (next to the existing `"2y ago"` abbreviation case). They fail on `main` and pass with this change.
- Full `tests/test_freshness_date_parser.py` (1057) and `tests/test_search.py` (244) pass — no regressions.
- `ruff check` / `ruff format --check` clean on the changed files.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I reproduced the issue, made the data change and regenerated `en.py` with the project's own script, verified the fix and the test run, and take responsibility for the contribution and will respond to review feedback personally.*
