### PR TITLE
Fix parsing time-only strings with a timezone-aware RELATIVE_BASE

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -564,7 +564,9 @@ class _parser:
             # Convert dateobj to utc time to compare with self.now
             try:
                 tz = tz or get_timezone_from_tz_string(self.settings.TIMEZONE)
-                tz_offset = tz.utcoffset(dateobj)
+                # `dateobj` may have been localized above when `self.now` is
+                # offset-aware; `utcoffset()` requires a naive datetime.
+                tz_offset = tz.utcoffset(dateobj.replace(tzinfo=None))
             except (pytz.UnknownTimeZoneError, pytz.NonExistentTimeError):
                 tz_offset = timedelta(hours=0)
 

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from functools import wraps
 from unittest.mock import Mock, patch
 
+import pytz
 from parameterized import param, parameterized
 
 import dateparser.timezone_parser
@@ -709,6 +710,27 @@ class TestDateParser(BaseTestCase):
         self.when_date_is_parsed(date_string)
         self.then_date_was_parsed_by_date_parser()
         self.then_date_obj_exactly_is(expected)
+
+    @parameterized.expand(
+        [
+            param("3pm", "past", datetime(2020, 6, 15, 18, 0)),
+            param("3pm", "future", datetime(2020, 6, 15, 12, 0)),
+        ]
+    )
+    def test_time_only_with_timezone_aware_relative_base(
+        self, date_string, prefer_dates_from, relative_base
+    ):
+        tz = pytz.timezone("America/Los_Angeles")
+        self.given_parser(
+            settings={
+                "TIMEZONE": "America/Los_Angeles",
+                "PREFER_DATES_FROM": prefer_dates_from,
+                "RELATIVE_BASE": tz.localize(relative_base),
+            }
+        )
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.then_period_is("day")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Closes #1213

When `RELATIVE_BASE` is offset-aware, `_correct_for_time_frame` localizes `dateobj` to UTC so it can be compared with `self.now`, and the following `tz.utcoffset(dateobj)` then gets an aware datetime, which pytz rejects with `ValueError: Not naive datetime`. That error isn't one of the two pytz exceptions caught there, so parsing aborts and `parse("3pm", ...)` returns `None`. Passing a naive copy to `utcoffset()` fixes it; a naive `RELATIVE_BASE` is unaffected.

Regression test added in `tests/test_date_parser.py` (both `PREFER_DATES_FROM` directions); it fails on master and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
