### PR TITLE
Add "ngram" search strategy to search_dates

### DIFF
--- a/dateparser/search/__init__.py
+++ b/dateparser/search/__init__.py
@@ -9,6 +9,7 @@ def search_dates(
     settings=None,
     add_detected_language=False,
     detect_languages_function=None,
+    strategy="split",
 ):
     """Find all substrings of the given string which represent date and/or time and parse them.
 
@@ -34,6 +35,13 @@ def search_dates(
         and returns a list of detected language codes.
         Note: detect_languages_function is only uses if `languages` are not provided.
     :type detect_languages_function: function
+
+    :param strategy:
+        The search strategy to use: "split" (default) translates the text and splits it
+        into chunks that are likely to contain dates, while "ngram" tries to parse the
+        longest possible sequences of tokens as dates. The "ngram" strategy tends to
+        produce more predictable results, at the cost of more parse attempts.
+    :type strategy: str
 
     :return: Returns list of tuples containing:
         substrings representing date and/or time, corresponding :mod:`datetime.datetime`
@@ -64,6 +72,7 @@ def search_dates(
         languages=languages,
         settings=settings,
         detect_languages_function=detect_languages_function,
+        strategy=strategy,
     )
     dates = result.get("Dates")
     if dates:

--- a/dateparser/search/ngram_search.py
+++ b/dateparser/search/ngram_search.py
@@ -1,0 +1,107 @@
+"""Date search based on parsing token n-grams.
+
+This module implements an alternative strategy for
+:func:`dateparser.search.search_dates` that looks for the longest sequences
+of tokens that can be parsed as dates. It originates from a production date
+extraction pipeline where it consistently produced more predictable results
+than the translation-based search.
+"""
+
+import logging
+
+import regex as re
+
+from dateparser.date import DateDataParser
+
+logger = logging.getLogger(__name__)
+
+# Characters that never occur inside a date expression and can therefore be
+# used to split a text into tokens. Unlike whitespace, ",", "|", "(", ")"
+# and "@", characters such as ".", "/", "-" and ":" *can* be part of a date
+# (e.g. "1.10.2020", "2020-10-01", "10:30") and must not be split on.
+_TOKEN_RE = re.compile(r"[^\s,|()@]+")
+
+# Words that often connect a date to the surrounding text and cause
+# annoying false positives; dropping them allows parsing token sequences
+# such as "on May 6th 2004" or "6 of October".
+_NOISE_TOKENS = frozenset(["on", "at", "of", "a"])
+
+# Whole candidates that are blacklisted because they are known to produce
+# false positives. They can still be parsed as part of a longer candidate.
+_BAD_CANDIDATE_RE = re.compile(
+    "^("
+    + "|".join(
+        [
+            r"\d{1,3}",  # bare numbers of less than 4 digits
+            r"#\d+",  # sequence numbers
+            r"[-/.]+",  # bare separators, parsed as the current date
+            r"\w\.?",  # single letters, with an optional dot
+            "an",  # parsed as a year in some languages
+        ]
+    )
+    + ")$"
+)
+
+# Punctuation stripped from the returned substrings, matching the behavior
+# of the translation-based search strategy.
+_STRIP_CHARS = " .,:()[]-'"
+
+
+class _NgramDateSearch:
+    """Search for dates by trying to parse token n-grams, longest first.
+
+    The text is split into tokens using characters that never occur inside
+    a date expression as separators. The tokens are then scanned left to
+    right; at each position the longest n-gram (up to ``max_tokens``
+    tokens) is tried first, so that the most complete date is parsed.
+    Whenever an n-gram is parsed successfully, the scan continues after it,
+    so the reported dates never overlap.
+    """
+
+    def __init__(self, max_tokens=7):
+        self.max_tokens = max_tokens
+
+    def search_parse(self, languages, text, settings):
+        """Find all dates in ``text`` and return ``(substring, date)`` pairs.
+
+        ``languages`` are tried in the given order for every candidate
+        n-gram.
+        """
+        parser = DateDataParser(
+            languages=languages, use_given_order=True, settings=settings
+        )
+        tokens = [
+            token
+            for token in _TOKEN_RE.finditer(text)
+            if token.group() not in _NOISE_TOKENS
+        ]
+        results = []
+        index = 0
+        while index < len(tokens):
+            for size in range(min(self.max_tokens, len(tokens) - index), 0, -1):
+                ngram = tokens[index : index + size]
+                candidate = " ".join(token.group() for token in ngram)
+                if _BAD_CANDIDATE_RE.match(candidate):
+                    continue
+                date_obj = self._parse_candidate(parser, candidate, languages)
+                if date_obj is not None:
+                    substring = text[ngram[0].start() : ngram[-1].end()]
+                    results.append((substring.strip(_STRIP_CHARS), date_obj))
+                    index += size
+                    break
+            else:
+                index += 1
+        return results
+
+    @staticmethod
+    def _parse_candidate(parser, candidate, languages):
+        try:
+            return parser.get_date_data(candidate).date_obj
+        except Exception:
+            logger.warning(
+                "Failed to parse %r (languages=%r)",
+                candidate,
+                languages,
+                exc_info=True,
+            )
+            return None

--- a/dateparser/search/search.py
+++ b/dateparser/search/search.py
@@ -7,6 +7,7 @@ from dateparser.conf import Settings, apply_settings, check_settings
 from dateparser.custom_language_detection.language_mapping import map_languages
 from dateparser.date import DateDataParser
 from dateparser.languages.loader import LocaleDataLoader
+from dateparser.search.ngram_search import _NgramDateSearch
 from dateparser.search.text_detection import FullTextLanguageDetector
 from dateparser.utils.time_spans import detect_time_span, generate_time_span
 
@@ -15,6 +16,19 @@ RELATIVE_REG = re.compile("(ago|in|from now|tomorrow|today|yesterday)")
 
 def date_is_relative(translation):
     return re.search(RELATIVE_REG, translation) is not None
+
+
+def _add_time_span_results(results, text, settings):
+    """Append time span start/end dates if RETURN_TIME_SPAN is enabled."""
+    if getattr(settings, "RETURN_TIME_SPAN", False):
+        span_info = detect_time_span(text)
+        if span_info:
+            base_date = getattr(settings, "RELATIVE_BASE", None) or datetime.now()
+            start_date, end_date = generate_time_span(span_info, base_date, settings)
+            matched_text = span_info["matched_text"]
+            results.append((matched_text + " (start)", start_date))
+            results.append((matched_text + " (end)", end_date))
+    return results
 
 
 class _ExactLanguageSearch:
@@ -190,17 +204,7 @@ class _ExactLanguageSearch:
 
         results = list(zip(substrings, [i[0]["date_obj"] for i in parsed]))
 
-        if getattr(settings, "RETURN_TIME_SPAN", False):
-            span_info = detect_time_span(text)
-            if span_info:
-                base_date = getattr(settings, "RELATIVE_BASE", None) or datetime.now()
-                start_date, end_date = generate_time_span(
-                    span_info, base_date, settings
-                )
-
-                matched_text = span_info["matched_text"]
-                results.append((matched_text + " (start)", start_date))
-                results.append((matched_text + " (end)", end_date))
+        _add_time_span_results(results, text, settings)
 
         parser._settings = Settings()
         return results
@@ -217,6 +221,7 @@ class DateSearchWithDetection:
         self.loader = LocaleDataLoader()
         self.available_language_map = self.loader.get_locale_map()
         self.search = _ExactLanguageSearch(self.loader)
+        self.ngram_search = _NgramDateSearch()
 
     def _get_candidate_languages(self, detected_language, languages):
         candidates = []
@@ -279,7 +284,12 @@ class DateSearchWithDetection:
 
     @apply_settings
     def search_dates(
-        self, text, languages=None, settings=None, detect_languages_function=None
+        self,
+        text,
+        languages=None,
+        settings=None,
+        detect_languages_function=None,
+        strategy="split",
     ):
         """
         Find all substrings of the given string which represent date and/or time and parse them.
