### PR TITLE
Parse dates wrapped in harmless extra text (Close #518)

### DIFF
--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -78,5 +78,13 @@ def parse(
 
     data = parser.get_date_data(date_string, date_formats)
 
-    if data:
+    if data and data["date_obj"]:
+        return data["date_obj"]
+
+    # The whole string could not be parsed as a date. Retry once, tolerating
+    # harmless extra text around the date, e.g. "Actualisé le 17 avril 2019"
+    # (issue #518). This is kept out of the strict ``get_date_data`` path so
+    # that ``search_dates`` and language detection are unaffected.
+    data = parser._get_date_data_stripping_extra_text(date_string, date_formats)
+    if data and data["date_obj"]:
         return data["date_obj"]

--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -78,13 +78,5 @@ def parse(
 
     data = parser.get_date_data(date_string, date_formats)
 
-    if data and data["date_obj"]:
-        return data["date_obj"]
-
-    # The whole string could not be parsed as a date. Retry once, tolerating
-    # harmless extra text around the date, e.g. "Actualisé le 17 avril 2019"
-    # (issue #518). This is kept out of the strict ``get_date_data`` path so
-    # that ``search_dates`` and language detection are unaffected.
-    data = parser._get_date_data_stripping_extra_text(date_string, date_formats)
-    if data and data["date_obj"]:
+    if data:
         return data["date_obj"]

--- a/dateparser/conf.py
+++ b/dateparser/conf.py
@@ -24,6 +24,7 @@ class Settings:
     * `RELATIVE_BASE`
     * `STRICT_PARSING`
     * `REQUIRE_PARTS`
+    * `IGNORE_SURROUNDING_TEXT`
     * `SKIP_TOKENS`
     * `NORMALIZE`
     * `RETURN_TIME_AS_PERIOD`
@@ -209,6 +210,7 @@ def check_settings(settings):
             "type": datetime
         },
         "STRICT_PARSING": {"type": bool},
+        "IGNORE_SURROUNDING_TEXT": {"type": bool},
         "REQUIRE_PARTS": {
             # "values" covered by the 'extra_check'
             "type": list,

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -255,7 +255,14 @@ def parse_with_formats(date_string, date_formats, settings):
 
 
 class _DateLocaleParser:
-    def __init__(self, locale, date_string, date_formats, settings=None):
+    def __init__(
+        self,
+        locale,
+        date_string,
+        date_formats,
+        settings=None,
+        ignore_surrounding_text=False,
+    ):
         self._settings = settings
         if not (date_formats is None or isinstance(date_formats, (list, tuple, Set))):
             raise TypeError("Date formats should be list, tuple or set of strings")
@@ -263,6 +270,7 @@ class _DateLocaleParser:
         self.locale = locale
         self.date_string = date_string
         self.date_formats = date_formats
+        self._ignore_surrounding_text = ignore_surrounding_text
         self._translated_date = None
         self._translated_date_with_formatting = None
         self._parsers = {
@@ -275,8 +283,17 @@ class _DateLocaleParser:
         }
 
     @classmethod
-    def parse(cls, locale, date_string, date_formats=None, settings=None):
-        instance = cls(locale, date_string, date_formats, settings)
+    def parse(
+        cls,
+        locale,
+        date_string,
+        date_formats=None,
+        settings=None,
+        ignore_surrounding_text=False,
+    ):
+        instance = cls(
+            locale, date_string, date_formats, settings, ignore_surrounding_text
+        )
         return instance._parse()
 
     def _parse(self):
@@ -372,14 +389,20 @@ class _DateLocaleParser:
     def _get_translated_date(self):
         if self._translated_date is None:
             self._translated_date = self.locale.translate(
-                self.date_string, keep_formatting=False, settings=self._settings
+                self.date_string,
+                keep_formatting=False,
+                settings=self._settings,
+                ignore_surrounding_text=self._ignore_surrounding_text,
             )
         return self._translated_date
 
     def _get_translated_date_with_formatting(self):
         if self._translated_date_with_formatting is None:
             self._translated_date_with_formatting = self.locale.translate(
-                self.date_string, keep_formatting=True, settings=self._settings
+                self.date_string,
+                keep_formatting=True,
+                settings=self._settings,
+                ignore_surrounding_text=self._ignore_surrounding_text,
             )
         return self._translated_date_with_formatting
 
@@ -580,53 +603,37 @@ class DateDataParser:
 
         date_string = sanitize_date(date_string)
 
-        for locale in self._get_applicable_locales(date_string):
+        parsed_date = self._parse_using_applicable_locales(date_string, date_formats)
+        if not parsed_date and self._settings.IGNORE_SURROUNDING_TEXT:
+            # The whole string could not be parsed as a date. Retry, ignoring
+            # unrecognized words at the edges of the string, so that a date
+            # wrapped in harmless extra text is still parsed (issue #518),
+            # e.g. "Actualisé le 17 avril 2019". Strings that can be parsed as
+            # a whole never reach this fallback, so they are unaffected.
+            parsed_date = self._parse_using_applicable_locales(
+                date_string, date_formats, ignore_surrounding_text=True
+            )
+        return parsed_date or DateData(date_obj=None, period="day", locale=None)
+
+    def _parse_using_applicable_locales(
+        self, date_string, date_formats, ignore_surrounding_text=False
+    ):
+        for locale in self._get_applicable_locales(
+            date_string, ignore_surrounding_text=ignore_surrounding_text
+        ):
             parsed_date = _DateLocaleParser.parse(
-                locale, date_string, date_formats, settings=self._settings
+                locale,
+                date_string,
+                date_formats,
+                settings=self._settings,
+                ignore_surrounding_text=ignore_surrounding_text,
             )
             if parsed_date:
                 parsed_date["locale"] = locale.shortname
                 if self.try_previous_locales:
                     self.previous_locales[locale] = None
                 return parsed_date
-        else:
-            return DateData(date_obj=None, period="day", locale=None)
-
-    def _get_date_data_stripping_extra_text(self, date_string, date_formats=None):
-        """Fallback for strings that are a real date surrounded by harmless
-        extra text (issue #518), e.g. ``"Actualisé le 17 avril 2019"``.
-
-        Used by :func:`dateparser.parse` only when the regular, strict parsing
-        of the whole string found nothing. It is intentionally *not* part of
-        :meth:`get_date_data` so that the strictness relied upon by
-        ``search_dates`` and language detection is preserved.
-
-        Only attempted when the language is known (given explicitly or already
-        detected): with a known language, foreign extra words can be stripped
-        confidently, and only a handful of locales are tried. Without that hint
-        the whole locale set would have to be scanned, so we stay conservative.
-        """
-        if not isinstance(date_string, str):
-            raise TypeError("Input type must be str")
-
-        if not (self.languages or self.locales):
-            return DateData(date_obj=None, period="day", locale=None)
-
-        date_string = sanitize_date(date_string)
-
-        for locale in self._get_locales_to_try():
-            stripped = locale.strip_extra_text(date_string, settings=self._settings)
-            if not stripped:
-                continue
-            parsed_date = _DateLocaleParser.parse(
-                locale, stripped, date_formats, settings=self._settings
-            )
-            if parsed_date and parsed_date["date_obj"]:
-                parsed_date["locale"] = locale.shortname
-                if self.try_previous_locales:
-                    self.previous_locales[locale] = None
-                return parsed_date
-        return DateData(date_obj=None, period="day", locale=None)
+        return None
 
     def get_date_tuple(self, *args, **kwargs):
         date_data = self.get_date_data(*args, **kwargs)
@@ -634,7 +641,7 @@ class DateDataParser:
         date_tuple = collections.namedtuple("DateData", fields)
         return date_tuple(**date_data.__dict__)
 
-    def _get_applicable_locales(self, date_string):
+    def _get_applicable_locales(self, date_string, ignore_surrounding_text=False):
         # The given order is preserved if requested either through the
         # ``use_given_order`` constructor argument or the
         # ``USE_GIVEN_LANGUAGE_ORDER`` setting (which also reaches the
@@ -666,7 +673,7 @@ class DateDataParser:
         if self.try_previous_locales:
             for locale in self.previous_locales.keys():
                 for s in date_strings():
-                    if self._is_applicable_locale(locale, s):
+                    if self._is_applicable_locale(locale, s, ignore_surrounding_text):
                         yield locale
 
         if self.detect_languages_function and not self.languages and not self.locales:
@@ -684,7 +691,7 @@ class DateDataParser:
             use_given_order=use_given_order,
         ):
             for s in date_strings():
-                if self._is_applicable_locale(locale, s):
+                if self._is_applicable_locale(locale, s, ignore_surrounding_text):
                     yield locale
 
         if self._settings.DEFAULT_LANGUAGES:
@@ -696,33 +703,12 @@ class DateDataParser:
             ):
                 yield locale
 
-    def _get_locales_to_try(self):
-        """Yield the candidate locales (given languages/locales, then any
-        ``DEFAULT_LANGUAGES``) without the applicability filter, for use by the
-        extra-text fallback where applicability is re-checked on the stripped
-        core."""
-        use_given_order = (
-            self.use_given_order or self._settings.USE_GIVEN_LANGUAGE_ORDER
-        )
-        yield from self._get_locale_loader().get_locales(
-            languages=self.languages,
-            locales=self.locales,
-            region=self.region,
-            use_given_order=use_given_order,
-        )
-        if self._settings.DEFAULT_LANGUAGES:
-            yield from self._get_locale_loader().get_locales(
-                languages=self._settings.DEFAULT_LANGUAGES,
-                locales=None,
-                region=self.region,
-                use_given_order=use_given_order,
-            )
-
-    def _is_applicable_locale(self, locale, date_string):
+    def _is_applicable_locale(self, locale, date_string, ignore_surrounding_text=False):
         return locale.is_applicable(
             date_string,
             strip_timezone=False,  # it is stripped outside
             settings=self._settings,
+            ignore_surrounding_text=ignore_surrounding_text,
         )
 
     @classmethod

--- a/dateparser/date.py
+++ b/dateparser/date.py
@@ -592,6 +592,42 @@ class DateDataParser:
         else:
             return DateData(date_obj=None, period="day", locale=None)
 
+    def _get_date_data_stripping_extra_text(self, date_string, date_formats=None):
+        """Fallback for strings that are a real date surrounded by harmless
+        extra text (issue #518), e.g. ``"Actualisé le 17 avril 2019"``.
+
+        Used by :func:`dateparser.parse` only when the regular, strict parsing
+        of the whole string found nothing. It is intentionally *not* part of
+        :meth:`get_date_data` so that the strictness relied upon by
+        ``search_dates`` and language detection is preserved.
+
+        Only attempted when the language is known (given explicitly or already
+        detected): with a known language, foreign extra words can be stripped
+        confidently, and only a handful of locales are tried. Without that hint
+        the whole locale set would have to be scanned, so we stay conservative.
+        """
+        if not isinstance(date_string, str):
+            raise TypeError("Input type must be str")
+
+        if not (self.languages or self.locales):
+            return DateData(date_obj=None, period="day", locale=None)
+
+        date_string = sanitize_date(date_string)
+
+        for locale in self._get_locales_to_try():
+            stripped = locale.strip_extra_text(date_string, settings=self._settings)
+            if not stripped:
+                continue
+            parsed_date = _DateLocaleParser.parse(
+                locale, stripped, date_formats, settings=self._settings
+            )
+            if parsed_date and parsed_date["date_obj"]:
+                parsed_date["locale"] = locale.shortname
+                if self.try_previous_locales:
+                    self.previous_locales[locale] = None
+                return parsed_date
+        return DateData(date_obj=None, period="day", locale=None)
+
     def get_date_tuple(self, *args, **kwargs):
         date_data = self.get_date_data(*args, **kwargs)
         fields = date_data.__dict__.keys()
@@ -659,6 +695,28 @@ class DateDataParser:
                 use_given_order=use_given_order,
             ):
                 yield locale
