### PR TITLE
1.4.2 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,47 @@
 History
 =======
 
+1.4.2 (unreleased)
+------------------
+
+New features:
+
+- Add an ``IGNORE_SURROUNDING_TEXT`` setting that, when enabled, retries
+  parsing after ignoring the leading and trailing words the language does
+  not recognize, so a date wrapped in extra text such as "Published on
+  16/04/2019" is parsed (#1356)
+- Add a ``strategy`` argument to ``search_dates()`` to choose the search
+  strategy: the default ``"split"`` keeps the current behavior, while the
+  new ``"ngram"`` strategy parses the longest sequences of tokens as dates
+  for more predictable results on noisy text (#1351)
+
+Fixes:
+
+- Do not read a two-digit number as a year once a later component has been
+  found in year-first date orders, so the day in Japanese dates such as
+  "4月20日" is no longer consumed as the year (#1358)
+- Parse ISO 8601 dates (those starting with a four-digit year) in month-day
+  order even when an explicit day-first language such as ``it`` or ``fr`` is
+  given, without needing to set ``PREFER_LOCALE_DATE_ORDER`` to ``False``
+  (#1352)
+- Honor ``PREFER_DATES_FROM`` and ``RELATIVE_BASE`` when parsing with custom
+  ``date_formats`` that use a two-digit year (``%y``) (#1342)
+- Honor the ``%j`` (day of year) directive in ``date_formats`` instead of
+  overwriting the parsed month and day with the current date (#1345)
+
+Improvements:
+
+- Update the bundled CLDR locale data to 44.1.0, adding many newly
+  recognized date forms across locales and a standalone hour/duration unit
+  (e.g. Catalan "2 hores"), while keeping previously supported forms
+  parseable (#1343)
+- Add the Italian expressions "un ora fa" and "un'ora fa", and skip "alle"
+  so phrases like "oggi alle 11:00" parse (#1049)
+- Expand Czech date translations with month locative/dative forms (e.g. "v
+  lednu 2023"), the July abbreviation "črv", and relative expressions such
+  as "za týden", "za měsíc" and "za rok" (#1172)
+- Specify the README header content as RST rather than raw HTML (#1360)
+
 1.4.1 (2026-06-15)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 History
 =======
 
-1.4.2 (unreleased)
+1.4.2 (2026-08-04)
 ------------------
 
 New features:

--- a/dateparser/__init__.py
+++ b/dateparser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 from .conf import apply_settings
 from .date import DateDataParser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "dateparser"
-version = "1.4.1"
+version = "1.4.2"
 description = "Date parsing library designed to parse dates from HTML pages"
 authors = [
     { name = "Scrapinghub", email = "opensource@zyte.com" },


### PR DESCRIPTION
Release notes and version bump for **dateparser 1.4.2**, following the same two-step approach used for 1.4.1 (#1337):

1. **`1.4.2 release notes`** — add the `1.4.2` section to `HISTORY.rst`, summarizing every PR merged since `v1.4.1`.
2. **`Bump version: 1.4.1 → 1.4.2`** — produced by `bump-my-version bump patch`, updating `pyproject.toml`, `dateparser/__init__.py`, and stamping the `HISTORY.rst` release date. `SECURITY.md` is unchanged because it tracks only `major.minor` (still `1.4.x`).

### Changelog

**New features:**
- Add an `IGNORE_SURROUNDING_TEXT` setting that, when enabled, retries parsing after ignoring the leading and trailing words the language does not recognize, so a date wrapped in extra text such as `Published on 16/04/2019` is parsed (#1356)
- Add a `strategy` argument to `search_dates()` to choose the search strategy: the default `"split"` keeps the current behavior, while the new `"ngram"` strategy parses the longest sequences of tokens as dates for more predictable results on noisy text (#1351)

**Fixes:**
- Do not read a two-digit number as a year once a later component has been found in year-first date orders, so the day in Japanese dates such as `4月20日` is no longer consumed as the year (#1358)
- Parse ISO 8601 dates (those starting with a four-digit year) in month-day order even when an explicit day-first language such as `it` or `fr` is given, without needing to set `PREFER_LOCALE_DATE_ORDER` to `False` (#1352)
- Honor `PREFER_DATES_FROM` and `RELATIVE_BASE` when parsing with custom `date_formats` that use a two-digit year (`%y`) (#1342)
- Honor the `%j` (day of year) directive in `date_formats` instead of overwriting the parsed month and day with the current date (#1345)

**Improvements:**
- Update the bundled CLDR locale data to 44.1.0, adding many newly recognized date forms across locales and a standalone hour/duration unit (e.g. Catalan `2 hores`), while keeping previously supported forms parseable (#1343)
- Add the Italian expressions `un ora fa` and `un'ora fa`, and skip `alle` so phrases like `oggi alle 11:00` parse (#1049)
- Expand Czech date translations with month locative/dative forms (e.g. `v lednu 2023`), the July abbreviation `črv`, and relative expressions such as `za týden`, `za měsíc` and `za rok` (#1172)
- Specify the README header content as RST rather than raw HTML (#1360)

### Validation

- `bump-my-version bump patch` produced a clean two-commit diff touching only `HISTORY.rst`, `pyproject.toml`, and `dateparser/__init__.py`; version is consistent across all three.
- `python -m build` + `twine check` pass for both the sdist and the wheel.
- Test suite green over the areas changed this cycle (`test_search`, `test_clean_api`, `test_date`, `test_date_parser`, `test_languages`, `test_timezone_parser`).

### After merge

The `v1.4.2` git tag is intentionally **not** included in this branch (a tag on a pre-merge branch would point at the wrong commit). After merging, tag the merge commit on `master`:

```
git tag v1.4.2 && git push origin v1.4.2
```

All PRs merged since `v1.4.1` are included in the changelog above; there were no internal-only changes to omit this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
