### PR TITLE
Do not truncate relative dates that use thousands separators

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -11,7 +11,7 @@ from .timezone_parser import pop_tz_offset_from_string
 
 _UNITS = r"decade|year|month|week|day|hour|minute|second"
 PATTERN = re.compile(
-    r"([+-]?\s*\d++(?:,\d{3})*+(?:[.,]\d++)?+)\s*(%s)\b" % _UNITS,
+    r"([+-]?\s*\d++(?:[.,]\d++)*+)\s*(%s)\b" % _UNITS,
     re.I | re.S | re.U,
 )
 # A ``,`` grouping exactly three digits (optionally repeated) is a thousands
@@ -28,10 +28,18 @@ def _parse_number(num):
     before a shorter group is treated as the decimal separator.
     """
     num = num.replace(" ", "")
-    if "." in num:
-        # ``.`` is the decimal separator, so any ``,`` groups thousands.
-        num = num.replace(",", "")
+    if "." in num and "," in num:
+        # Both separators are present, so the one that comes last is the
+        # decimal separator and the other one groups thousands.
+        decimal, thousands = (
+            (".", ",") if num.rfind(".") > num.rfind(",") else (",", ".")
+        )
+        num = num.replace(thousands, "").replace(decimal, ".")
     elif _THOUSANDS_GROUPED.fullmatch(num):
+        num = num.replace(",", "")
+    elif num.count(",") > 1:
+        # Repeated ``,`` cannot be a decimal separator, and the token is not a
+        # well-formed grouping either; drop the separators instead of failing.
         num = num.replace(",", "")
     else:
         num = num.replace(",", ".")

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -10,7 +10,32 @@ from .parser import time_parser
 from .timezone_parser import pop_tz_offset_from_string
 
 _UNITS = r"decade|year|month|week|day|hour|minute|second"
-PATTERN = re.compile(r"([+-]?\s*\d++[.,]?\d*+)\s*(%s)\b" % _UNITS, re.I | re.S | re.U)
+PATTERN = re.compile(
+    r"([+-]?\s*\d++(?:,\d{3})*+(?:[.,]\d++)?+)\s*(%s)\b" % _UNITS,
+    re.I | re.S | re.U,
+)
+# A ``,`` grouping exactly three digits (optionally repeated) is a thousands
+# separator, e.g. ``1,000`` or ``1,000,000``.
+_THOUSANDS_GROUPED = re.compile(r"[+-]?\d{1,3}(?:,\d{3})+")
+
+
+def _parse_number(num):
+    """Convert a captured numeric token such as ``1,000`` or ``0,5`` to a float.
+
+    ``,`` is ambiguous: depending on locale it groups thousands (``1,000``) or
+    marks the decimal fraction (``0,5``, added in #876). A ``,`` followed by
+    exactly three digits is treated as a thousands separator; a lone ``,``
+    before a shorter group is treated as the decimal separator.
+    """
+    num = num.replace(" ", "")
+    if "." in num:
+        # ``.`` is the decimal separator, so any ``,`` groups thousands.
+        num = num.replace(",", "")
+    elif _THOUSANDS_GROUPED.fullmatch(num):
+        num = num.replace(",", "")
+    else:
+        num = num.replace(",", ".")
+    return float(num)
 
 
 class FreshnessDateDataParser:
@@ -170,7 +195,7 @@ class FreshnessDateDataParser:
         for num, unit in m:
             has_explicit_sign = num.startswith("+") or num.startswith("-")
             explicit_signs[unit + "s"] = has_explicit_sign
-            kwargs[unit + "s"] = float(num.replace(",", ".").replace(" ", ""))
+            kwargs[unit + "s"] = _parse_number(num)
 
         return kwargs, explicit_signs
 

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -2589,6 +2589,11 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("in 10.75 minutes", date(2010, 6, 4), time(13, 25, 45)),
             param("in 1.5 days", date(2010, 6, 6), time(1, 15)),
             param("0,5 hours ago", date(2010, 6, 4), time(12, 45)),
+            param("1,5 hours ago", date(2010, 6, 4), time(11, 45)),
+            # Thousands separators must not truncate the relative number (#1367)
+            param("1,000 days ago", date(2007, 9, 8), time(13, 15)),
+            param("12,345 days ago", date(1976, 8, 16), time(13, 15)),
+            param("2,000 hours ago", date(2010, 3, 13), time(5, 15)),
         ]
     )
     def test_freshness_date_with_relative_base(self, date_string, date, time):

--- a/tests/test_freshness_date_parser.py
+++ b/tests/test_freshness_date_parser.py
@@ -2594,6 +2594,13 @@ class TestFreshnessDateDataParser(BaseTestCase):
             param("1,000 days ago", date(2007, 9, 8), time(13, 15)),
             param("12,345 days ago", date(1976, 8, 16), time(13, 15)),
             param("2,000 hours ago", date(2010, 3, 13), time(5, 15)),
+            # A "," group that is not exactly three digits stays a decimal separator
+            param("1,0000 hours ago", date(2010, 6, 4), time(12, 15)),
+            # With both separators present, the last one is the decimal separator
+            param("1,000.5 days ago", date(2007, 9, 8), time(1, 15)),
+            param("1.000,5 days ago", date(2007, 9, 8), time(1, 15)),
+            # A malformed grouping must still parse instead of raising
+            param("1,000,00 days ago", date(1736, 8, 19), time(13, 15)),
         ]
     )
     def test_freshness_date_with_relative_base(self, date_string, date, time):


### PR DESCRIPTION
## What's wrong

Relative dates whose number contains a thousands separator are silently truncated to the digits before the first comma. `"1,000 days ago"` is read as one day ago, and (as the issue title notes) `"1,000,000 days ago"` collapses all the way to the current time.

```pycon
>>> import dateparser
>>> from datetime import datetime
>>> base = {"RELATIVE_BASE": datetime(2010, 6, 4, 13, 15)}
>>> dateparser.parse("1,000 days ago", settings=base)
datetime.datetime(2010, 6, 3, 13, 15)      # 1 day, not 1000
>>> dateparser.parse("12,345 days ago", settings=base)
datetime.datetime(2010, 5, 23, 4, 58, 12)  # read as 12.345
```

## Root cause

In `dateparser/freshness_date_parser.py`, `PATTERN` captured only `\d+` for the number, so `"1,000 days"` matched `1` and discarded `,000`. `get_kwargs` then applied `float(num.replace(",", "."))`, which exists for the European decimal comma (`"0,5 hours"`, added in #876) and cannot tell a thousands separator apart from a decimal one — so `"12,345"` became `12.345`.

## Fix

- Widen the numeric group in `PATTERN` to accept `,`-grouped digits and an optional fraction.
- Parse the captured token with a small helper, `_parse_number`, that disambiguates the comma:
  - a comma grouping exactly three digits (`1,000`, `1,000,000`) is a thousands separator and is removed;
  - a lone comma before a shorter group (`0,5`) stays the decimal separator;
  - a `.` anywhere in the token forces any `,` to be read as a thousands separator.

The decimal-comma behaviour from #876 is unchanged.

## Verification

Same snippet after the fix:

```pycon
>>> dateparser.parse("1,000 days ago", settings=base)
datetime.datetime(2007, 9, 8, 13, 15)
>>> dateparser.parse("12,345 days ago", settings=base)
datetime.datetime(1976, 8, 16, 13, 15)
>>> dateparser.parse("0,5 hours ago", settings=base)   # decimal comma still works
datetime.datetime(2010, 6, 4, 12, 45)
```

- `pytest tests/test_freshness_date_parser.py` -> 1059 passed, including new regression cases for `1,000` / `12,345` / `2,000` alongside the existing `0,5` / `1,5` decimal-comma cases.
- `ruff format --check` and `ruff check` on the changed files report no new issues.

Fixes #1367
