### PR TITLE
tests: add CodSpeed benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,56 @@
+name: CodSpeed
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+    paths:
+      - dateparser/**
+      - dateparser_data/**
+      - tests/benchmarks/**
+      - pytest.ini
+      - tox.ini
+      - pyproject.toml
+      - .github/workflows/codspeed.yml
+  # Lets CodSpeed trigger a run to collect the initial baseline.
+  workflow_dispatch:
+
+# Superseded runs of the same pull request are cancelled. Outside pull requests
+# the group is unique per run, so a master baseline is never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    # A reintroduced #1335-style regression makes the benchmarks orders of
+    # magnitude slower, so cap the job instead of letting it run for hours.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+          tox -e benchmark --notest
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v5
+        with:
+          mode: simulation
+          # The step above already built the environment, so the measured command
+          # only runs pytest instead of packaging and installing again.
+          run: tox -e benchmark --skip-pkg-install

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ docs/_build
 # CLDR
 /cldr-json/
 
+# CodSpeed
+.codspeed
+
 # Other
 raw_data

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,41 @@
+"""CodSpeed benchmarks.
+
+These are only collected when ``pytest-codspeed`` is installed, which is the
+case in the dedicated ``benchmark`` tox environment (see ``tox.ini``). In every
+other environment they are skipped, so the regular test runs are unaffected.
+"""
+
+import pytest
+
+pytest.importorskip("pytest_codspeed", reason="Benchmark tests require pytest-codspeed")
+
+# Relative date strings in the form the freshness parser actually receives them:
+# the locale translates the input first, which turns plural units singular
+# ("2 hours, 50 minutes ago" -> "2 hour 50 minute ago"). PATTERN only matches
+# singular units, so benchmarking the untranslated strings would measure a failed
+# scan instead of the real workload.
+#
+# Each benchmark runs the whole list rather than a single string: CodSpeed's
+# simulation mode measures one call, and a lone match on a short string is too
+# small a unit of work to be meaningful.
+TRANSLATED_RELATIVE_STRINGS = [
+    "1 minute ago",
+    "2 hour 50 minute ago",
+    "3 day ago",
+    "in 2 week",
+    "10.5 year ago",
+    "1 day 2 hour 3 minute 4 second ago",
+]
+
+# A long run of digits: the input shape that made the relative-date regexes
+# backtrack superlinearly before #1335. Deliberately pathological rather than
+# realistic -- it is what turns a reintroduced regression into an unmissable
+# signal.
+#
+# The length is chosen so that a regressed run still *finishes and reports*:
+# with the old greedy quantifiers this takes ~380ms against ~0.7ms for the
+# possessive ones, a ~500x jump that no threshold can miss, while remaining a
+# handful of seconds under CodSpeed's instrumentation. The 3200 digits of the
+# original #1335 repro would instead need ~20 minutes per benchmark once
+# regressed, so the job would time out without ever reporting.
+LONG_DIGIT_RUN = "9" * 800

--- a/tests/benchmarks/test_benchmark_freshness_date_parser.py
+++ b/tests/benchmarks/test_benchmark_freshness_date_parser.py
@@ -1,0 +1,60 @@
+r"""Benchmarks for :mod:`dateparser.freshness_date_parser`.
+
+``PATTERN`` matches a number followed by a time unit, and is applied to the whole
+input string by ``findall()`` (in ``get_kwargs()``) and by ``sub()`` (in
+``_parse_time()``). Until #1335 it spelled the number as the greedy
+``\d+[.,]?\d*``, whose adjacent digit quantifiers backtrack without ever
+changing the match, so the cost grew superlinearly with the length of a digit
+run. #1335 made the quantifiers possessive (``\d++[.,]?\d*+``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dateparser.freshness_date_parser import PATTERN, freshness_date_parser
+from tests.benchmarks import LONG_DIGIT_RUN, TRANSLATED_RELATIVE_STRINGS
+
+if TYPE_CHECKING:
+    from pytest_codspeed import BenchmarkFixture
+
+
+def test_freshness_pattern_findall(benchmark: BenchmarkFixture) -> None:
+    def run():
+        for date_string in TRANSLATED_RELATIVE_STRINGS:
+            PATTERN.findall(date_string)
+
+    # Guard against measuring a no-op: were PATTERN to stop matching these
+    # inputs, the benchmark would get faster instead of failing.
+    assert PATTERN.findall(TRANSLATED_RELATIVE_STRINGS[-1]) == [
+        ("1", "day"),
+        (" 2", "hour"),
+        (" 3", "minute"),
+        (" 4", "second"),
+    ]
+
+    benchmark(run)
+
+
+def test_freshness_pattern_findall_long_digit_run(benchmark: BenchmarkFixture) -> None:
+    assert PATTERN.findall(LONG_DIGIT_RUN) == []
+
+    benchmark(lambda: PATTERN.findall(LONG_DIGIT_RUN))
+
+
+def test_freshness_pattern_sub_long_digit_run(benchmark: BenchmarkFixture) -> None:
+    """``_parse_time()`` runs ``PATTERN.sub()`` over the input as well."""
+    assert PATTERN.sub("", LONG_DIGIT_RUN) == LONG_DIGIT_RUN
+
+    benchmark(lambda: PATTERN.sub("", LONG_DIGIT_RUN))
+
+
+def test_freshness_get_kwargs(benchmark: BenchmarkFixture) -> None:
+    def run():
+        for date_string in TRANSLATED_RELATIVE_STRINGS:
+            freshness_date_parser.get_kwargs(date_string)
+
+    kwargs, _ = freshness_date_parser.get_kwargs(TRANSLATED_RELATIVE_STRINGS[1])
+    assert kwargs == {"hours": 2.0, "minutes": 50.0}
+
+    benchmark(run)

--- a/tests/benchmarks/test_benchmark_languages.py
+++ b/tests/benchmarks/test_benchmark_languages.py
@@ -1,0 +1,40 @@
+r"""Benchmarks for :mod:`dateparser.languages.dictionary`.
+
+``Dictionary.split()`` first splits the input with a regex built from the
+locale's ``relative-type-regex`` entries. Those entries carried the same greedy
+``\d+[.,]?\d*`` that #1335 replaced with the possessive ``\d++[.,]?\d*+``, and
+because the alternation is applied by ``re.split()`` across the whole input, a
+long digit run backtracked quadratically here too.
+
+The typical-input side of ``Dictionary.split()`` is covered end to end by
+``test_benchmark_parse.py``, which reaches it through the real locale objects.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import dateparser.data.date_translation_data.en as en_data
+from dateparser.conf import settings
+from dateparser.languages.dictionary import Dictionary
+from tests.benchmarks import LONG_DIGIT_RUN
+
+if TYPE_CHECKING:
+    from pytest_codspeed import BenchmarkFixture
+
+
+def test_dictionary_split_relative_regex_long_digit_run(
+    benchmark: BenchmarkFixture,
+) -> None:
+    # Only the compiled relative-split regex is taken from the dictionary, as
+    # ``tests/test_freshness_date_parser.py`` already does. For English the
+    # regex a plain Dictionary compiles is identical to the NormalizedDictionary
+    # one the parser uses, since normalization leaves these strings untouched.
+    split_relative_regex = Dictionary(
+        en_data.info, settings
+    )._get_split_relative_regex_cache()
+
+    # A digit run holds no relative-date string, so it must come back unsplit.
+    assert split_relative_regex.split(LONG_DIGIT_RUN) == [LONG_DIGIT_RUN]
+
+    benchmark(lambda: split_relative_regex.split(LONG_DIGIT_RUN))

--- a/tests/benchmarks/test_benchmark_parse.py
+++ b/tests/benchmarks/test_benchmark_parse.py
@@ -1,0 +1,52 @@
+"""Benchmarks for the public :func:`dateparser.parse` entry point.
+
+Where the other benchmark modules pin down individual regexes, these cover the
+end-to-end cost a caller actually pays, so that a slowdown anywhere in the
+parsing pipeline is caught too.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import dateparser
+
+if TYPE_CHECKING:
+    from pytest_codspeed import BenchmarkFixture
+
+RELATIVE_DATE_STRINGS = [
+    "2 hours ago",
+    "3 days ago",
+    "in 5 minutes",
+    "a week ago",
+    "2 months, 3 weeks ago",
+]
+
+ABSOLUTE_DATE_STRINGS = [
+    "2015-06-01",
+    "June 1, 2015",
+    "01/06/2015",
+    "1st of June 2015",
+    "2015-06-01T13:00:00Z",
+]
+
+
+def _benchmark_parse(benchmark: BenchmarkFixture, date_strings: list[str]) -> None:
+    def run():
+        for date_string in date_strings:
+            dateparser.parse(date_string)
+
+    # Load the locale data and warm the parser caches outside the measurement.
+    run()
+
+    assert dateparser.parse(date_strings[0]) is not None
+
+    benchmark(run)
+
+
+def test_parse_relative_date_strings(benchmark: BenchmarkFixture) -> None:
+    _benchmark_parse(benchmark, RELATIVE_DATE_STRINGS)
+
+
+def test_parse_absolute_date_strings(benchmark: BenchmarkFixture) -> None:
+    _benchmark_parse(benchmark, ABSOLUTE_DATE_STRINGS)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit,min,min-all,py310,py311,py312,py313,py314,all,scripts,docs,twinedeck
+envlist = pre-commit,min,min-all,py310,py311,py312,py313,py314,all,scripts,docs,twinedeck,benchmark
 
 [base]
 deps =
@@ -70,3 +70,22 @@ deps =
 commands =
     python -m build --sdist --wheel
     twine check dist/*
+
+# Pinned to a single interpreter: CodSpeed compares measurements across runs, and
+# instruction counts are not comparable between Python versions.
+[testenv:benchmark]
+basepython = python3.13
+deps =
+    {[base]deps}
+    pytest-codspeed
+# The CodSpeed runner drives pytest-codspeed through CODSPEED_* variables, which
+# have to reach the command tox runs for any measurement to happen.
+passenv =
+    *codspeed*
+    *ci*
+# tox picks a random hash seed per run, which would show up as noise in the
+# instruction counts CodSpeed compares.
+set_env =
+    PYTHONHASHSEED = 0
+commands =
+    pytest tests/benchmarks/ --no-cov --codspeed


### PR DESCRIPTION
Closes #1336

## Why

#1335 fixed a serious performance problem in the relative-date regexes. The
number was spelled as the greedy `\d+[.,]?\d*`, whose adjacent digit quantifiers
backtrack without ever changing the match, so the cost grew superlinearly with
the length of a digit run — `PATTERN.findall('9' * 3200)` took ~23s. Making the
quantifiers possessive (`\d++[.,]?\d*+`) brought that back to ~10ms.

Nothing in CI would have caught that regression when it was introduced: the
suite still passed, it just got slow. #1336 asks for CodSpeed so this class of
change is measured, following the precedent of scrapy/w3lib#247.

## Benchmarks

`tests/benchmarks/`, 7 benchmarks. Each one runs a list of inputs rather than a
single string, because CodSpeed's simulation mode measures a single call and one
match on a short string is too small a unit of work to be meaningful.

**`test_benchmark_freshness_date_parser.py`** — `PATTERN`, the regex #1335
changed, on both of its call sites:

- `test_freshness_pattern_findall` — typical relative phrases (`get_kwargs()`)
- `test_freshness_pattern_findall_long_digit_run` — the #1335 input shape
- `test_freshness_pattern_sub_long_digit_run` — same, via the `sub()` in `_parse_time()`
- `test_freshness_get_kwargs`

The typical inputs are the *translated* forms the freshness parser actually
receives (`"2 hour 50 minute ago"`, not `"2 hours, 50 minutes ago"`), since
`PATTERN` only matches singular units — the untranslated strings would have
benchmarked a failed scan.

**`test_benchmark_languages.py`** — the second path #1335 touched: the relative-split
regex `Dictionary` compiles from the locale's `relative-type-regex` entries,
applied by `re.split()` across the whole input.

**`test_benchmark_parse.py`** — `dateparser.parse()` end to end for relative and
absolute strings, so a slowdown anywhere in the pipeline is caught too.

Assertions sit outside the measured region and guard against a benchmark
silently degrading into measuring a no-op — a regex that stops matching would
otherwise show up as an *improvement*.

## Would a #1335 revert actually be caught?

Measured locally, old greedy pattern vs. current possessive one, same inputs and
identical match results:

| digits | old (greedy) | new (possessive) | ratio |
|---|---|---|---|
| 100 | 1.7 ms | 24.6 µs | 69x |
| 400 | 55 ms | 224 µs | 248x |
| 800 | 381 ms | 719 µs | **530x** |
| 3200 | 20.5 s | 9.7 ms | 2109x |

`LONG_DIGIT_RUN` is 800 digits rather than the 3200 of the original repro. 800 is
already a ~500x signal that no threshold can miss, and a regressed run still
finishes in seconds under instrumentation so CodSpeed *reports* it. At 3200 a
regressed run would need ~20 minutes per benchmark and the job would time out
without reporting anything.

## CI

New `.github/workflows/codspeed.yml`: push to master, pull requests (path
filtered), and `workflow_dispatch` so CodSpeed can collect the initial baseline.
`id-token: write` on the job for CodSpeed's OIDC authentication, `contents: read`
at the top level, and `timeout-minutes: 30` so a regressed run is capped rather
than burning hours of runner time.

Benchmarks run through tox, as in w3lib: `tox -e benchmark --notest` prepares the
environment first, then `CodSpeedHQ/action@v5` runs
`tox -e benchmark --skip-pkg-install` under instrumentation, so the measured
command only runs pytest instead of rebuilding and reinstalling the package.

New `[testenv:benchmark]` in `tox.ini`, pinned to Python 3.13 because instruction
counts are not comparable between interpreter versions. It also sets
`PYTHONHASHSEED = 0`: tox otherwise picks a random hash seed per run, which would
show up as noise in the counts CodSpeed compares. Unlike w3lib this does not
hardcode `--codspeed-mode`, so the action's `mode` input stays authoritative and
cannot silently disagree with the tox command.

## Impact on the existing test suite

None. No existing test was modified. The benchmarks are guarded by
`pytest.importorskip("pytest_codspeed")`, so they are collected only in the
`benchmark` environment and skipped everywhere else. `pytest-codspeed` is a
dependency of that tox environment only, not of the package.

## Status of the first CI run

The `Build` workflow is green across the whole matrix, including `pre-commit`,
so the benchmarks skip cleanly on 3.10–3.14 and nothing else moved.

The CodSpeed job measured successfully — the log shows valgrind being installed,
`skip building and installing the package` taking effect,
`codspeed: 5.0.3 (enabled, mode: simulation, callgraph: enabled)` and
`7 benchmarked / 7 passed`, with the whole job taking 18s. So the instrumentation
really does engage through tox rather than quietly running plain tests.

It then fails on the last step only:

```
Uploading results
##[error]Failed to retrieve upload data: 401 Unauthorized
  -> Reason: Repository not found or the user does not have access to it.
```

That is the expected outcome until `scrapinghub/dateparser` is connected on
codspeed.io (CodSpeed GitHub App installed on the repository). Once it is
onboarded, OIDC authentication covers a public repo and no upload token is
needed; `workflow_dispatch` is there so CodSpeed can then backfill a baseline.
Nothing in this branch needs to change for that — it is a one-off account-side
step, and the red check will clear on the next run afterwards.
