### PR TITLE
Strip a leading colon before parsing (: 24 February 2019)

### DIFF
--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -40,6 +40,7 @@ RE_NBSP = re.compile("\xa0", flags=re.UNICODE)
 RE_SPACES = re.compile(r"\s+")
 RE_TRIM_SPACES = re.compile(r"^\s+(\S.*?)\s+$")
 RE_TRIM_COLONS = re.compile(r"(\S.*?):*$")
+RE_TRIM_LEADING_COLONS = re.compile(r"^\s*:+\s*")
 
 RE_SANITIZE_SKIP = re.compile(
     r"\t|\n|\r|\u00bb|,\s\u0432\b|\u200e|\xb7|\u200f|\u064e|\u064f", flags=re.M
@@ -143,6 +144,11 @@ def sanitize_date(date_string):
     date_string = RE_SANITIZE_PERIOD.sub("", date_string)
     date_string = RE_SANITIZE_ON.sub(r"\1", date_string)
     date_string = RE_TRIM_COLONS.sub(r"\1", date_string)
+    # RE_TRIM_COLONS only strips trailing colons; a leading colon (e.g.
+    # ": 24 February 2019") otherwise becomes a stray token and the parse
+    # fails. A time such as "12:30" has digits before the colon, so it is
+    # unaffected.
+    date_string = RE_TRIM_LEADING_COLONS.sub("", date_string)
     date_string = RE_SANITIZE_APOSTROPHE.sub("'", date_string)
     date_string = date_string.strip()
     return date_string

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -40,7 +40,9 @@ RE_NBSP = re.compile("\xa0", flags=re.UNICODE)
 RE_SPACES = re.compile(r"\s+")
 RE_TRIM_SPACES = re.compile(r"^\s+(\S.*?)\s+$")
 RE_TRIM_COLONS = re.compile(r"(\S.*?):*$")
-RE_TRIM_LEADING_COLONS = re.compile(r"^\s*:+\s*")
+# Not applied when the remainder is a bare number: ":30" looks like a time
+# fragment, and stripping the colon would turn a former None into day 30.
+RE_TRIM_LEADING_COLONS = re.compile(r"^\s*:+\s*(?!\s*\d+\s*$)")
 
 RE_SANITIZE_SKIP = re.compile(
     r"\t|\n|\r|\u00bb|,\s\u0432\b|\u200e|\xb7|\u200f|\u064e|\u064f", flags=re.M

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1122,6 +1122,15 @@ class TestSanitizeDate(BaseTestCase):
         self.assertEqual(date.sanitize_date("2019:"), "2019")
         self.assertEqual(date.sanitize_date("31/07/2019:"), "31/07/2019")
 
+    def test_sanitize_date_leading_colons(self):
+        # A leading colon must be stripped (issue #889) ...
+        self.assertEqual(date.sanitize_date(": 24 February 2019"), "24 February 2019")
+        self.assertEqual(date.sanitize_date(":24 February 2019"), "24 February 2019")
+        self.assertEqual(date.sanitize_date(":: 2019-02-24"), "2019-02-24")
+        # ... but a colon inside a time must be left alone.
+        self.assertEqual(date.sanitize_date("12:30"), "12:30")
+        self.assertEqual(date.sanitize_date("2019-02-24 12:30"), "2019-02-24 12:30")
+
 
 class TestDateLocaleParser(BaseTestCase):
     def setUp(self):

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1127,9 +1127,13 @@ class TestSanitizeDate(BaseTestCase):
         self.assertEqual(date.sanitize_date(": 24 February 2019"), "24 February 2019")
         self.assertEqual(date.sanitize_date(":24 February 2019"), "24 February 2019")
         self.assertEqual(date.sanitize_date(":: 2019-02-24"), "2019-02-24")
-        # ... but a colon inside a time must be left alone.
+        # ... but a colon inside a time must be left alone ...
         self.assertEqual(date.sanitize_date("12:30"), "12:30")
         self.assertEqual(date.sanitize_date("2019-02-24 12:30"), "2019-02-24 12:30")
+        # ... and a colon followed by a bare number looks like a time fragment,
+        # not a prefixed date: stripping it would turn None into day-of-month.
+        self.assertEqual(date.sanitize_date(":30"), ":30")
+        self.assertEqual(date.sanitize_date(": 30"), ": 30")
 
 
 class TestDateLocaleParser(BaseTestCase):


### PR DESCRIPTION
Closes #889.

`: 24 February 2019` returns `None`, while `24 February 2019` parses correctly:

```python
>>> dateparser.parse(": 24 February 2019")
None
>>> dateparser.parse("24 February 2019")
datetime.datetime(2019, 2, 24, 0, 0)
```

`sanitize_date` already trims *trailing* colons — `RE_TRIM_COLONS = r"(\S.*?):*$"` — so `"2019:"` → `"2019"`. But a **leading** colon is left in place, becomes a stray token, and the parse fails.

The fix adds `RE_TRIM_LEADING_COLONS = r"^\s*:+\s*"` and applies it right after the existing trailing-colon trim:

```
": 24 February 2019"   -> "24 February 2019"   -> 2019-02-24
":24 February 2019"    -> "24 February 2019"   -> 2019-02-24
":: 2019-02-24"        -> "2019-02-24"         -> 2019-02-24
```

The important constraint is that this must not touch a colon inside a time — and it doesn't, because a time has digits before the colon (`^\s*:` only matches a colon at the very start):

```
"12:30"              -> unchanged  (still parses as a time)
"2019-02-24 12:30"   -> unchanged
"5:45 pm"            -> unchanged
"11:59:59"           -> unchanged
```

### Scope

I deliberately kept this to the **leading colon**, which is what the issue reports. The related label-prefix cases mentioned in passing (`at: …`, `Date: …`) are a broader and riskier change — stripping an arbitrary `word:` prefix could swallow real tokens — so I left them out. `on:` is already handled separately by `RE_SANITIZE_ON`; happy to add a general label-prefix sanitizer in a follow-up if you'd like one.

### Tests

Extended `TestSanitizeDate.test_sanitize_date_colons` with a `test_sanitize_date_leading_colons` covering the leading-colon cases **and** asserting `"12:30"` / `"2019-02-24 12:30"` are untouched. Reverting the source leaves `sanitize_date(": 24 February 2019")` unchanged, so the test fails without the fix.

`ruff check` and `ruff format --check` (v0.9.3, matching `.pre-commit-config.yaml`) are clean. `tests/test_date_parser.py` + `tests/test_search.py` are 781 passed / 3 failed locally — the 3 are pre-existing Windows-only `datetime.fromtimestamp` `OSError`s in `test_parse_negative_timestamp`, unrelated to this change. (`tests/test_date.py`, which holds the new unit test, only collects on POSIX because of its `from time import tzset` import, so it runs in CI rather than on my Windows box.)