+
+    def _get_locales_to_try(self):
+        """Yield the candidate locales (given languages/locales, then any
+        ``DEFAULT_LANGUAGES``) without the applicability filter, for use by the
+        extra-text fallback where applicability is re-checked on the stripped
+        core."""
+        use_given_order = (
+            self.use_given_order or self._settings.USE_GIVEN_LANGUAGE_ORDER
+        )
+        yield from self._get_locale_loader().get_locales(
+            languages=self.languages,
+            locales=self.locales,
+            region=self.region,
+            use_given_order=use_given_order,
+        )
+        if self._settings.DEFAULT_LANGUAGES:
+            yield from self._get_locale_loader().get_locales(
+                languages=self._settings.DEFAULT_LANGUAGES,
+                locales=None,
+                region=self.region,
+                use_given_order=use_given_order,
+            )
 
     def _is_applicable_locale(self, locale, date_string):
         return locale.is_applicable(

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -3,6 +3,7 @@ from operator import methodcaller
 
 import regex as re
 
+from dateparser.timezone_parser import is_timezone_token
 from dateparser.utils import normalize_unicode
 
 PARSER_HARDCODED_TOKENS = [":", ".", " ", "-", "/"]
@@ -142,13 +143,9 @@ class Dictionary:
         if has_only_keep_tokens:
             return False
         match_relative_regex = self._get_match_relative_regex_cache()
-        for token in tokens:
-            if token.isdigit() or match_relative_regex.match(token) or token in self:
-                continue
-            else:
-                return False
-        else:
-            return True
+        return all(
+            self._is_known_token(token, match_relative_regex) for token in tokens
+        )
 
     def _is_known_token(self, token, match_relative_regex):
         """Whether ``token`` is recognised by this locale: a number, a relative
@@ -163,7 +160,21 @@ class Dictionary:
         locale does not recognise (neither digits, relative expressions, nor
         dictionary words), along with any whitespace those removals leave at
         the edges. Interior tokens are left untouched. Used when the
-        ``IGNORE_SURROUNDING_TEXT`` setting is enabled."""
+        ``IGNORE_SURROUNDING_TEXT`` setting is enabled.
+
+        A timezone abbreviation that is the final token (e.g. a trailing
+        ``"EST"``) is kept even though the locale dictionary does not list it,
+        so that the offset is applied rather than silently discarded. It
+        survives translation and is popped later by
+        :func:`~dateparser.timezone_parser.pop_tz_offset_from_string`. The
+        timezone is kept only when it is the last token: if further
+        unrecognized text follows it, the tokenizer merges the two and the
+        timezone is dropped together with that text, like any other edge noise.
+
+        This timezone exception is deliberately made at the trailing edge
+        only: a timezone conventionally follows the date it qualifies
+        (``"... 1:21 PM EST"``) and does not precede it, so the leading edge
+        keeps stripping unrecognized tokens unconditionally."""
         match_relative_regex = self._get_match_relative_regex_cache()
 
         def is_extra_text(token):
@@ -172,9 +183,17 @@ class Dictionary:
             )
 
         start, end = 0, len(tokens)
+        # Leading edge: drop every unrecognized token. A timezone does not
+        # precede the date it qualifies, so no timezone exception is made here.
         while start < end and is_extra_text(tokens[start]):
             start += 1
-        while end > start and is_extra_text(tokens[end - 1]):
+        # Trailing edge: drop unrecognized tokens, but keep a recognized
+        # timezone abbreviation (e.g. ``" est"``) so its offset is applied.
+        while (
+            end > start
+            and is_extra_text(tokens[end - 1])
+            and not is_timezone_token(tokens[end - 1])
+        ):
             end -= 1
         return tokens[start:end]
 

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -42,10 +42,6 @@ KNOWN_WORD_TOKENS = [
     "pm",
 ]
 
-# Month and weekday names — the strong, language-specific date words used to
-# confirm that a string with harmless extra text really contains a date.
-_MONTH_AND_WEEKDAY_TOKENS = frozenset(KNOWN_WORD_TOKENS[:19])
-
 PARENTHESES_PATTERN = re.compile(r"[\(\)]")
 NUMERAL_PATTERN = re.compile(r"(\d+)")
 KEEP_TOKEN_PATTERN = re.compile(r"^.*[^\W_].*$", flags=re.U)
@@ -154,58 +150,33 @@ class Dictionary:
         else:
             return True
 
-    def _is_known_token(self, token, match_relative_regex=None):
+    def _is_known_token(self, token, match_relative_regex):
         """Whether ``token`` is recognised by this locale: a number, a relative
-        expression, or a dictionary word (this is the per-token check used by
-        :meth:`are_tokens_valid`)."""
-        if match_relative_regex is None:
-            match_relative_regex = self._get_match_relative_regex_cache()
+        expression, or a dictionary word (the same per-token check that
+        :meth:`are_tokens_valid` applies)."""
         return bool(
             token.isdigit() or match_relative_regex.match(token) or token in self
         )
 
-    def _is_date_anchor(self, token):
-        """Whether ``token`` is a strong, locale-specific date word — a month or
-        weekday name, or a relative expression — as opposed to a bare number,
-        punctuation, or a universal token such as ``am``/``pm``. Used to make
-        sure extra-text stripping only rescues genuine dates."""
-        if self._get_match_relative_regex_cache().match(token):
-            return True
-        return self._dictionary.get(token) in _MONTH_AND_WEEKDAY_TOKENS
-
     def _strip_unknown_edge_tokens(self, tokens):
-        """Remove leading and trailing tokens that are not recognised by this
-        locale (neither digits, relative expressions, nor dictionary words).
-        Interior tokens are left untouched."""
+        """Return ``tokens`` without the leading and trailing tokens that this
+        locale does not recognise (neither digits, relative expressions, nor
+        dictionary words), along with any whitespace those removals leave at
+        the edges. Interior tokens are left untouched. Used when the
+        ``IGNORE_SURROUNDING_TEXT`` setting is enabled."""
         match_relative_regex = self._get_match_relative_regex_cache()
+
+        def is_extra_text(token):
+            return token.isspace() or not self._is_known_token(
+                token, match_relative_regex
+            )
+
         start, end = 0, len(tokens)
-        while start < end and not self._is_known_token(
-            tokens[start], match_relative_regex
-        ):
+        while start < end and is_extra_text(tokens[start]):
             start += 1
-        while end > start and not self._is_known_token(
-            tokens[end - 1], match_relative_regex
-        ):
+        while end > start and is_extra_text(tokens[end - 1]):
             end -= 1
         return tokens[start:end]
-
-    def strip_extra_edge_tokens(self, tokens):
-        """Return the date ``core`` obtained by removing harmless extra words
-        from the leading/trailing edges of ``tokens`` (issue #518), or ``None``
-        when nothing can be safely stripped.
-
-        Stripping is only applied when it actually removes something, the
-        surviving core is a valid date for this locale, and that core still
-        contains a month, weekday or relative expression (so that genuine
-        non-dates and bare numbers are not rescued)."""
-        core = self._strip_unknown_edge_tokens(tokens)
-        if (
-            len(core) == len(tokens)
-            or not any(self._is_date_anchor(token) for token in core)
-            or not self.are_tokens_valid(core)
-        ):
-            return None
-        return core
 
     def split(self, string, keep_formatting=False):
         """

--- a/dateparser/languages/dictionary.py
+++ b/dateparser/languages/dictionary.py
@@ -42,6 +42,10 @@ KNOWN_WORD_TOKENS = [
     "pm",
 ]
 
+# Month and weekday names — the strong, language-specific date words used to
+# confirm that a string with harmless extra text really contains a date.
+_MONTH_AND_WEEKDAY_TOKENS = frozenset(KNOWN_WORD_TOKENS[:19])
+
 PARENTHESES_PATTERN = re.compile(r"[\(\)]")
 NUMERAL_PATTERN = re.compile(r"(\d+)")
 KEEP_TOKEN_PATTERN = re.compile(r"^.*[^\W_].*$", flags=re.U)
@@ -149,6 +153,59 @@ class Dictionary:
                 return False
         else:
             return True
+
+    def _is_known_token(self, token, match_relative_regex=None):
+        """Whether ``token`` is recognised by this locale: a number, a relative
+        expression, or a dictionary word (this is the per-token check used by
+        :meth:`are_tokens_valid`)."""
+        if match_relative_regex is None:
+            match_relative_regex = self._get_match_relative_regex_cache()
+        return bool(
+            token.isdigit() or match_relative_regex.match(token) or token in self
+        )
+
+    def _is_date_anchor(self, token):
+        """Whether ``token`` is a strong, locale-specific date word — a month or
+        weekday name, or a relative expression — as opposed to a bare number,
+        punctuation, or a universal token such as ``am``/``pm``. Used to make
+        sure extra-text stripping only rescues genuine dates."""
+        if self._get_match_relative_regex_cache().match(token):
+            return True
+        return self._dictionary.get(token) in _MONTH_AND_WEEKDAY_TOKENS
+
+    def _strip_unknown_edge_tokens(self, tokens):
+        """Remove leading and trailing tokens that are not recognised by this
+        locale (neither digits, relative expressions, nor dictionary words).
+        Interior tokens are left untouched."""
+        match_relative_regex = self._get_match_relative_regex_cache()
+        start, end = 0, len(tokens)
+        while start < end and not self._is_known_token(
+            tokens[start], match_relative_regex
+        ):
+            start += 1
+        while end > start and not self._is_known_token(
+            tokens[end - 1], match_relative_regex
+        ):
+            end -= 1
+        return tokens[start:end]
+
+    def strip_extra_edge_tokens(self, tokens):
+        """Return the date ``core`` obtained by removing harmless extra words
+        from the leading/trailing edges of ``tokens`` (issue #518), or ``None``
+        when nothing can be safely stripped.
+
+        Stripping is only applied when it actually removes something, the
+        surviving core is a valid date for this locale, and that core still
+        contains a month, weekday or relative expression (so that genuine
+        non-dates and bare numbers are not rescued)."""
+        core = self._strip_unknown_edge_tokens(tokens)
+        if (
+            len(core) == len(tokens)
+            or not any(self._is_date_anchor(token) for token in core)
+            or not self.are_tokens_valid(core)
+        ):
+            return None
+        return core
 
     def split(self, string, keep_formatting=False):
         """

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -202,6 +202,26 @@ class Locale:
             settings=settings,
         )
 
+    def strip_extra_text(self, date_string, settings=None):
+        """Return ``date_string`` with harmless extra words removed from its
+        leading and trailing edges (issue #518), e.g.
+        ``"Actualisé le 17 avril 2019"`` -> ``"le 17 avril 2019"``.
+
+        Only the edges are trimmed, and only when the surviving core is a valid
+        date for this locale that contains a month, weekday or relative
+        expression. Returns ``None`` when there is nothing safe to strip, so the
+        caller can tell that the string is not simply "a date with extra text".
+        """
+        prepared = self._translate_numerals(date_string)
+        if settings.NORMALIZE:
+            prepared = normalize_unicode(prepared)
+        prepared = self._simplify(prepared, settings=settings)
+        dictionary = self._get_dictionary(settings)
+        core = dictionary.strip_extra_edge_tokens(dictionary.split(prepared))
+        if not core:
+            return None
+        return "".join(core).strip()
+
     def _translate_numerals(self, date_string):
         date_string_tokens = NUMERAL_PATTERN.split(date_string)
         for i, token in enumerate(date_string_tokens):

--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -54,7 +54,13 @@ class Locale:
         self.info = combine_dicts(language_info, locale_specific_info)
         self.info.pop("locale_specific", None)
 
-    def is_applicable(self, date_string, strip_timezone=False, settings=None):
+    def is_applicable(
+        self,
+        date_string,
+        strip_timezone=False,
+        settings=None,
+        ignore_surrounding_text=False,
+    ):
         """
         Check if the locale is applicable to translate date string.
 
@@ -65,6 +71,11 @@ class Locale:
         :param strip_timezone:
             If True, timezone is stripped from date string.
         :type strip_timezone: bool
+
+        :param ignore_surrounding_text:
+            If True, tokens that the locale does not recognise are ignored at
+            the edges of the date string (``IGNORE_SURROUNDING_TEXT`` setting).
+        :type ignore_surrounding_text: bool
 
         :return: boolean value representing if the locale is applicable for the date string or not.
         """
@@ -77,6 +88,8 @@ class Locale:
         date_string = self._simplify(date_string, settings=settings)
         dictionary = self._get_dictionary(settings)
         date_tokens = dictionary.split(date_string)
+        if ignore_surrounding_text:
+            date_tokens = dictionary._strip_unknown_edge_tokens(date_tokens)
         return dictionary.are_tokens_valid(date_tokens)
 
     def count_applicability(self, text, strip_timezone=False, settings=None):
@@ -116,7 +129,13 @@ class Locale:
             del dictionary[del_key]
         return dictionary
 
-    def translate(self, date_string, keep_formatting=False, settings=None):
+    def translate(
+        self,
+        date_string,
+        keep_formatting=False,
+        settings=None,
+        ignore_surrounding_text=False,
+    ):
         """
         Translate the date string to its English equivalent.
 
@@ -128,6 +147,12 @@ class Locale:
             If True, retain formatting of the date string after translation.
         :type keep_formatting: bool
 
+        :param ignore_surrounding_text:
+            If True, tokens that the locale does not recognise are dropped from
+            the edges of the date string before translation
+            (``IGNORE_SURROUNDING_TEXT`` setting).
+        :type ignore_surrounding_text: bool
+
         :return: translated date string.
         """
         date_string = self._translate_numerals(date_string)
@@ -136,6 +161,10 @@ class Locale:
         date_string = self._simplify(date_string, settings=settings)
         dictionary = self._get_dictionary(settings)
         date_string_tokens = dictionary.split(date_string, keep_formatting)
+        if ignore_surrounding_text:
+            date_string_tokens = dictionary._strip_unknown_edge_tokens(
+                date_string_tokens
+            )
 
         relative_translations = self._get_relative_translations(settings=settings)
 
@@ -201,26 +230,6 @@ class Locale:
             separator="" if keep_formatting else " ",
             settings=settings,
         )
