### PR TITLE
Specify README header content as RST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,21 @@
 
 .. raw:: html
 
-    <h1 align="center">
-        <br/>
-        <a href="https://github.com/scrapinghub/dateparser">
-            <img src="artwork/dateparser-logo.png" alt="Dateparser" width="500">
-        </a>
-        <br/>
-    </h1>
+    <div align="center">
 
-    <h3 align="center">Python parser for human readable dates</h4>
+
+.. image:: artwork/dateparser-logo.png
+   :alt: Dateparser
+   :width: 500
+   :target: https://github.com/scrapinghub/dateparser
+
+
+**Python parser for human readable dates**
+
+
+.. raw:: html
+
+    </div>
 
     <p align="center">
         <a href="https://pypi.python.org/pypi/dateparser">

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,12 @@
 
     </div>
 
+
+.. docs-include-marker
+
+
+.. raw:: html
+
     <p align="center">
         <a href="https://pypi.python.org/pypi/dateparser">
             <img src="https://img.shields.io/pypi/dm/dateparser.svg" alt="PyPI - Downloads">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@ dateparser -- python parser for human readable dates
 ====================================================
 
 .. include:: ../README.rst
+   :start-after: docs-include-marker
 
 Indices and tables
 ------------------


### PR DESCRIPTION
Instead of HTML. Centering HTML is still there, but simplified. This means image and title is shown in PyPI. See https://github.com/EpicWink/dateparser/tree/rst-readme for rendered page