### PR TITLE
Fix ISO8601 parsing with explicit languages

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -633,7 +633,23 @@ class _parser:
         def parse_number(token, skip_component=None):
             type = 0
 
-            for component, directives in self.ordered_num_directives.items():
+            num_directives = self.ordered_num_directives
+            if (
+                skip_component == "year"
+                and self.day is None
+                and self.month is None
+                and "DATE_ORDER" not in self.settings._mod_settings
+            ):
+                # The date string starts with a four-digit year (e.g. an
+                # ISO 8601 date like "2017-06-22"), so the remaining numeric
+                # components are expected in month-day order, regardless of
+                # the locale date order, unless the caller explicitly set
+                # DATE_ORDER (#360).
+                num_directives = {
+                    k: self.num_directives[k] for k in ("month", "day", "year")
+                }
+
+            for component, directives in num_directives.items():
                 if skip_component == component:
                     continue
                 for directive in directives:

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -931,6 +931,32 @@ class TestDateParser(BaseTestCase):
 
     @parameterized.expand(
         [
+            param("2017-06-22", languages=["it"], expected=datetime(2017, 6, 22)),
+            param("2017-06-10", languages=["it"], expected=datetime(2017, 6, 10)),
+            param("2017-06-22", languages=["fr"], expected=datetime(2017, 6, 22)),
+            param(
+                "2015-05-02T10:20:19+0000",
+                languages=["fr"],
+                expected=datetime(2015, 5, 2, 10, 20, 19),
+            ),
+        ]
+    )
+    def test_iso_datestamp_format_should_parse_with_locale_date_order(
+        self, date_string, languages, expected
+    ):
+        # Regression test for #360: dates starting with a four-digit year
+        # (e.g. ISO 8601 dates) must parse even when the locale date order
+        # is not year-first (Italian and French use DMY), without needing
+        # the PREFER_LOCALE_DATE_ORDER=False workaround.
+        self.given_local_tz_offset(0)
+        self.given_parser(languages=languages)
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.result["date_obj"] = self.result["date_obj"].replace(tzinfo=None)
+        self.then_date_obj_exactly_is(expected)
+
+    @parameterized.expand(
+        [
             # Epoch timestamps.
             param("1484823450", expected=datetime(2017, 1, 19, 10, 57, 30)),
             param("1436745600000", expected=datetime(2015, 7, 13, 0, 0)),


### PR DESCRIPTION
Fixes #360

## Bug

`dateparser.parse("2017-06-22", languages=["it"])` returns `None`, while the same string parses fine with `languages=["en"]` or with no `languages` at all.

There is also a silent variant: when the day is ≤ 12, a wrong date is returned instead of `None`:

```python
>>> dateparser.parse("2017-06-10", languages=["it"])
datetime.datetime(2017, 10, 6, 0, 0)  # October 6 instead of June 10
```

Any language whose locale date order is day-first is affected (`it`, `fr`, `de`, …) — 253 of the 308 locales in the project data use `DMY`.

## Root cause

Italian's locale `date_order` is `DMY`, so `_parser`'s `parse_number()` in `dateparser/parser.py` tries to assign numeric tokens to components in day → month → year order:

- `2017` only fits `year` (and, being a four-digit token, also sets `skip_component = "year"` for the remaining tokens),
- `06` is assigned to **day**, because day precedes month in `DMY`,
- `22` cannot be a month (> 12) and the year slot is skipped, so assignment fails with `ValueError: Unable to parse: 22`, and the result is `None`.

For `2017-06-10` the last token *can* be a month, so parsing "succeeds" — with month and day swapped.

## Fix

A date string that starts with a four-digit year is big-endian (ISO 8601-style); no real-world notation puts the day between the year and the month (no locale in the project data uses `YDM`). So, when the year has already been consumed from a leading four-digit token and neither day nor month has been assigned yet, `parse_number()` now expects the remaining numeric components in month → day order.

The correction deliberately does **not** apply when the caller explicitly sets `DATE_ORDER` (checked via `settings._mod_settings`, the same mechanism `date.py` uses to decide whether the locale order applies), so explicit `DATE_ORDER="DMY"`/`"YDM"` behavior is unchanged. It also does not trigger for strings where the year is not the leading token (`22-06-2017`, `06 2017 10`) or for two-digit years, and the existing `PREFER_LOCALE_DATE_ORDER=False` workaround keeps working.

## Tests

Added `test_iso_datestamp_format_should_parse_with_locale_date_order` covering:

- the exact case from #360 (`2017-06-22`, `it` — was `None`),
- the silent month/day swap (`2017-06-10`, `it` — was October 6),
- another DMY language (`2017-06-22`, `fr`),
- a full ISO timestamp under a DMY locale, without the `PREFER_LOCALE_DATE_ORDER=False` workaround that the neighbouring existing test needs.

All four fail on current master and pass with the fix. Full suite: 24064 passed, 20 skipped, 1 xfailed. `pre-commit` (ruff, ruff-format) passes.

Related: #790 proposes a dedicated ISO parser; this PR instead makes a minimal correction to the existing token-assignment logic, which also fixes the silent month/day swap that occurs before any fallback parser would run.