-
-    def strip_extra_text(self, date_string, settings=None):
-        """Return ``date_string`` with harmless extra words removed from its
-        leading and trailing edges (issue #518), e.g.
-        ``"Actualisé le 17 avril 2019"`` -> ``"le 17 avril 2019"``.
-
-        Only the edges are trimmed, and only when the surviving core is a valid
-        date for this locale that contains a month, weekday or relative
-        expression. Returns ``None`` when there is nothing safe to strip, so the
-        caller can tell that the string is not simply "a date with extra text".
-        """
-        prepared = self._translate_numerals(date_string)
-        if settings.NORMALIZE:
-            prepared = normalize_unicode(prepared)
-        prepared = self._simplify(prepared, settings=settings)
-        dictionary = self._get_dictionary(settings)
-        core = dictionary.strip_extra_edge_tokens(dictionary.split(prepared))
-        if not core:
-            return None
-        return "".join(core).strip()
 
     def _translate_numerals(self, date_string):
         date_string_tokens = NUMERAL_PATTERN.split(date_string)

--- a/dateparser/timezone_parser.py
+++ b/dateparser/timezone_parser.py
@@ -50,6 +50,22 @@ def word_is_tz(word):
     return bool(_search_regex.match(word))
 
 
+def is_timezone_token(token):
+    """Whether ``token`` is, on its own, a recognized timezone abbreviation.
+
+    Unlike :func:`word_is_tz` (a case-sensitive prefix match used while
+    scanning original-cased text), this trims surrounding whitespace and does a
+    case-insensitive *full* match, so it recognizes an already-lowercased,
+    space-padded token such as ``" est"``. Because the match is anchored, an
+    ordinary word that merely begins with a timezone abbreviation is not
+    treated as a timezone (e.g. ``"actualisé"`` is not the ``ACT`` zone). This
+    is used only on single edge tokens, so the trailing ``.*`` in the UTC/GMT
+    numeric-offset patterns (which a full match would otherwise let absorb
+    following text) is not a concern here.
+    """
+    return bool(_search_regex_ignorecase.fullmatch(token.strip()))
+
+
 def convert_to_local_tz(datetime_obj, datetime_tz_offset):
     return datetime_obj - datetime_tz_offset + local_tz_offset
 

