### PR TITLE
Fix IndexError in search_dates for zh-Hans, zh-Hant, and yue locales

### DIFF
--- a/dateparser/languages/locale.py
+++ b/dateparser/languages/locale.py
@@ -300,7 +300,8 @@ class Locale:
                     translated_chunk.append(word)
                     original_chunk.append(original_tokens[i])
                 elif (
-                    current_and_next_joined in dictionary
+                    i < last_token_index
+                    and current_and_next_joined in dictionary
                     and word not in dashes
                     and self.shortname not in word_joint_unsupported_languages
                 ):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1453,6 +1453,14 @@ class TestNgramSearch(BaseTestCase):
             )
         )
 
+
+    def test_search_dates_cjk_locales_no_index_error(self):
+        self.assertIsNotNone(search_dates("聽日"))
+        self.assertIsNotNone(search_dates("舊年"))
+        self.assertIsNotNone(search_dates("今天", languages=["zh-Hans"]))
+        self.assertIsNone(search_dates("2020年3月4日", languages=["zh-Hant"]))
+        self.assertIsNotNone(search_dates("00Z", languages=["yue"]))
+
     def test_unknown_strategy_raises_error(self):
         with self.assertRaisesRegex(ValueError, "strategy must be"):
             search_dates("4 October 1957", languages=["en"], strategy="unknown")


### PR DESCRIPTION
## Summary
Fixes `IndexError: list index out of range` in `search_dates()` for `zh-Hans`, `zh-Hant`, and `yue` locales.

## Root Cause
In `Locale.translate_search()` (`dateparser/languages/locale.py`), the word-joining branch read `original_tokens[i + 1]` without checking bounds (`i < last_token_index`), causing an index overflow on the final token when joined forms matched dictionary entries.

## Fix
- Added `i < last_token_index` bounds check to the word-joining condition.
- Added regression unit tests covering `zh-Hans`, `zh-Hant`, and `yue` locales in `tests/test_search.py`.

Closes #1372
