### PR TITLE
Honor PREFER_DATES_FROM for a date_formats entry with no year

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -177,22 +177,23 @@ def get_date_from_timestamp(date_string, settings, negative=False):
         return date_obj
 
 
-def _apply_century_preference(date_obj, now, prefer_from):
-    """Shift *date_obj* by ±100 years to satisfy PREFER_DATES_FROM.
+def _apply_year_preference(date_obj, now, prefer_from, years):
+    """Shift *date_obj* by ±*years* to satisfy PREFER_DATES_FROM.
 
-    *now* is normalised to naive so a tz-aware RELATIVE_BASE does not raise
-    TypeError.  When the shifted year falls on Feb 29 in a non-leap year, the
-    nearest valid leap year in the preferred direction is used — matching the
-    behaviour of the NLP path in ``parser.py``.
+    Used with ``years=100`` for a two-digit-year format and ``years=1`` for a
+    format with no year at all.  *now* is normalised to naive so a tz-aware
+    RELATIVE_BASE does not raise TypeError.  When the shifted year falls on
+    Feb 29 in a non-leap year, the nearest valid leap year in the preferred
+    direction is used — matching the behaviour of the NLP path in ``parser.py``.
 
     Returns the adjusted datetime, or the original when no shift is needed.
     """
     now_naive = now.replace(tzinfo=None) if now.tzinfo is not None else now
 
     if now_naive < date_obj and prefer_from == "past":
-        target_year = date_obj.year - 100
+        target_year = date_obj.year - years
     elif now_naive >= date_obj and prefer_from == "future":
-        target_year = date_obj.year + 100
+        target_year = date_obj.year + years
     else:
         return date_obj
 
@@ -242,9 +243,12 @@ def parse_with_formats(date_string, date_formats, settings):
             )
             if not ("%y" in date_format or "%Y" in date_format):
                 date_obj = date_obj.replace(year=now.year)
+                date_obj = _apply_year_preference(
+                    date_obj, now, settings.PREFER_DATES_FROM, 1
+                )
             elif "%y" in date_format and "%Y" not in date_format:
-                date_obj = _apply_century_preference(
-                    date_obj, now, settings.PREFER_DATES_FROM
+                date_obj = _apply_year_preference(
+                    date_obj, now, settings.PREFER_DATES_FROM, 100
                 )
 
             date_obj = apply_timezone_from_settings(date_obj, settings)

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -712,6 +712,27 @@ class TestDateParser(BaseTestCase):
 
     @parameterized.expand(
         [
+            param("December 25", "past", datetime(2026, 6, 15), datetime(2025, 12, 25)),
+            param("March 10", "future", datetime(2026, 6, 15), datetime(2027, 3, 10)),
+        ]
+    )
+    def test_prefer_dates_from_with_yearless_format(
+        self, date_string, prefer_from, relative_base, expected
+    ):
+        # PREFER_DATES_FROM must apply to a date_formats entry that has no year
+        # directive, not only to the two-digit-year case.
+        result = parse(
+            date_string,
+            date_formats=["%B %d"],
+            settings={
+                "PREFER_DATES_FROM": prefer_from,
+                "RELATIVE_BASE": relative_base,
+            },
+        )
+        self.assertEqual(result, expected)
+
+    @parameterized.expand(
+        [
             param("29 Feb", datetime(2020, 1, 1), datetime(2020, 2, 29)),
             param("29/02", datetime(2020, 3, 30), datetime(2020, 2, 29)),
             param("29 Feb", datetime(1702, 3, 1), datetime(1704, 2, 29)),


### PR DESCRIPTION
`parse_with_formats` applied `PREFER_DATES_FROM` only to a two-digit-year format
(through `_apply_century_preference`, added in #1342). A `date_formats` entry
with no year directive at all took the current year unconditionally:

```python
import dateparser
from datetime import datetime
RB = datetime(2026, 6, 15)

dateparser.parse("December 25", date_formats=["%B %d"],
                 settings={"RELATIVE_BASE": RB, "PREFER_DATES_FROM": "past"})
# -> 2026-12-25   (a future date, under PREFER_DATES_FROM="past")
```

The result contradicts the setting, and disagrees with the NLP path, which
parses the same string+settings correctly to `2025-12-25`. `docs/settings.rst`
states `PREFER_DATES_FROM` applies "if date string is missing some part" (its
example omits the year), with no carve-out for `date_formats`. This is the
other half of #1342 — that PR wired the setting into the adjacent two-digit-year
branch but left the year-less branch.

Fix: generalise the `#1342` helper to shift by ±N years and call it with `1`
for the year-less branch (`100` stays for the two-digit branch), so both share
the same direction logic and Feb-29 leap-year handling. Added a regression test.

---
This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug, ran the repro, wrote the test, and wrote this description.
The human account holder reviews every change and is accountable for it. The
verification is real and re-runnable from the diff. If this isn't the kind of
contribution you want, say so and I'll close it.