--- a/dateparser_data/settings.py
+++ b/dateparser_data/settings.py
@@ -34,5 +34,6 @@ settings = {
     # Other settings
     "RETURN_TIME_AS_PERIOD": False,
     "PARSERS": default_parsers,
+    "IGNORE_SURROUNDING_TEXT": False,
     "CACHE_SIZE_LIMIT": 1000,
 }

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -175,13 +175,29 @@ the setting was disabled:
     >>> parse('17 foobar avril 2019', languages=['fr'], settings={'IGNORE_SURROUNDING_TEXT': True})
     None
 
-.. warning:: When this setting is enabled, the ignored text is discarded — even if it
-   could have changed the meaning of the date (for example, an unrecognized timezone
-   name) — and what remains is parsed as if it were the whole input. As a result,
-   strings that merely contain date-like words can produce a date, e.g.
-   ``'Chapter 12 March of the Penguins'``. Enable it only when the input is expected
-   to contain a date, and consider combining it with ``STRICT_PARSING`` or
-   ``REQUIRE_PARTS`` to discard remainders that are not complete dates.
+Stripping stops at the first token the language *does* recognize, and a number counts
+as recognized. So surrounding text that contains a number of its own (an id, a page
+number, a count) is not ignored, and the string is not parsed:
+
+    >>> parse('invoice 12345 paid on 3 March 2019', settings={'IGNORE_SURROUNDING_TEXT': True})
+    None
+
+To extract a date out of arbitrary text that does not follow this shape, use
+:func:`dateparser.search.search_dates` instead, which scans the whole string rather
+than only trimming its edges.
+
+.. warning:: When this setting is enabled, discarded edge text is dropped even if it
+   could have changed the meaning of the date, and what remains is parsed as if it
+   were the whole input. As a result, strings that merely contain date-like words can
+   produce a date, e.g. ``'Chapter 12 March of the Penguins'``. A recognized timezone is
+   kept and applied only when it is the last token of the string (e.g.
+   ``'... 1:21 PM EST'``); a timezone before the date, one followed by further
+   unrecognized text, or any timezone name the parser does not recognize, is discarded
+   with the rest of the surrounding text (use
+   :func:`dateparser.search.search_dates` for such input). Enable this setting only when
+   the input is expected to contain a date, and consider combining it with
+   ``STRICT_PARSING`` or ``REQUIRE_PARTS`` to discard remainders that are not complete
+   dates.
 
 
 Language Detection

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -155,6 +155,34 @@ For example, assuming current date is `June 16, 2019`:
     >>> parse('March 12, 2012', settings={'REQUIRE_PARTS': ['day', 'month', 'year']})
     datetime.datetime(2012, 3, 12, 0, 0)
 