@@ -302,6 +312,13 @@ class DateSearchWithDetection:
                returns a list of detected language codes.
         :type detect_languages_function: function
 
+        :param strategy:
+               The search strategy to use: "split" (default) translates the text and splits it
+               into chunks that are likely to contain dates, while "ngram" tries to parse the
+               longest possible sequences of tokens as dates. The "ngram" strategy tends to
+               produce more predictable results, at the cost of more parse attempts.
+        :type strategy: str
+
         :return: a dict mapping keys to two letter language code and a list of tuples of pairs:
                 substring representing date expressions and corresponding :mod:`datetime.datetime` object.
             For example:
@@ -310,6 +327,10 @@ class DateSearchWithDetection:
             {'Language': None, 'Dates': None}
         :raises: ValueError - Unknown Language
         """
+        if strategy not in ("split", "ngram"):
+            raise ValueError(
+                'strategy must be "split" or "ngram" (%r given)' % strategy
+            )
 
         check_settings(settings)
 
@@ -325,6 +346,13 @@ class DateSearchWithDetection:
         )
         if not candidate_languages:
             return {"Language": None, "Dates": None}
+
+        if strategy == "ngram":
+            dates = self.ngram_search.search_parse(
+                candidate_languages, text, settings=settings
+            )
+            _add_time_span_results(dates, text, settings)
+            return {"Language": language_shortname, "Dates": dates}
 
         for candidate_language in candidate_languages:
             dates = self.search.search_parse(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1339,3 +1339,118 @@ class TestTranslateSearch(BaseTestCase):
         if result:
             span_results = [r for r in result if "(start)" in r[0] or "(end)" in r[0]]
             self.assertEqual(len(span_results), 0)
+
+
+class TestNgramSearch(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.search_with_detection = DateSearchWithDetection()
+
+    @parameterized.expand(
+        [
+            # noise words ("on") are not part of the returned substring and
+            # trailing punctuation is stripped
+            param(
+                "en",
+                text="The first artificial Earth satellite was launched"
+                " on 4 October 1957.",
+                expected=[("4 October 1957", datetime.datetime(1957, 10, 4))],
+            ),
+            # all non-overlapping dates are returned, longest match first
+            param(
+                "en",
+                text="The client arrived to the office for the first time"
+                " in March 3rd, 2004 and got serviced, after a couple of months,"
+                " on May 6th 2004, the customer returned indicating a defect on"
+                " the part",
+                expected=[
+                    ("in March 3rd, 2004 and", datetime.datetime(2004, 3, 3)),
+                    ("May 6th 2004, the", datetime.datetime(2004, 5, 6)),
+                ],
+            ),
+            # bare small numbers are blacklisted and do not produce dates
+            param("en", text="Chapter 12, page 3", expected=[]),
+            # French
+            param(
+                "fr",
+                text="Publié le 11 juillet 2016",
+                expected=[("le 11 juillet 2016", datetime.datetime(2016, 7, 11))],
+            ),
+            param(
+                "fr",
+                text="Le premier satellite artificiel, lancé le 4 octobre 1957,"
+                " pesait 83 kg",
+                expected=[("le 4 octobre 1957", datetime.datetime(1957, 10, 4))],
+            ),
+            # Russian
+            param(
+                "ru",
+                text="веб-страница обновлена 11 июля 2016 года",
+                expected=[("11 июля 2016 года", datetime.datetime(2016, 7, 11))],
+            ),
+        ]
+    )
+    def test_ngram_search(self, shortname, text, expected):
+        result = self.search_with_detection.search_dates(
+            text, languages=[shortname], strategy="ngram"
+        )
+        self.assertEqual(result["Language"], shortname)
+        self.assertEqual(result["Dates"], expected)
+
+    def test_ngram_search_with_relative_base(self):
+        result = self.search_with_detection.search_dates(
+            "posted 10 minutes ago",
+            languages=["en"],
+            settings={"RELATIVE_BASE": datetime.datetime(2020, 1, 1, 12, 0)},
+            strategy="ngram",
+        )
+        self.assertEqual(
+            result["Dates"],
+            [("10 minutes ago", datetime.datetime(2020, 1, 1, 11, 50))],
+        )
+
+    def test_ngram_search_returns_time_spans(self):
+        result = self.search_with_detection.search_dates(
+            "messages received for the past week",
+            languages=["en"],
+            settings={
+                "RETURN_TIME_SPAN": True,
+                "RELATIVE_BASE": datetime.datetime(2025, 2, 15, 12, 0),
+            },
+            strategy="ngram",
+        )
+        self.assertEqual(
+            result["Dates"],
+            [
+                ("for the past week (start)", datetime.datetime(2025, 2, 3, 12, 0)),
+                ("for the past week (end)", datetime.datetime(2025, 2, 9, 12, 0)),
+            ],
+        )
+
+    def test_search_dates_with_ngram_strategy(self):
+        result = search_dates(
+            "launched on 4 October 1957", languages=["en"], strategy="ngram"
+        )
+        self.assertEqual(result, [("4 October 1957", datetime.datetime(1957, 10, 4))])
+
+    def test_search_dates_with_ngram_strategy_and_detected_language(self):
+        result = search_dates(
+            "launched on 4 October 1957",
+            languages=["en"],
+            strategy="ngram",
+            add_detected_language=True,
+        )
+        self.assertEqual(
+            result, [("4 October 1957", datetime.datetime(1957, 10, 4), "en")]
+        )
+
+    def test_search_dates_ngram_strategy_returns_none_when_no_dates_found(self):
+        self.assertIsNone(
+            search_dates(
+                "Hello world nothing here at all", languages=["en"], strategy="ngram"
+            )
+        )
+
+    def test_unknown_strategy_raises_error(self):
+        with self.assertRaisesRegex(ValueError, "strategy must be"):
+            search_dates("4 October 1957", languages=["en"], strategy="unknown")


### PR DESCRIPTION
The new strategy tokenizes the text on characters that never occur inside a date expression and tries to parse token n-grams, longest first, so that the most complete date is found. Compared to the default translation-based "split" strategy it produces more predictable results on noisy real-world text.

The strategy is exposed through the new "strategy" parameter of search_dates and defaults to the existing behavior.