### PR TITLE
Sanitize Russian year abbreviation written without a trailing period

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -45,6 +45,7 @@ RE_SANITIZE_SKIP = re.compile(
     r"\t|\n|\r|\u00bb|,\s\u0432\b|\u200e|\xb7|\u200f|\u064e|\u064f", flags=re.M
 )
 RE_SANITIZE_RUSSIAN = re.compile(r"([\W\d])\u0433\.", flags=re.I | re.U)
+RE_SANITIZE_RUSSIAN_YEAR = re.compile(r"(\d{4})\s*\u0433(?![\w.])", flags=re.I | re.U)
 RE_SANITIZE_CROATIAN = re.compile(
     r"(\d+)\.\s?(\d+)\.\s?(\d+)\.( u)?", flags=re.I | re.U
 )
@@ -136,6 +137,9 @@ def sanitize_date(date_string):
     date_string = RE_SANITIZE_RUSSIAN.sub(
         r"\1 ", date_string
     )  # remove 'г.' (Russian for year) but not in words
+    date_string = RE_SANITIZE_RUSSIAN_YEAR.sub(
+        r"\1 ", date_string
+    )  # remove a trailing 'г' after a year, where the period is omitted
     date_string = RE_SANITIZE_CROATIAN.sub(
         r"\1.\2.\3 ", date_string
     )  # extra '.' and 'u' interferes with parsing relative fractional dates

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1118,6 +1118,15 @@ class TestSanitizeDate(BaseTestCase):
         self.assertEqual(date.sanitize_date("2005 г. 15:24"), "2005 15:24")
         self.assertEqual(date.sanitize_date("Авг."), "Авг")
 
+    def test_remove_year_in_russian_without_period(self):
+        self.assertEqual(date.sanitize_date("2005г"), "2005")
+        self.assertEqual(date.sanitize_date("2005 г"), "2005")
+        self.assertEqual(date.sanitize_date("09/08/2021г"), "09/08/2021")
+        self.assertEqual(date.sanitize_date("13 авг 2005 г 19:13"), "13 авг 2005 19:13")
+        # 'г' that is not a year abbreviation must be left alone
+        self.assertEqual(date.sanitize_date("2005 год"), "2005 год")
+        self.assertEqual(date.sanitize_date("5 г назад"), "5 г назад")
+
     def test_sanitize_date_colons(self):
         self.assertEqual(date.sanitize_date("2019:"), "2019")
         self.assertEqual(date.sanitize_date("31/07/2019:"), "31/07/2019")


### PR DESCRIPTION
Closes #1229

`sanitize_date` only strips the Russian year marker when it is written as `г.`, so a string ending in a bare `г` (`09/08/2021г`, `09/08/2021 г`) kept the letter, which was then translated to `year` and parsed as a relative year expression rather than the given date.

The added pass removes `г` only when it directly follows a four-digit year and is not part of a longer word or a dotted abbreviation, so `год`/`года` and relative forms like `5 г назад` are unaffected.