### PR TITLE
fix: force month-day order for ISO leading year with explicit DATE_ORDER

### DIFF
--- a/dateparser/parser.py
+++ b/dateparser/parser.py
@@ -636,17 +636,9 @@ class _parser:
             type = 0
 
             num_directives = self.ordered_num_directives
-            if (
-                skip_component == "year"
-                and self.day is None
-                and self.month is None
-                and "DATE_ORDER" not in self.settings._mod_settings
-            ):
-                # The date string starts with a four-digit year (e.g. an
-                # ISO 8601 date like "2017-06-22"), so the remaining numeric
-                # components are expected in month-day order, regardless of
-                # the locale date order, unless the caller explicitly set
-                # DATE_ORDER (#360).
+            if skip_component == "year" and self.day is None and self.month is None:
+                # Leading four-digit year (ISO 8601): remaining components are
+                # month-day, regardless of DATE_ORDER (#360, explicit setting).
                 num_directives = {
                     k: self.num_directives[k] for k in ("month", "day", "year")
                 }

--- a/tests/test_date_parser.py
+++ b/tests/test_date_parser.py
@@ -957,6 +957,38 @@ class TestDateParser(BaseTestCase):
 
     @parameterized.expand(
         [
+            param("2026-08-31", settings={"DATE_ORDER": "DMY"}, expected=datetime(2026, 8, 31)),
+            param(
+                "2026-08-31T01:46:00+00:00",
+                settings={"DATE_ORDER": "DMY"},
+                expected=datetime(2026, 8, 31, 1, 46),
+            ),
+            param(
+                "2026-05-08",
+                settings={"DATE_ORDER": "DMY"},
+                expected=datetime(2026, 5, 8),
+            ),
+            param(
+                "03-12-2026",
+                settings={"DATE_ORDER": "DMY"},
+                expected=datetime(2026, 12, 3),
+            ),
+        ]
+    )
+    def test_iso_datestamp_format_should_parse_with_explicit_date_order(
+        self, date_string, settings, expected
+    ):
+        # Extends #1352/#360 to explicit DATE_ORDER: ISO dates must parse;
+        # ambiguous dates without a leading year must still honor DATE_ORDER.
+        self.given_local_tz_offset(0)
+        self.given_parser(languages=["en"], settings=settings)
+        self.when_date_is_parsed(date_string)
+        self.then_date_was_parsed_by_date_parser()
+        self.result["date_obj"] = self.result["date_obj"].replace(tzinfo=None)
+        self.then_date_obj_exactly_is(expected)
+
+    @parameterized.expand(
+        [
             # Epoch timestamps.
             param("1484823450", expected=datetime(2017, 1, 19, 10, 57, 30)),
             param("1436745600000", expected=datetime(2015, 7, 13, 0, 0)),


### PR DESCRIPTION
dateparser already forced month-day ordering after a leading 4-digit year, but only when DATE_ORDER wasn't explicitly set. So an explicit DATE_ORDER=DMY/YDM (needed for a source's genuinely ambiguous dates) still broke unambiguous ISO strings:
```
dateparser.parse("2026-08-31", settings={"DATE_ORDER": "DMY"})  # -> None (invalid month=31)
dateparser.parse("2026-05-08", settings={"DATE_ORDER": "DMY"})  # -> 2026-08-05 (swapped, wrong)
```
This drops that guard, so a leading year always fixes the remaining order as month-then-day, regardless of DATE_ORDER. Ambiguous non-ISO strings without a leading year (e.g. "03-12-2026") still honor DATE_ORDER as before.