+``IGNORE_SURROUNDING_TEXT``: defaults to ``False``. By default, the whole input string
+must be a date, so a date wrapped in surrounding text is not parsed. When this setting
+is enabled and the whole string could not be parsed as a date, dateparser retries
+ignoring the words at the beginning and at the end of the string that the tried
+language does not recognize as date-related:
+
+    >>> parse('Actualisé le 17 avril 2019', languages=['fr'])
+    None
+    >>> parse('Actualisé le 17 avril 2019', languages=['fr'], settings={'IGNORE_SURROUNDING_TEXT': True})
+    datetime.datetime(2019, 4, 17, 0, 0)
+    >>> parse('Published on 16/04/2019', settings={'IGNORE_SURROUNDING_TEXT': True})
+    datetime.datetime(2019, 4, 16, 0, 0)
+
+Only the edges of the string are affected. An unrecognized word inside the date still
+prevents parsing, and strings that can be parsed as a whole are parsed exactly as if
+the setting was disabled:
+
+    >>> parse('17 foobar avril 2019', languages=['fr'], settings={'IGNORE_SURROUNDING_TEXT': True})
+    None
+
+.. warning:: When this setting is enabled, the ignored text is discarded — even if it
+   could have changed the meaning of the date (for example, an unrecognized timezone
+   name) — and what remains is parsed as if it were the whole input. As a result,
+   strings that merely contain date-like words can produce a date, e.g.
+   ``'Chapter 12 March of the Penguins'``. Enable it only when the input is expected
+   to contain a date, and consider combining it with ``STRICT_PARSING`` or
+   ``REQUIRE_PARTS`` to discard remainders that are not complete dates.
+
 
 Language Detection
 ++++++++++++++++++

--- a/tests/test_clean_api.py
+++ b/tests/test_clean_api.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from parameterized import param, parameterized
 from pytz import utc
@@ -462,6 +462,133 @@ class TestIgnoreSurroundingTextSetting(BaseTestCase):
         # search_dates keeps relying on the strict behavior of get_date_data.
         self.result = search_dates("Actualisé le 17 avril 2019", languages=["fr"])
         self.assertEqual([("le 17 avril 2019", datetime(2019, 4, 17))], self.result)
+
+    def test_trailing_timezone_is_preserved(self):
+        # A recognized timezone at the trailing edge must not be discarded with
+        # the surrounding text: wrapping a date in extra text yields the same
+        # instant as parsing the bare date, timezone included.
+        settings = {"IGNORE_SURROUNDING_TEXT": True, "RETURN_AS_TIMEZONE_AWARE": True}
+        wrapped = dateparser.parse(
+            "Updated 23 March 2000 1:21 PM EST", languages=["en"], settings=settings
+        )
+        unwrapped = dateparser.parse(
+            "23 March 2000 1:21 PM EST",
+            languages=["en"],
+            settings={"RETURN_AS_TIMEZONE_AWARE": True},
+        )
+        self.assertEqual(timedelta(hours=-5), wrapped.utcoffset())
+        self.assertEqual(unwrapped, wrapped)
+
+    @parameterized.expand(
+        [
+            # Abbreviations that are not dictionary words, so they are kept via
+            # is_timezone_token rather than the plain known-word branch. Their
+            # names and offsets are chosen not to coincide with a plausible
+            # local timezone (in particular not UTC or CET), so a reversion of
+            # the trailing-tz exception is caught on any machine rather than
+            # only under a non-local timezone.
+            param(
+                wrapped="Updated 23 March 2000 1:21 PM PST",
+                bare="23 March 2000 1:21 PM PST",
+                tzname="PST",
+                utcoffset=timedelta(hours=-8),
+            ),
+            param(
+                wrapped="Updated 23 March 2000 1:21 PM JST",
+                bare="23 March 2000 1:21 PM JST",
+                tzname="JST",
+                utcoffset=timedelta(hours=9),
+            ),
+        ]
+    )
+    def test_more_trailing_timezones_are_preserved(
+        self, wrapped, bare, tzname, utcoffset
+    ):
+        # Like test_trailing_timezone_is_preserved, for further abbreviations:
+        # wrapping the date in extra text yields the same tz-aware instant as
+        # parsing the bare date. The timezone *name* is asserted (not only the
+        # offset) so the test cannot pass by the dropped timezone happening to
+        # match the machine's local offset.
+        settings = {"IGNORE_SURROUNDING_TEXT": True, "RETURN_AS_TIMEZONE_AWARE": True}
+        wrapped_result = dateparser.parse(wrapped, languages=["en"], settings=settings)
+        bare_result = dateparser.parse(
+            bare, languages=["en"], settings={"RETURN_AS_TIMEZONE_AWARE": True}
+        )
+        self.assertEqual(tzname, wrapped_result.tzname())
+        self.assertEqual(utcoffset, wrapped_result.utcoffset())
+        self.assertEqual(bare_result, wrapped_result)
+
+    def test_parenthesized_trailing_timezone_is_applied(self):
+        # A parenthesized trailing timezone is applied end to end. GMT is a
+        # dictionary token, so the parentheses are split off and it is kept via
+        # the ordinary known-word branch, not via is_timezone_token (which the
+        # PST/JST cases above exercise). A parenthesized abbreviation that is
+        # *not* a dictionary word stays glued to its parentheses and is dropped
+        # like any other unrecognized edge token, so GMT is used here.
+        settings = {"IGNORE_SURROUNDING_TEXT": True, "RETURN_AS_TIMEZONE_AWARE": True}
+        wrapped = dateparser.parse(
+            "Last updated: 12 March 2019 at 10:30 (GMT)",
+            languages=["en"],
+            settings=settings,
+        )
+        bare = dateparser.parse(
+            "12 March 2019 at 10:30 (GMT)",
+            languages=["en"],
+            settings={"RETURN_AS_TIMEZONE_AWARE": True},
+        )
+        self.assertEqual("GMT", wrapped.tzname())
+        self.assertEqual(timedelta(0), wrapped.utcoffset())
+        self.assertEqual(bare, wrapped)
+
+    def test_only_trailing_timezone_is_preserved(self):
+        # tz-recognition when stripping edge tokens is deliberately applied to
+        # the trailing edge only: a timezone that follows the date is kept and
+        # applied, while the same abbreviation before the date is treated as
+        # ordinary surrounding text and dropped.
+        settings = {"IGNORE_SURROUNDING_TEXT": True, "RETURN_AS_TIMEZONE_AWARE": True}
+        trailing = dateparser.parse(
+            "23 March 2000 1:21 PM EST", languages=["en"], settings=settings
+        )
+        leading = dateparser.parse(
+            "EST 23 March 2000 1:21 PM", languages=["en"], settings=settings
+        )
+        without_tz = dateparser.parse(
+            "23 March 2000 1:21 PM",
+            languages=["en"],
+            settings={"RETURN_AS_TIMEZONE_AWARE": True},
+        )
+        # Trailing EST is applied...
+        self.assertEqual(timedelta(hours=-5), trailing.utcoffset())
+        # ...leading EST is not: the result matches the same string with no
+        # timezone at all, and does not carry the EST offset.
+        self.assertEqual(without_tz, leading)
+        self.assertNotEqual(trailing, leading)
+
+    def test_trailing_timezone_followed_by_more_text_is_dropped(self):
+        # Known limitation: a trailing timezone is kept only when it is the
+        # final token. If unrecognized text follows it, the tokenizer merges
+        # the two, so the timezone is stripped together with that text and its
+        # offset is not applied (use search_dates for such input). The date is
+        # still parsed -- only the timezone is lost.
+        settings = {"IGNORE_SURROUNDING_TEXT": True, "RETURN_AS_TIMEZONE_AWARE": True}
+        result = dateparser.parse(
+            "Updated 23 March 2000 1:21 PM EST reportedly",
+            languages=["en"],
+            settings=settings,
+        )
+        self.assertEqual(datetime(2000, 3, 23, 13, 21), result.replace(tzinfo=None))
+        self.assertNotEqual(timedelta(hours=-5), result.utcoffset())
+
+    def test_leading_numeric_noise_is_not_ignored(self):
+        # Documented limitation: stripping stops at the first recognized token,
+        # and a number counts as recognized, so leading text that contains a
+        # number of its own blocks parsing. search_dates covers this shape.
+        self.when_date_is_parsed(
+            "invoice 12345 paid on 3 March 2019",
+            languages=["en"],
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_date_was_not_parsed()
 
     def when_date_is_parsed(self, date_string, **kwargs):
         self.result = dateparser.parse(date_string, **kwargs)

--- a/tests/test_clean_api.py
+++ b/tests/test_clean_api.py
@@ -4,6 +4,7 @@ from parameterized import param, parameterized
 from pytz import utc
 
 import dateparser
+from dateparser.search import search_dates
 from tests import BaseTestCase
 
 
@@ -282,6 +283,191 @@ class TestParseFunction(BaseTestCase):
 
     def then_parsed_date_and_time_is(self, expected_date):
         self.assertEqual(self.result, expected_date)
+
+    def then_date_was_not_parsed(self):
+        self.assertIsNone(self.result)
+
+
+class TestIgnoreSurroundingTextSetting(BaseTestCase):
+    """Tests for the opt-in ``IGNORE_SURROUNDING_TEXT`` setting (issue #518)."""
+
+    def setUp(self):
+        super().setUp()
+        self.result = NotImplemented
+
+    @parameterized.expand(
+        [
+            # Issue #518: dates wrapped in harmless extra text.
+            param(
+                date_string="Actualisé le 17 avril 2019",
+                languages=["fr"],
+                expected_datetime=datetime(2019, 4, 17),
+            ),
+            param(
+                date_string="Publié le 16 avril 2019",
+                languages=["fr"],
+                expected_datetime=datetime(2019, 4, 16),
+            ),
+            # The behavior is not French-specific.
+            param(
+                date_string="Published on 16 April 2019",
+                languages=["en"],
+                expected_datetime=datetime(2019, 4, 16),
+            ),
+            # Purely numeric dates do not need a month name to survive.
+            param(
+                date_string="published 2019-04-16 ok",
+                languages=["en"],
+                expected_datetime=datetime(2019, 4, 16),
+            ),
+            param(
+                date_string="xx 16/04/2019 yy",
+                languages=["en"],
+                expected_datetime=datetime(2019, 4, 16),
+            ),
+            # No language hint is needed: locales are tried as usual.
+            param(
+                date_string="Actualisé le 17 avril 2019",
+                languages=None,
+                expected_datetime=datetime(2019, 4, 17),
+            ),
+            # Strings that parse as a whole are parsed exactly as before.
+            param(
+                date_string="le 17 avril 2019",
+                languages=["fr"],
+                expected_datetime=datetime(2019, 4, 17),
+            ),
+            param(
+                date_string="17 avril 2019",
+                languages=["fr"],
+                expected_datetime=datetime(2019, 4, 17),
+            ),
+        ]
+    )
+    def test_dates_with_surrounding_text_are_parsed(
+        self, date_string, languages, expected_datetime
+    ):
+        self.when_date_is_parsed(
+            date_string,
+            languages=languages,
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_parsed_datetime_is(expected_datetime)
+
+    @parameterized.expand(
+        [
+            param(date_string="Actualisé le 17 avril 2019", languages=["fr"]),
+            param(date_string="Publié le 16 avril 2019", languages=["fr"]),
+            param(date_string="Published on 16 April 2019", languages=["en"]),
+        ]
+    )
+    def test_dates_with_surrounding_text_are_not_parsed_by_default(
+        self, date_string, languages
+    ):
+        self.when_date_is_parsed(date_string, languages=languages)
+        self.then_date_was_not_parsed()
+
+    @parameterized.expand(
+        [
+            # An unrecognized word inside the date still prevents parsing.
+            param(date_string="17 foobar avril 2019", languages=["fr"]),
+            # A string without any date content is still not parsed.
+            param(date_string="hello world", languages=["en"]),
+        ]
+    )
+    def test_non_dates_are_not_parsed_even_when_enabled(self, date_string, languages):
+        self.when_date_is_parsed(
+            date_string,
+            languages=languages,
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_date_was_not_parsed()
+
+    def test_surrounding_text_ignored_with_locales_argument(self):
+        self.when_date_is_parsed(
+            "Actualisé le 17 avril 2019",
+            locales=["fr-CA"],
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_parsed_datetime_is(datetime(2019, 4, 17))
+
+    def test_surrounding_text_ignored_with_region_argument(self):
+        self.when_date_is_parsed(
+            "Actualisé le 17 avril 2019",
+            languages=["fr"],
+            region="CA",
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_parsed_datetime_is(datetime(2019, 4, 17))
+
+    def test_surrounding_text_ignored_with_default_languages_setting(self):
+        self.when_date_is_parsed(
+            "Actualisé le 17 avril 2019",
+            settings={"IGNORE_SURROUNDING_TEXT": True, "DEFAULT_LANGUAGES": ["fr"]},
+        )
+        self.then_parsed_datetime_is(datetime(2019, 4, 17))
+
+    def test_surrounding_text_ignored_with_detected_language(self):
+        self.when_date_is_parsed(
+            "Actualisé le 17 avril 2019",
+            detect_languages_function=lambda text, confidence_threshold: ["fr"],
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_parsed_datetime_is(datetime(2019, 4, 17))
+
+    def test_surrounding_text_ignored_with_date_formats(self):
+        self.when_date_is_parsed(
+            "Published on 16/04/2019",
+            date_formats=["%d/%m/%Y"],
+            languages=["en"],
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.then_parsed_datetime_is(datetime(2019, 4, 16))
+
+    def test_relative_date_with_surrounding_text(self):
+        self.when_date_is_parsed(
+            "asdf 3 hours ago asdf",
+            languages=["en"],
+            settings={
+                "IGNORE_SURROUNDING_TEXT": True,
+                "RELATIVE_BASE": datetime(2019, 4, 17, 12, 0),
+            },
+        )
+        self.then_parsed_datetime_is(datetime(2019, 4, 17, 9, 0))
+
+    def test_strict_parsing_rejects_incomplete_remainder(self):
+        # The remainder is parsed as if it were the whole input, so settings
+        # such as STRICT_PARSING apply to it as usual.
+        self.when_date_is_parsed(
+            "Page 3",
+            languages=["en"],
+            settings={"IGNORE_SURROUNDING_TEXT": True, "STRICT_PARSING": True},
+        )
+        self.then_date_was_not_parsed()
+
+    def test_surrounding_text_can_turn_non_dates_into_dates(self):
+        # Documented caveat: with the setting enabled, a string that merely
+        # contains date-like words produces a date.
+        self.when_date_is_parsed(
+            "Chapter 12 March of the Penguins",
+            languages=["en"],
+            settings={
+                "IGNORE_SURROUNDING_TEXT": True,
+                "RELATIVE_BASE": datetime(2026, 7, 27),
+            },
+        )
+        self.then_parsed_datetime_is(datetime(2026, 3, 12))
+
+    def test_search_dates_is_not_affected_by_default(self):
+        # search_dates keeps relying on the strict behavior of get_date_data.
+        self.result = search_dates("Actualisé le 17 avril 2019", languages=["fr"])
+        self.assertEqual([("le 17 avril 2019", datetime(2019, 4, 17))], self.result)
+
+    def when_date_is_parsed(self, date_string, **kwargs):
+        self.result = dateparser.parse(date_string, **kwargs)
+
+    def then_parsed_datetime_is(self, expected_datetime):
+        self.assertEqual(expected_datetime, self.result)
 
     def then_date_was_not_parsed(self):
         self.assertIsNone(self.result)

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -714,6 +714,59 @@ class TestDateDataParser(BaseTestCase):
 
     @parameterized.expand(
         [
+            # Issue #518: harmless leading text (unknown words) must not prevent
+            # parsing of an otherwise unambiguous date.
+            param(
+                date_string="Actualisé le 17 avril 2019",
+                languages=["fr"],
+                expected=datetime(2019, 4, 17),
+            ),
+            param(
+                date_string="Publié le 16 avril 2019",
+                languages=["fr"],
+                expected=datetime(2019, 4, 16),
+            ),
+            # The bug is not French-specific: any unknown leading word breaks it.
+            param(
+                date_string="Published on 16 April 2019",
+                languages=["en"],
+                expected=datetime(2019, 4, 16),
+            ),
+            # Already-working baselines, guarded against regression.
+            param(
+                date_string="le 17 avril 2019",
+                languages=["fr"],
+                expected=datetime(2019, 4, 17),
+            ),
+            param(
+                date_string="17 avril 2019",
+                languages=["fr"],
+                expected=datetime(2019, 4, 17),
+            ),
+        ]
+    )
+    def test_dates_with_leading_extra_text_are_parsed(
+        self, date_string, languages, expected
+    ):
+        self.assertEqual(expected, dateparser.parse(date_string, languages=languages))
+
+    @parameterized.expand(
+        [
+            # Only leading/trailing extra text is tolerated; a string with no
+            # real date must still not be parsed.
+            param(date_string="Ceci n'est pas une date", languages=["fr"]),
+            # An unknown word in the *interior* of the date must still prevent a
+            # (wrong) match, so the strictness for genuine garbage is preserved.
+            param(date_string="17 foobar avril 2019", languages=["fr"]),
+            # A bare number left over after stripping extra text is not enough.
+            param(date_string="the 5 apples cost 3 dollars", languages=["en"]),
+        ]
+    )
+    def test_non_dates_with_extra_text_are_not_parsed(self, date_string, languages):
+        self.assertIsNone(dateparser.parse(date_string, languages=languages))
+
+    @parameterized.expand(
+        [
             param(
                 date_string="14 giu 13",
                 date_formats=["%y %B %d"],

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -712,58 +712,38 @@ class TestDateDataParser(BaseTestCase):
         self.then_date_was_parsed()
         self.then_parsed_date_has_timezone()
 
-    @parameterized.expand(
-        [
-            # Issue #518: harmless leading text (unknown words) must not prevent
-            # parsing of an otherwise unambiguous date.
-            param(
-                date_string="Actualisé le 17 avril 2019",
-                languages=["fr"],
-                expected=datetime(2019, 4, 17),
-            ),
-            param(
-                date_string="Publié le 16 avril 2019",
-                languages=["fr"],
-                expected=datetime(2019, 4, 16),
-            ),
-            # The bug is not French-specific: any unknown leading word breaks it.
-            param(
-                date_string="Published on 16 April 2019",
-                languages=["en"],
-                expected=datetime(2019, 4, 16),
-            ),
-            # Already-working baselines, guarded against regression.
-            param(
-                date_string="le 17 avril 2019",
-                languages=["fr"],
-                expected=datetime(2019, 4, 17),
-            ),
-            param(
-                date_string="17 avril 2019",
-                languages=["fr"],
-                expected=datetime(2019, 4, 17),
-            ),
-        ]
-    )
-    def test_dates_with_leading_extra_text_are_parsed(
-        self, date_string, languages, expected
-    ):
-        self.assertEqual(expected, dateparser.parse(date_string, languages=languages))
+    def test_ignore_surrounding_text_setting_parses_wrapped_date(self):
+        # Issue #518: a date wrapped in harmless extra text is parsed when the
+        # ``IGNORE_SURROUNDING_TEXT`` setting is enabled.
+        self.given_parser(
+            restrict_to_languages=["fr"], settings={"IGNORE_SURROUNDING_TEXT": True}
+        )
+        self.when_date_string_is_parsed("Actualisé le 17 avril 2019")
+        self.then_date_was_parsed()
+        self.then_parsed_datetime_is(datetime(2019, 4, 17))
+        self.then_detected_locale("fr")
+        self.then_period_is("day")
 
-    @parameterized.expand(
-        [
-            # Only leading/trailing extra text is tolerated; a string with no
-            # real date must still not be parsed.
-            param(date_string="Ceci n'est pas une date", languages=["fr"]),
-            # An unknown word in the *interior* of the date must still prevent a
-            # (wrong) match, so the strictness for genuine garbage is preserved.
-            param(date_string="17 foobar avril 2019", languages=["fr"]),
-            # A bare number left over after stripping extra text is not enough.
-            param(date_string="the 5 apples cost 3 dollars", languages=["en"]),
-        ]
-    )
-    def test_non_dates_with_extra_text_are_not_parsed(self, date_string, languages):
-        self.assertIsNone(dateparser.parse(date_string, languages=languages))
+    def test_get_date_data_ignores_surrounding_text_only_when_enabled(self):
+        # The safety property of the ``IGNORE_SURROUNDING_TEXT`` setting: by
+        # default, ``get_date_data`` keeps requiring the whole string to be a
+        # date, so language detection and ``search_dates`` are unaffected.
+        self.given_parser(restrict_to_languages=["fr"])
+        self.when_date_string_is_parsed("Actualisé le 17 avril 2019")
+        self.then_date_was_not_parsed()
+
+    def test_ignore_surrounding_text_with_try_previous_locales(self):
+        self.given_parser(
+            restrict_to_languages=["fr", "en"],
+            try_previous_locales=True,
+            settings={"IGNORE_SURROUNDING_TEXT": True},
+        )
+        self.when_date_string_is_parsed("Actualisé le 17 avril 2019")
+        self.then_parsed_datetime_is(datetime(2019, 4, 17))
+        self.then_previous_locales_is(["fr"])
+        self.when_date_string_is_parsed("Publié le 16 avril 2019")
+        self.then_parsed_datetime_is(datetime(2019, 4, 16))
+        self.then_previous_locales_is(["fr"])
 
     @parameterized.expand(
         [
@@ -1007,6 +987,9 @@ class TestDateDataParser(BaseTestCase):
 
     def then_date_was_parsed(self):
         self.assertIsNotNone(self.result["date_obj"])
+
+    def then_date_was_not_parsed(self):
+        self.assertIsNone(self.result["date_obj"])
 
     def then_date_locale(self):
         self.assertIsNotNone(self.result["locale"])

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2481,6 +2481,13 @@ class TestBundledLanguages(BaseTestCase):
             param("fr", "actualisé le 17 avril 2019", " 17 april 2019"),
             param("en", "published on 16 april 2019", " 16 april 2019"),
             param("en", "xx 16/04/2019 yy", "16/04/2019"),
+            # A recognized timezone at the trailing edge is kept, so the offset
+            # is not discarded; the result matches the unwrapped translation.
+            param(
+                "en",
+                "updated 23 march 2000 1:21 pm est",
+                "23 march 2000 1:21 pm  est",
+            ),
         ]
     )
     def test_translation_when_ignoring_surrounding_text(

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2438,6 +2438,60 @@ class TestBundledLanguages(BaseTestCase):
         self.when_datetime_string_checked_if_applicable(strip_timezone)
         self.then_language_is_not_applicable()
 
+    @parameterized.expand(
+        [
+            # Dates wrapped in text the locale does not recognize (issue #518).
+            param("fr", "actualisé le 17 avril 2019"),
+            param("fr", "publié le 16 avril 2019"),
+            param("en", "published on 16 april 2019"),
+            param("en", "xx 16/04/2019 yy"),
+        ]
+    )
+    def test_applicable_languages_when_ignoring_surrounding_text(
+        self, shortname, datetime_string
+    ):
+        self.given_settings()
+        self.given_bundled_language(shortname)
+        self.given_string(datetime_string)
+        self.when_datetime_string_checked_if_applicable_ignoring_surrounding_text()
+        self.then_language_is_applicable()
+
+    @parameterized.expand(
+        [
+            # An unrecognized token inside the date keeps the locale
+            # inapplicable: only the edges may be ignored.
+            param("fr", "17 foobar avril 2019"),
+            # Nothing is left when every token is unrecognized.
+            param("en", "hello world"),
+        ]
+    )
+    def test_not_applicable_languages_when_ignoring_surrounding_text(
+        self, shortname, datetime_string
+    ):
+        self.given_settings()
+        self.given_bundled_language(shortname)
+        self.given_string(datetime_string)
+        self.when_datetime_string_checked_if_applicable_ignoring_surrounding_text()
+        self.then_language_is_not_applicable()
+
+    @parameterized.expand(
+        [
+            # The result is the same as translating the date without the
+            # surrounding text.
+            param("fr", "actualisé le 17 avril 2019", " 17 april 2019"),
+            param("en", "published on 16 april 2019", " 16 april 2019"),
+            param("en", "xx 16/04/2019 yy", "16/04/2019"),
+        ]
+    )
+    def test_translation_when_ignoring_surrounding_text(
+        self, shortname, datetime_string, expected_translation
+    ):
+        self.given_settings()
+        self.given_bundled_language(shortname)
+        self.given_string(datetime_string)
+        self.when_datetime_string_translated_ignoring_surrounding_text()
+        self.then_string_translated_to(expected_translation)
+
     @apply_settings
     def given_settings(self, settings=None):
         self.settings = settings
@@ -2463,6 +2517,21 @@ class TestBundledLanguages(BaseTestCase):
     def when_datetime_string_checked_if_applicable(self, strip_timezone):
         self.result = self.language.is_applicable(
             self.datetime_string, strip_timezone, settings=self.settings
+        )
+
+    def when_datetime_string_checked_if_applicable_ignoring_surrounding_text(self):
+        self.result = self.language.is_applicable(
+            self.datetime_string,
+            strip_timezone=False,
+            settings=self.settings,
+            ignore_surrounding_text=True,
+        )
+
+    def when_datetime_string_translated_ignoring_surrounding_text(self):
+        self.translation = self.language.translate(
+            self.datetime_string,
+            settings=self.settings,
+            ignore_surrounding_text=True,
         )
 
     def then_string_translated_to(self, expected_string):

--- a/tests/test_timezone_parser.py
+++ b/tests/test_timezone_parser.py
@@ -11,7 +11,9 @@ from dateparser import parse
 from dateparser.timezone_parser import (
     StaticTzInfo,
     get_local_tz_offset,
+    is_timezone_token,
     pop_tz_offset_from_string,
+    word_is_tz,
 )
 from tests import BaseTestCase
 
@@ -240,3 +242,37 @@ class TestStaticTzInfo(BaseTestCase):
     def then_localized_date_is(self, expected_date, expected_tzname):
         self.assertEqual(self.localized_date.date(), expected_date.date())
         self.assertEqual(self.localized_date.tzname(), expected_tzname)
+
+
+class TestIsTimezoneToken(BaseTestCase):
+    """Unit tests for ``is_timezone_token``, used to keep a trailing timezone
+    when ``IGNORE_SURROUNDING_TEXT`` strips edge tokens."""
+
+    @parameterized.expand(
+        [
+            param(token="EST", expected=True),
+            # Already-lowercased and space-padded tokens (as produced by the
+            # translation pipeline) are recognized too.
+            param(token="est", expected=True),
+            param(token=" est", expected=True),
+            param(token="cet", expected=True),
+            param(token="pst", expected=True),
+            param(token="utc", expected=True),
+            # A longer word that merely starts with a timezone abbreviation must
+            # not be treated as a timezone.
+            param(token="actualisé", expected=False),
+            param(token="ACTUALISÉ", expected=False),
+            param(token="updated", expected=False),
+            param(token="", expected=False),
+            param(token="   ", expected=False),
+        ]
+    )
+    def test_is_timezone_token(self, token, expected):
+        self.assertEqual(expected, is_timezone_token(token))
+
+    def test_anchored_match_unlike_word_is_tz(self):
+        # word_is_tz prefix-matches ("ACT" of "ACTUALISÉ"); is_timezone_token is
+        # anchored, so it does not — this is what keeps a noise word from
+        # surviving as a timezone when edges are stripped.
+        self.assertTrue(word_is_tz("ACTUALISÉ"))
+        self.assertFalse(is_timezone_token("ACTUALISÉ"))


### PR DESCRIPTION
## Summary

`dateparser.parse()` returns `None` for strings that are a perfectly good date wrapped in a bit of harmless leading (or trailing) text, e.g. `'Actualisé le 17 avril 2019'` (issue #518). The problem is not French-specific — the same happens in any language.

This PR adds an explicit, **opt-in** `IGNORE_SURROUNDING_TEXT` setting (default: `False`) implemented inside `DateDataParser.get_date_data()`:

```python
>>> import dateparser
>>> dateparser.parse('Actualisé le 17 avril 2019', languages=['fr'])
>>> dateparser.parse('Actualisé le 17 avril 2019', languages=['fr'],
...                  settings={'IGNORE_SURROUNDING_TEXT': True})
datetime.datetime(2019, 4, 17, 0, 0)
>>> dateparser.parse('Published on 16/04/2019', settings={'IGNORE_SURROUNDING_TEXT': True})
datetime.datetime(2019, 4, 16, 0, 0)
```

Closes #518.

## Root cause

`parse()` requires the **whole** string to be recognised: before a locale is even tried, `Locale.is_applicable()` → `Dictionary.are_tokens_valid()` demands that every token be a number, a relative expression, or a dictionary word. A single unknown word such as `Actualisé` makes the locale non-applicable, so parsing gives up before it starts.

## Design

The setting is honored by `get_date_data()` itself, so `parse()` and `get_date_data()` always agree, and it works the same regardless of how the language is known (`languages=`, `locales=`, `region=`, `DEFAULT_LANGUAGES`, `detect_languages_function`, or full-scan when no hint is given).

When the setting is enabled **and the regular, whole-string parse found nothing**, `get_date_data()` retries the same locale iteration with `ignore_surrounding_text=True`:

1. `Locale.is_applicable(..., ignore_surrounding_text=True)` validates the tokens after `Dictionary._strip_unknown_edge_tokens()` removes unrecognised tokens from the leading/trailing edges. An unrecognised token in the *interior* still makes the locale non-applicable, so `'17 foobar avril 2019'` stays unparsed.
2. `Locale.translate(..., ignore_surrounding_text=True)` drops the same edge tokens *inside* the single, normal translation pass (numerals → normalization → simplifications → split → strip → translate → join), then parsing proceeds exactly as usual. The result is identical to parsing the wrapped date without its surrounding text.

Because stripping happens inside the regular pipeline, there is no re-simplification, no re-joining of raw tokens, and `date_formats`, `STRICT_PARSING`, `REQUIRE_PARTS`, `PREFER_*` etc. compose naturally. Purely numeric dates (`'published 2019-04-16 ok'`) and relative expressions (`'asdf 3 hours ago asdf'`) are handled too — no month/weekday anchor is required, since enabling the setting is an explicit request for this behavior.

## Why this is safe

- **Default behavior is byte-for-byte unchanged**: with the setting off (the default), no new code path runs. `search_dates()` and language detection keep their existing strictness; tests lock this in.
- **Fully parseable strings are unaffected even with the setting on**: the fallback only runs after the normal parse found nothing, so e.g. `'23 March 2000, 1:21 PM CET'` still parses timezone-aware.
- The ignored-text behavior is documented in `docs/settings.rst`, including the caveat that strings merely containing date-like words (e.g. `'Chapter 12 March of the Penguins'`) produce a date when the setting is enabled, and the suggestion to combine it with `STRICT_PARSING`/`REQUIRE_PARTS`.

## Tests

- `tests/test_clean_api.py`: `parse()`-level tests — the issue examples, numeric/`date_formats`/relative cases, every language-hint source, default-off locks, non-date guards, the documented caveat, and a `search_dates` strictness lock.
- `tests/test_date.py`: `get_date_data()`-level tests, including `try_previous_locales` and the default-strict lock.
- `tests/test_languages.py`: `Locale.is_applicable`/`translate` unit tests for `ignore_surrounding_text`, asserting the stripped translation equals the translation of the unwrapped date.

Full suite: `24114 passed, 20 skipped, 1 xfailed`. 100% patch coverage; ruff/ruff-format clean; docs build clean.

## Known limitations

- No-word-spacing languages can still fail when the surrounding text itself contains a date word: in `'更新日 2019年4月17日 です'` (ja), `更新日` splits into `更新` + the known token `日`, which leaves a dangling "day" unit the parser cannot drop (same class of problem as the `parse()` facet of #521, out of scope here). `'2019年4月17日 です'` works.
- `region='FR'` *without* `languages` cannot parse French with or without this setting, because the loader has no `<lang>-FR` locale for `fr` (plain `fr` covers France); that is pre-existing loader behavior, unrelated to this PR. `languages=['fr'], region=...` and `locales=['fr-CA']` work with the setting and are tested.
